### PR TITLE
fix(hooks): install.sh wheel/pipx 情境支援

### DIFF
--- a/changelog.d/wheel-install-hooks.md
+++ b/changelog.d/wheel-install-hooks.md
@@ -1,0 +1,2 @@
+### Fixed
+- wheel/pipx 情境 `hippo install hooks`：repo_root 無 pyproject 時 importer venv 改複製已解包套件（原 pip install -e 必失敗）；sample yaml 隨包（config-samples/）

--- a/paulsha_hippo/config-samples/agents-projects.sample.yaml
+++ b/paulsha_hippo/config-samples/agents-projects.sample.yaml
@@ -1,0 +1,16 @@
+version: 1
+projects:
+  paulshaclaw:
+    slug: paulshaclaw
+    roots:
+      - /path/to/paulshaclaw
+    remotes:
+      - github.com/hamanpaul/paulshaclaw
+    aliases: [paulsha, paulshia, psc]
+  obs-auto-moc:
+    slug: obs-auto-moc
+    roots:
+      - /path/to/obs-auto-moc
+    remotes:
+      - github.com/hamanpaul/obs-auto-moc
+    aliases: [auto-moc, obs-moc]

--- a/paulsha_hippo/hooks/install.sh
+++ b/paulsha_hippo/hooks/install.sh
@@ -153,7 +153,21 @@ venv_dir="${memory_root}/hooks/.venv"
 if [[ "$skip_venv" != true ]]; then
   if python3 -m venv --help &>/dev/null 2>&1; then
     python3 -m venv "$venv_dir"
-    "${venv_dir}/bin/pip" install --quiet -e "${repo_root}"
+    if [[ -f "${repo_root}/pyproject.toml" ]]; then
+      # 開發/checkout 情境：editable 安裝 repo
+      "${venv_dir}/bin/pip" install --quiet -e "${repo_root}"
+    else
+      # wheel/pipx 情境（repo_root=site-packages 根）：直接把已解包的套件
+      # 複製進 venv site-packages（零網路、與安裝版本一致）
+      _hooks_pkg_src="${repo_root}/paulsha_hippo"
+      _venv_site="$("${venv_dir}/bin/python" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+      if [[ -d "$_hooks_pkg_src" && -n "$_venv_site" ]]; then
+        "${venv_dir}/bin/pip" install --quiet pyyaml
+        cp -r "$_hooks_pkg_src" "$_venv_site/"
+      else
+        echo "install.sh: WARN cannot locate packaged paulsha_hippo; importer venv incomplete" >&2
+      fi
+    fi
   else
     echo "install.sh: WARN python3 venv unavailable; skipping venv creation" >&2
   fi
@@ -496,6 +510,9 @@ install -d -m 700 "$(dirname "$projects_yaml")"
 
 if [[ ! -f "$projects_yaml" ]]; then
   sample_yaml="${repo_root}/config/agents-projects.sample.yaml"
+  if [[ ! -f "$sample_yaml" ]]; then
+    sample_yaml="$(dirname "${BASH_SOURCE[0]}")/../config-samples/agents-projects.sample.yaml"
+  fi
   if [[ -f "$sample_yaml" ]]; then
     install -m 600 "$sample_yaml" "$projects_yaml"
   else


### PR DESCRIPTION
## 摘要

fresh-install E2E 第二個坑：`hippo install hooks` 在 pipx（wheel）情境下 `pip install -e ${repo_root}` 必失敗（repo_root=site-packages，無 pyproject）。修正：偵測 pyproject——checkout 情境維持 editable；wheel 情境將已解包套件複製進 importer venv（零網路、版本一致）+ pyyaml。sample yaml 改隨包出貨（config-samples/）供無 repo 情境。

## 驗證

- tests/test_hooks.py + test_tree_skeleton.py 65 passed（checkout 路徑不回歸）
- 本機 pipx 實裝驗證於 merge 後執行（E2E 流程）

🤖 Generated with [Claude Code](https://claude.com/claude-code)