### PR TITLE
docs: v0.1.0 上線——README 狀態轉正 + CHANGELOG 彙整

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@
 格式基於 [Keep a Changelog 1.1.0](https://keepachangelog.com/zh-TW/1.1.0/)，
 本專案遵循 hamanpaul project policy v1.0.12。
 
-## [Unreleased]
+## [0.1.0] - 2026-07-07
 
 ### Added
-- 自 `hamanpaul/new-project-template` 建立 repo 骨架（agent 檔 symlink 模式、Policy Check／Tests CI）
+- #125 Phase 1 code 遷入：paulshaclaw `memory/**`（31k LOC、872 tests 綠）平移為 `paulsha_hippo/**`；`lifecycle` → `lib/lifecycle`、`idle` → `lib/idle`；hippo CLI 樹去 `memory` 前綴（`hippo atomize|dream|janitor|replay|bundle|search|wakeup|syncback|knowledge`）；`paths.py` 單一權威 resolver（`HIPPO_*` > `PSC_*` deprecated 警告 > config.yaml > `~/.agents/memory`）；stage2 12 份 capability specs、integration check、gemma4 wrapper（scripts/ + examples/）隨遷
+- 隨遷主 repo `tests/` 下漏網的 memory 測試：policy 三件（boundary/redaction/lint/cli，54 tests）與 #218 hooks 截取自足回歸 2 件
+- quickstart 面：`hippo init`（backend preset 寫入 atomizer override）、`hippo doctor`（雙 root FAIL 健檢）、`hippo install hooks|service`（systemd 偵測＋`dream supervise` fallback）、`hippo dream supervise`（前景常駐）；蒸餾三檔位——`claude-headless`（零 key）、`openai-compatible`（stdlib http-runner）、`custom-argv`（既有 agent_exec）
+- repo 骨架：conventions 引擎 1.0.12（pin 5829015）+ `tier: shareable`（R-21 deident gate day-1）、package 0.1.0 與 `hippo --version` 入口、版號一致性測試、`paulsha_hippo.lib` import 隔離護欄、骨架期 README
+- `paulsha_hippo.lib.session_readers`：`read_codex_rollout`/`read_copilot_history` 升格 lib API（hippo importer + paulshaclaw bro hook 兩使用者；adapters.base 保留 re-export）
 
-### Changed
-- **conventions 引擎 1.0.7 → 1.0.12**：`.paul-project.yml` 與 CLAUDE.md 版本註記同步、`Policy Check` workflow re-pin 引擎到 1.0.12 SHA `5829015`（`policy_version` / `policy_engine_ref` 同步）；宣告 `tier: shareable` 啟用 R-21 機密掃描（deident gate day-1）
+### Fixed
+- #7 遞迴自捕捉：agent_exec 對蒸餾子程序注入 `HIPPO_SELF_SESSION=1`，5 個 capture hook（session_end×3／precompact×2）讀到即早退（layer 1）；importer 對 prompt 內容即 atomize skill 調用文本者 `self-skip`（layer 2）
+- #8 空 session 汙染：importer 對無 prompt/無 touched files/summary 空或佔位/turn≤1 的 session `empty-skip`，不寫 inbox、不入蒸餾佇列
+- wheel/pipx 情境 `hippo install hooks`：repo_root 無 pyproject 時 importer venv 改複製已解包套件（原 pip install -e 必失敗）；sample yaml 隨包（config-samples/）
+- wheel 安裝缺非 .py 資產（hooks install.sh／dream systemd 範本／atomizer.yaml／skills）——補 package-data 宣告；fresh-install E2E 驗證抓到

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 > 跨 LLM vendor 的經驗筆記基座——session 自動蒸餾成原子筆記，睡眠期（dream）整理，隔天喚醒（wakeup）回灌 context。
 > 命名取自海馬迴（hippocampus）：大腦在睡眠時做記憶固化的器官。
 
-**狀態：🚧 Phase 1 遷入完成（885 tests 綠），本機部署驗證中。** 設計見
-[拆包執行設計 spec](https://github.com/hamanpaul/paulshaclaw/blob/main/docs/superpowers/specs/2026-07-06-memory-extraction-hippo-design.md)。
+**狀態：✅ v0.1.0 上線。** 已從 [paulshaclaw](https://github.com/hamanpaul/paulshaclaw) 完整拆出、可單獨安裝運轉（953 tests；WSL2+systemd 全鏈實測：截取→蒸餾→回灌）。
+設計見[拆包執行設計 spec](https://github.com/hamanpaul/paulshaclaw/blob/main/docs/superpowers/specs/2026-07-06-memory-extraction-hippo-design.md)。
+> 已驗環境：WSL2＋systemd＋claude-headless。其他 backend（codex/copilot/openai-compatible headless）與無 systemd 主機為 opt-in，見 [#10](https://github.com/hamanpaul/paulsha-hippo/issues/10)。
 
 ## Quickstart
 

--- a/changelog.d/125-code-migration.md
+++ b/changelog.d/125-code-migration.md
@@ -1,2 +1,0 @@
-### Added
-- #125 Phase 1 code 遷入：paulshaclaw `memory/**`（31k LOC、872 tests 綠）平移為 `paulsha_hippo/**`；`lifecycle` → `lib/lifecycle`、`idle` → `lib/idle`；hippo CLI 樹去 `memory` 前綴（`hippo atomize|dream|janitor|replay|bundle|search|wakeup|syncback|knowledge`）；`paths.py` 單一權威 resolver（`HIPPO_*` > `PSC_*` deprecated 警告 > config.yaml > `~/.agents/memory`）；stage2 12 份 capability specs、integration check、gemma4 wrapper（scripts/ + examples/）隨遷

--- a/changelog.d/125-policy-tests.md
+++ b/changelog.d/125-policy-tests.md
@@ -1,2 +1,0 @@
-### Added
-- 隨遷主 repo `tests/` 下漏網的 memory 測試：policy 三件（boundary/redaction/lint/cli，54 tests）與 #218 hooks 截取自足回歸 2 件

--- a/changelog.d/125-second-cut.md
+++ b/changelog.d/125-second-cut.md
@@ -1,2 +1,0 @@
-### Added
-- quickstart 面：`hippo init`（backend preset 寫入 atomizer override）、`hippo doctor`（雙 root FAIL 健檢）、`hippo install hooks|service`（systemd 偵測＋`dream supervise` fallback）、`hippo dream supervise`（前景常駐）；蒸餾三檔位——`claude-headless`（零 key）、`openai-compatible`（stdlib http-runner）、`custom-argv`（既有 agent_exec）

--- a/changelog.d/bootstrap.md
+++ b/changelog.d/bootstrap.md
@@ -1,2 +1,0 @@
-### Added
-- repo 骨架：conventions 引擎 1.0.12（pin 5829015）+ `tier: shareable`（R-21 deident gate day-1）、package 0.1.0 與 `hippo --version` 入口、版號一致性測試、`paulsha_hippo.lib` import 隔離護欄、骨架期 README

--- a/changelog.d/launch-v0.1.0.md
+++ b/changelog.d/launch-v0.1.0.md
@@ -1,0 +1,2 @@
+### Changed
+- v0.1.0 上線：README 狀態轉正、changelog.d 碎片彙整為 CHANGELOG `[0.1.0]`

--- a/changelog.d/lib-session-readers.md
+++ b/changelog.d/lib-session-readers.md
@@ -1,2 +1,0 @@
-### Added
-- `paulsha_hippo.lib.session_readers`：`read_codex_rollout`/`read_copilot_history` 升格 lib API（hippo importer + paulshaclaw bro hook 兩使用者；adapters.base 保留 re-export）

--- a/changelog.d/self-empty-capture.md
+++ b/changelog.d/self-empty-capture.md
@@ -1,3 +1,0 @@
-### Fixed
-- #7 遞迴自捕捉：agent_exec 對蒸餾子程序注入 `HIPPO_SELF_SESSION=1`，5 個 capture hook（session_end×3／precompact×2）讀到即早退（layer 1）；importer 對 prompt 內容即 atomize skill 調用文本者 `self-skip`（layer 2）
-- #8 空 session 汙染：importer 對無 prompt/無 touched files/summary 空或佔位/turn≤1 的 session `empty-skip`，不寫 inbox、不入蒸餾佇列

--- a/changelog.d/wheel-install-hooks.md
+++ b/changelog.d/wheel-install-hooks.md
@@ -1,2 +1,0 @@
-### Fixed
-- wheel/pipx 情境 `hippo install hooks`：repo_root 無 pyproject 時 importer venv 改複製已解包套件（原 pip install -e 必失敗）；sample yaml 隨包（config-samples/）

--- a/changelog.d/wheel-package-data.md
+++ b/changelog.d/wheel-package-data.md
@@ -1,2 +1,0 @@
-### Fixed
-- wheel 安裝缺非 .py 資產（hooks install.sh／dream systemd 範本／atomizer.yaml／skills）——補 package-data 宣告；fresh-install E2E 驗證抓到


### PR DESCRIPTION
## 摘要

宣告上線收尾（issue #9）。#7/#8 品質閘已修（PR #12），功能齊備、E2E 全鏈實測通過，README 狀態由「🚧 本機驗證中」轉為「✅ v0.1.0 上線」；changelog.d 8 個碎片彙整為 CHANGELOG `[0.1.0]`。

merge 後打 `v0.1.0` annotated tag + GitHub release。

## 誠實邊界（README 已註明）

已驗環境：WSL2＋systemd＋claude-headless 全鏈。其他 backend（codex/copilot/openai-compatible headless）與無 systemd 主機為 opt-in（#10）；冷啟自起待下次重啟證明（#9）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)