### PR TITLE
docs(policy): CLAUDE.md 修正 R-09——改 code 需加 changelog.d 碎片

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,10 @@ policy_version: 1.0.12
 - [ ] 若本任務跨多個子項，先建議用 `git worktree` 拆開
 
 ## 改 code 時
-- [ ] 同一 PR 必須同步更新 `CHANGELOG.md [Unreleased]`
-- [ ] 除非可明確標示為 docs-only / test-only / chore，否則不得省略 CHANGELOG
+- [ ] 同一 PR 必須新增 `changelog.d/<slug>.md` 碎片——R-09 實際檢查的是這個碎片是否存在，不是直接改 `CHANGELOG.md`；鏡像進 `CHANGELOG.md [Unreleased]` 仍是慣例，但不是 R-09 的判定對象
+- [ ] 除非可明確標示為 docs-only / test-only / chore，否則不得省略 changelog.d 碎片（豁免用 `skip-changelog` label + 理由）
 - [ ] code_paths 涵蓋的檔案變動皆視為 code change
+- R-09 為 diff-aware：本機 `python3 -m policy_check --repo .`（無 PR context）不會抓到碎片缺漏，須在有 PR base/head 資訊時（CI）才驗得出來
 
 ## 改版號時（release 觸發時）
 - [ ] 嚴格遵循 `<MAJOR>.<MINOR>.<PATCH>[-fix.N]`
@@ -31,7 +32,7 @@ policy_version: 1.0.12
 - [ ] MAJOR bump 需使用者明確核可
 
 ## 完成任務（claim done）前
-- [ ] `CHANGELOG.md [Unreleased]` 有對應 entry（或 PR 標 `skip-changelog` + 理由）
+- [ ] `changelog.d/` 有對應碎片（或 PR 標 `skip-changelog` + 理由）
 - [ ] `VERSION` 內容與意圖一致（release label PR 才可偏離 latest tag）
 - [ ] `.github/pull_request_template.md` checklist 全勾
 - [ ] `python3 -m policy_check --repo .` 無任何 failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ policy_version: 1.0.12
 - `policy-exempt:branch-name` — R-12 分支來源規則
 - `policy-exempt:agent-files` — R-13 agent convention files 存在
 - `policy-exempt:cli-help` — R-16 CLI help 同步
-- `skip-changelog` — R-09 code 變動要求 CHANGELOG entry（特殊用途，需附理由）
+- `skip-changelog` — R-09 code 變動要求 changelog.d 碎片（或直寫 CHANGELOG）（特殊用途，需附理由）
 - `wip` — R-11 自動通過 PR body checkbox 未全勾（work in progress）
 
 > 各 policy 版本新增的 exemption label 列於下方對應「新增規則」段。

--- a/changelog.d/changelog-convention-doc.md
+++ b/changelog.d/changelog-convention-doc.md
@@ -1,0 +1,2 @@
+### Changed
+- CLAUDE.md 修正 R-09 說明：改 code 需加 changelog.d 碎片（非只改 CHANGELOG.md）。


### PR DESCRIPTION
## 摘要
修正 `CLAUDE.md` 對 R-09 的過時說明：R-09（policy v1.0.12）實際檢查 PR 是否新增 `changelog.d/<slug>.md` 碎片，而非直接改 `CHANGELOG.md`。舊措辭曾誤導實作者只改 `CHANGELOG.md`、漏了碎片，造成 CI R-09 失敗。

## 變更
- `## 改 code 時`：改為要求新增 `changelog.d/<slug>.md` 碎片（R-09 判定對象）；鏡像進 `CHANGELOG.md [Unreleased]` 仍是慣例但非 gated artifact。
- `## 完成任務（claim done）前`：checklist 改為以碎片為準。
- 註記 R-09 為 diff-aware（本機 `policy_check --repo .` 不會抓到碎片缺漏，須 CI 帶 PR context）。
- 僅改 canonical `CLAUDE.md`；symlink 鏡像（AGENTS/GEMINI/copilot）不動，R-14 維持。

## 測試
- pinned-engine policy_check（full PR context）：fail:0（R-09 pass、R-14 pass）。

## Checklist
- [x] 已新增 `changelog.d/` 碎片
- [x] 本 PR 內容使用 zh-tw
- [x] 未執行 merge
