### PR TITLE
fix(ops): install service ExecStart 綁定當前 interpreter（修 pipx dream service）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 格式基於 [Keep a Changelog 1.1.0](https://keepachangelog.com/zh-TW/1.1.0/)，
 本專案遵循 hamanpaul project policy v1.0.12。
 
+## [Unreleased]
+
+### Fixed
+- `install service` 生成的 systemd unit：`ExecStart` 綁定當前 interpreter（`sys.executable`），修正 pipx / venv 隔離安裝下寫死 `/usr/bin/env python3`（全域 python）import 不到 `paulsha_hippo`、導致 dream service 一觸發即 `exit 1`（ModuleNotFoundError）的問題。
+
 ## [0.1.0] - 2026-07-07
 
 ### Added

--- a/changelog.d/fix-dream-service-interpreter.md
+++ b/changelog.d/fix-dream-service-interpreter.md
@@ -1,0 +1,2 @@
+### Fixed
+- `install service` 生成的 systemd unit：`ExecStart` 綁定當前 interpreter（`sys.executable`），修正 pipx / venv 隔離安裝下寫死 `/usr/bin/env python3`（全域 python）import 不到 `paulsha_hippo`、導致 dream service 一觸發即 `exit 1`（ModuleNotFoundError）的問題。

--- a/paulsha_hippo/ops.py
+++ b/paulsha_hippo/ops.py
@@ -163,6 +163,11 @@ def run_install_service(*, enable: bool, home_dir: str | None = None) -> int:
     ):
         src = src_dir / src_name
         text = src.read_text(encoding="utf-8").replace("paulsha-memory-dream", "paulsha-hippo-dream")
+        # ExecStart 綁定當前 interpreter：pipx / venv 隔離安裝下，template 寫死的
+        # /usr/bin/env python3（全域 python）會 import 不到 paulsha_hippo
+        # （ModuleNotFoundError → 服務啟動即 exit 1）。改用 sys.executable 指向
+        # 實際安裝環境的 python，確保 systemd 服務能載入套件。
+        text = text.replace("/usr/bin/env python3", sys.executable)
         dst = unit_dir / dst_name
         dst.write_text(text, encoding="utf-8")
         written.append(str(dst))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -185,6 +186,18 @@ class InstallServiceUnitContentTests(unittest.TestCase):
             self.assertNotIn("paulshaclaw.memory", body)
             self.assertNotIn("cli memory ", body)
             self.assertIn("paulsha_hippo.cli dream run", body)
+
+    def test_execstart_uses_current_interpreter_not_env_python(self):
+        with TemporaryDirectory() as tmp:
+            with mock.patch.object(ops, "_systemd_user_available", return_value=True), \
+                 mock.patch.object(ops.subprocess, "run") as run:
+                run.return_value = mock.Mock(returncode=0, stdout="Linger=yes")
+                ops.run_install_service(enable=False, home_dir=tmp)
+            body = (Path(tmp) / ".config" / "systemd" / "user" / "paulsha-hippo-dream.service").read_text(encoding="utf-8")
+            # pipx / venv 隔離安裝下，ExecStart 必須綁定當前 interpreter（sys.executable），
+            # 不能用 /usr/bin/env python3（全域 python 會 import 不到 paulsha_hippo）
+            self.assertIn(f"ExecStart={sys.executable} -m paulsha_hippo.cli dream run", body)
+            self.assertNotIn("/usr/bin/env python3", body)
 
 
 class InstallHooksResolverTests(unittest.TestCase):


### PR DESCRIPTION
## 摘要

修正 `hippo install service` 生成的 systemd unit：`ExecStart` 綁定當前 interpreter，解決 **pipx / venv 隔離安裝下 dream service 無法啟動**的問題。

## 問題

`run_install_service` 從 template 生成 unit 時，`ExecStart` 沿用 template 寫死的 `/usr/bin/env python3`（全域 python）。但 pipx 安裝時 `paulsha_hippo` 只存在於隔離 venv，全域 python `import` 不到 → dream service 每次 timer 觸發即 `exit 1`（`ModuleNotFoundError`，只跑 11ms）。

實機確認：`paulsha-hippo-dream.service` 狀態 `failed`；`/usr/bin/env python3 -c "import paulsha_hippo"` → `ModuleNotFoundError`。

## 修復

`run_install_service` 生成 unit 時，將 `ExecStart` 的 `/usr/bin/env python3` 替換為 `sys.executable`（執行 install 的 interpreter，即實際安裝環境的 python）。pipx / venv / 全域安裝皆正確。

## 測試

- 新增 `test_execstart_uses_current_interpreter_not_env_python`
- 全測試：**951 passed, 1 skipped, 99 subtests**
- `policy_check`：**fail: 0**（順帶補回 v0.1.0 彙整後缺的 `## [Unreleased]`，修 R-04）
- 端到端：生成的 unit `ExecStart` 綁定 `sys.executable`，該 interpreter 可 `import paulsha_hippo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
