### PR TITLE
feat(skills): 多模型跨 agent orchestration skill

### DIFF
--- a/changelog.d/multi-model-orchestration-skill.md
+++ b/changelog.d/multi-model-orchestration-skill.md
@@ -1,0 +1,2 @@
+### Added
+- `custom-skills/multi-model-orchestration/`：多模型跨 agent ultracode workflow 編排 skill——模型分工、fail-closed 異質 gate、copilot driver 監控、Codex forwarder、harness resume/journal 機制，含可執行 workflow-template.js（RED/GREEN 測試驗證）

--- a/custom-skills/multi-model-orchestration/SKILL.md
+++ b/custom-skills/multi-model-orchestration/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: multi-model-orchestration
+description: Use when running a large multi-batch implementation across many issues/PRs where a single expensive model would hit session/rate limits, when you need a foreign-model adversarial gate before merge, or when driving copilot/codex CLIs as agent labor inside a Workflow. Keywords: ultracode, multi-model, copilot driver, codex gate, heterogeneous review, workflow resume, session limit, fail-closed merge.
+---
+
+# Multi-Model Orchestration
+
+## Overview
+
+Run a large implementation (many issues → many PRs) as a **Workflow** where different models do different jobs by their comparative advantage, and **no code merges without passing a foreign-model adversarial gate**.
+
+Core insight: **the factory and the inspector must be different models.** Same-model self-review shares the same blind spots — three same-model lenses still miss what one foreign model catches. Put the expensive frontier model on the critical path only for hard fixes; push bulk labor to cheaper/other-vendor models; make a foreign model (Codex) the merge gate.
+
+**Two load-bearing invariants (violating either defeats the purpose):**
+1. **Heterogeneous gate is fail-closed.** A foreign-model reviewer's blocking finding blocks merge — no same-model majority can override it. If the gate is absent (timeout/error), say so explicitly; never silently merge as if it passed.
+2. **Resume, don't restart.** Long runs WILL hit session/rate limits. The Workflow journal caches completed agents; re-invoke to continue at zero re-cost. Never re-run merged batches.
+
+## When to Use
+
+- A backlog of independent-ish issues, each a PR-sized change, that a single model can't finish before hitting limits.
+- You want an independent (different-vendor) adversarial review as a hard merge gate, not advisory.
+- You want to offload implement/mechanical work to copilot CLI or codex CLI while keeping orchestration in the Workflow.
+- The user opted into multi-agent orchestration (said "ultracode", "use a workflow", or invoked a skill that calls Workflow).
+
+**When NOT to use:** a single PR or a few files (just do it inline); work with no natural batch decomposition; when the user hasn't opted into workflow-scale spend.
+
+**REQUIRED BACKGROUND:** the `Workflow` tool contract (pipeline/parallel/agent, journal, resume). This skill assumes you author Workflow scripts.
+
+## Model Roster (assign by comparative advantage, not by prestige)
+
+| Role | Model | Why |
+|---|---|---|
+| Orchestrator (main loop) | frontier (e.g. Fable/Opus) | Holds the plan, dispatches, reads gates, decides topology. Cheap in tokens — mostly tool calls. |
+| Bulk implement (per-task TDD) | copilot CLI `gpt-5.4` (via driver) | High-volume mechanical labor; different vendor conserves frontier quota. |
+| Driver / verify / mechanical | `sonnet` subagents | Drives copilot, runs full test suite, 3-lens verify, ship/merge, closeout. Good judgment, cheaper than frontier. |
+| Trivial setup | `haiku` subagents | Worktree checks, cleanup — near-zero judgment. |
+| **Merge gate (adversarial)** | **Codex `gpt-5.6-sol` (foreign)** | The whole point: catches what same-model review can't. |
+| Hard fixes | frontier (main loop only) | Security/correctness fixes flagged by the gate — the one place to spend the best model. |
+
+Set per-agent model in the Workflow via `agent(prompt, { model: 'sonnet' | 'haiku' | ... })`. The main loop's own model is set by the session (`/model`); when the frontier model's limit resets, switch the session model to keep going — subagents inherit the new session model unless pinned.
+
+**Rule of thumb:** the frontier model should only ever touch (a) orchestration and (b) fixes the foreign gate demands. Everything else is someone else's job. When the frontier limit is hit mid-run, that's a signal you leaned on it too hard — move more to sonnet/copilot next round.
+
+## The Batch Pipeline (per PR, in its own git worktree)
+
+Each batch runs these gates in order; failing any gate stops the batch (downstream batches that depend on it are skipped and reported, never force-merged):
+
+1. **worktree** (haiku) — create from latest `origin/main`, or (resume) verify existing worktree + drop `.psc_tmp` residue.
+2. **implement** (copilot driver, sonnet) — one task at a time, TDD, per the plan. See `copilot-driver-contract.md`.
+3. **full test** (sonnet) — whole suite + policy/lint green, small fixes allowed.
+4. **3-lens verify** (sonnet ×3 parallel) — correctness / policy / regression. **fail-closed: any lens's blocking finding stops the batch**, no majority vote. ≤2 fix rounds.
+5. **foreign gate** (sonnet forwarder → Codex) — adversarial review of the branch diff. Blocking findings → fix (frontier) → re-gate. Absent (timeout) → report explicitly, fall back to lens results + human sign-off. See `codex-gate-contract.md`.
+6. **ship** (sonnet) — rebase onto latest main (resolve conflicts by the plan's merge rules), re-run full verify, open PR (`Closes #N`), squash-merge, remove worktree.
+
+Topology is expressed with plain promises: independent batches start together; dependent batches `await` their upstream's merged result. Batches that touch the same file must be **serialized**, not merely both-await-a-common-ancestor (parallel edits to one file collide at rebase).
+
+A generalized, runnable script is in `workflow-template.js`.
+
+## Boundaries & Behavior Constraints (non-negotiable)
+
+- **Foreign gate is fail-closed and un-overridable.** No same-model majority overrules a foreign blocking finding. This is the reason the architecture exists.
+  - **"The reviewer might be wrong, so let the author triage the findings" is the trap that voids the gate.** A blocking finding is resolved exactly two ways: (a) fix the code and pass a fresh re-gate, or (b) the *foreign reviewer itself* withdraws it on re-review. The author-side model (Sonnet/frontier that wrote or drove the code) does NOT get to judge a foreign finding a false positive and merge over it — that is same-vendor override wearing a "technical judgment" hat. Genuine false positives are cheap to disprove: fix or clarify, then re-gate. If you're arguing with the finding instead of re-gating, stop.
+- **Gate absence is surfaced, never hidden.** If Codex times out and even the resume-fallback fails, the batch is marked "gate absent" and merge requires explicit human sign-off — the PR body must say the gate was absent.
+- **No `git add -A` in implement agents.** Copilot and subagents stage only files the task touched. Test-harness residue (`.psc_tmp/`, `__pycache__`) must never enter version control. Add such paths to `.git/info/exclude`. (Learned the hard way: bulk `git add` committed hundreds of temp files and stalled a whole re-run on a dirty worktree check.)
+- **Squash-merge only.** Per-task commits and any residue stay out of main history.
+- **Recovery/stateful ops touch real state — quiesce first, back up first, verify restore.** Any step that mutates live runtime (not code) stops all writers, takes a verified-restorable backup, gates on a real probe, and halts on the first failed verification without rolling back merged code.
+- **Conditional close.** A PR only carries `Closes #N` when the issue's acceptance is fully evidenced. Missing evidence → `Refs #N` + split the remainder into a new issue; never auto-close on partial delivery.
+- **Honest capability claims.** If a probe can't prove a capability (e.g. a CLI's hook actually fired), mark it inconclusive/produce-only — don't upgrade an unverified path to "supported".
+
+## Quick Reference
+
+| Situation | Action |
+|---|---|
+| Frontier model limit hit mid-run | `/model` to another tier; re-invoke Workflow with `resumeFromRunId` — completed agents replay from cache |
+| A batch's fix was done outside the workflow | re-invoke with a `skipImplement`-style flag so it re-runs gates only, not implement |
+| Batch already merged in a prior run | hard-code it as `Promise.resolve({merged:true})` so the next run doesn't redo it |
+| Codex model rejected ("not supported on this account") | check `~/.codex/models_cache.json` for the real available ids; don't guess |
+| Codex review hangs | forwarder cancels after a timeout, then `task --resume` asks for the conclusion it already formed |
+| Worktree dirty on resume | `rm -rf <wt>/.psc_tmp` then check only for non-`??` (tracked) changes |
+| Same file edited by two batches | serialize the batches (A→C→D), don't run them in parallel |
+
+## Monitoring the run
+
+- **Live:** `/workflows` shows the progress tree; each `agent()` label (`A:task3:copilot`, `E:codex-gate`) maps to a node.
+- **Post-mortem / debugging an empty or surprising result:** read `<transcriptDir>/journal.jsonl` — one `{"type":"result",...}` line per completed agent with its full return value. Cross-reference `started` lines (which carry the agent label→id map) to attribute a finding to a batch/lens. Do NOT `cat`/tail the per-agent `agent-<id>.jsonl` transcripts into your context — they overflow it.
+- **Copilot progress:** the driver subagent is your monitor. It runs copilot under `timeout`, then verifies (commit exists, tests pass, diff matches intent) and retries/takes-over on failure. See `copilot-driver-contract.md`.
+
+## Common Mistakes
+
+- **Same-model gate.** Three Claude lenses ≠ a foreign review. If the gate isn't a different vendor, you don't have this architecture — you have expensive self-review.
+- **Silent merge on gate timeout.** Defeats the whole point. Absence must block-or-escalate, never pass.
+- **Restarting instead of resuming.** Burns the whole run's tokens again. Always `resumeFromRunId`; hard-code already-merged batches.
+- **Frontier model on bulk work.** You'll hit the limit and stall the critical path. Push implement/verify/mechanical to copilot/sonnet/haiku.
+- **`git add -A` anywhere.** Commits harness residue; a later run's clean-worktree check then blocks. Stage named files only.
+- **Parallel batches on one file.** Rebase collision. Serialize file-overlapping batches.
+- **Trusting a passing local suite as the gate.** The foreign reviewer repeatedly found real defects (secret-redaction bypass, non-atomic publish, silent YAML truncation, lost-update races) that a fully-green suite missed. The suite is necessary, not sufficient.
+
+## Real-World Impact
+
+Across one multi-day run (9 issues → 6 PR batches), the foreign gate peeled defects layer by layer that same-model 3-lens verify + a green test suite had passed: e.g. a requeue path was fixed four times (add terminal state → purge poison cache → gate on fragment presence → validate fragment frontmatter/session ownership), each deeper defect surfaced only by the foreign reviewer. Zero half-baked PRs reached main; every blocked PR was a real defect.

--- a/custom-skills/multi-model-orchestration/codex-gate-contract.md
+++ b/custom-skills/multi-model-orchestration/codex-gate-contract.md
@@ -1,0 +1,53 @@
+# Codex Adversarial Gate Contract
+
+How a Workflow runs Codex (`gpt-5.6-sol`) as the **foreign-model merge gate**. Codex runs via the codex-companion runtime (a Node script shipped with the Codex plugin), driven by a `sonnet` **forwarder subagent**. Codex is a different vendor from the Claude factory — that difference is the entire value.
+
+## Companion runtime
+
+The companion script lives under the Codex plugin cache; resolve its path once (do NOT hardcode a personal absolute path in committed artifacts):
+
+```
+COMPANION="$(find "$HOME/.claude/plugins/cache" -name codex-companion.mjs -path '*codex*' | head -1)"
+```
+
+Key subcommands (all `node "$COMPANION" <cmd>`):
+- `task-resume-candidate --json` — is there a resumable thread from this session?
+- `task [--fresh|--resume] [--model <id>] [--effort <lvl>] "<text>"` — run a task turn.
+- `adversarial-review [--background] [--base <ref>] "focus: …"` — challenge review of a diff.
+- `status <id>` / `cancel <id>` — poll / cancel a background job.
+
+## Model id gotcha
+
+The account's available Codex models are enumerated in `~/.codex/models_cache.json`. Requesting an unavailable id fails hard:
+`The '<id>' model is not supported when using Codex with a ChatGPT account.` Observed: the desired `gpt-5.6-sol` was the config default while a mistaken `gpt-5.6-codex-sol` was rejected. **Read the cache file for the real ids; don't guess from the config or from memory.**
+
+## Forwarder subagent contract (the gate step)
+
+A `sonnet` agent runs and monitors the review:
+
+1. `cd "$WT"`, launch background review:
+   ```
+   node "$COMPANION" adversarial-review --background --base origin/main \
+     "focus: 審本 branch 相對 origin/main 的完整 diff，對照 plan 與 spec，挑戰實作正確性與驗收達成。"
+   ```
+2. Grab the task id, poll `status <id>` every ~60s until `completed`/`failed` or a **45-minute** cap.
+3. `completed` → read the review, distil `[high]`-level items into `blocking_findings[]`.
+4. **Timeout fallback:** `cancel <id>`, then `task --resume "上一輪 review 掛住了，請直接輸出你已形成的結論"` once (≈10-min cap) — Codex has usually already formed the verdict; this recovers it cheaply. (In practice a 55-min hang was recovered exactly this way.)
+5. All recovery failed → return `absent: true`. **Absence is reported, never treated as a pass.**
+6. Return `{verdict, blocking_findings: string[], absent}`.
+
+## How the orchestrator uses the verdict (fail-closed)
+
+- `blocking_findings.length > 0` and not absent → dispatch a **frontier** fix agent for exactly those findings → **re-gate** (a fresh review of HEAD). Loop until clean or a bounded retry.
+- `absent` → do NOT merge silently. Mark the batch gate-absent; merge requires explicit human sign-off and the PR body must disclose it.
+- clean → proceed to ship.
+
+No same-model lens or majority can override a Codex blocking finding. If Codex says high-severity, it blocks.
+
+## Why this earns its cost (observed)
+
+A fully-green local suite + same-model 3-lens verify still passed defects that Codex caught: a secret-redaction path a user policy override could disable (PATs into ledgers), a DB published non-atomically before its coverage sidecar (violating "old index preserved on failure"), unquoted YAML interpolation that a standard parser silently truncates while the repo's own parser stayed green, and a lost-update race where a lock covered only the final write but not the read-modify-append pipeline. Each was a real, reproducible bug behind a green build. The gate is where those die.
+
+## Plan-level pre-gate (cheaper, earlier)
+
+Run one Codex `adversarial-review` on the **plans** before any implementation starts. Upstream interception is far cheaper than catching the same design flaw six PRs deep. Fold its blocking findings into the plans first.

--- a/custom-skills/multi-model-orchestration/copilot-driver-contract.md
+++ b/custom-skills/multi-model-orchestration/copilot-driver-contract.md
@@ -1,0 +1,56 @@
+# Copilot CLI Driver Contract
+
+How a Workflow drives GitHub Copilot CLI (`gpt-5.4`) as bulk implement labor, and how the driver **monitors** it. Copilot is a headless CLI that edits files and runs commands; it is NOT a Workflow agent, so a `sonnet` **driver subagent** wraps each invocation: brief → run → verify → retry/take-over.
+
+## Why a driver instead of calling copilot directly
+
+Copilot is fire-and-forget headless: it runs to completion (or a timeout) and prints a final message; there is no mid-run status/cancel API like the Codex companion has. So monitoring = **a supervising subagent that verifies the result and owns the fallback.** The driver is the model that can read the diff, judge whether the task was actually done, and finish the job itself if copilot stalls.
+
+## Copilot invocation (verified working)
+
+```bash
+cd "$WT" && timeout 1800 copilot \
+  --model gpt-5.4 \
+  -p "$(cat "$BRIEF_FILE")" \
+  -s \
+  --allow-all-tools \
+  --add-dir "$WT"
+```
+
+- `-p/--prompt <text>` — non-interactive; copilot exits after completion.
+- `-s/--silent` — print only the agent's final response (scriptable).
+- `--allow-all-tools` — REQUIRED for non-interactive; without it copilot blocks on permission prompts and hangs to timeout.
+- `--add-dir "$WT"` — grant file access to the worktree.
+- `--model gpt-5.4` — pin the tier. Use `auto` to let copilot choose.
+- Wrap in `timeout` (≈1800s) — copilot has no self-cancel; the wrapper is your only bound.
+- Pass the brief via a temp **file** (`$(cat …)`), not a giant inline arg — long CJK prompts break shell quoting.
+
+## Known reliability caveat (route around it)
+
+Copilot's stdin handling of `-p` payloads was observed unreliable for large content (content dropped, agent wanders to timeout). Mitigations that held up:
+- Keep each invocation scoped to **one plan task**, not a whole plan.
+- Put the full task text in the brief file; keep the shell arg short.
+- The driver's verify+takeover (below) is the real safety net — treat copilot as best-effort labor, not a guaranteed worker.
+
+## Driver subagent contract (this is the monitoring)
+
+The driver is a `sonnet` agent. Per plan task it does:
+
+1. **Brief** — read the plan's `### Task N` section. Write a brief file to scratch containing: the working dir, a TDD instruction (failing test → FAIL → minimal impl → PASS → commit per the plan's message), the full task text, the drift note (plan line numbers are advisory; anchor by content), the test-runner note (`PYTHONPATH=. python3 -m pytest`), and **"stage only files this task touched — never `git add -A`; never commit `.psc_tmp`/`__pycache__`."**
+2. **Run** — the copilot invocation above.
+3. **Verify (the monitor step)** — after copilot exits, check ALL of:
+   - a new commit exists (`git log origin/main..HEAD`), else copilot didn't finish;
+   - the task's tests actually PASS (run them, don't trust the transcript);
+   - `git status --porcelain` has no non-`??` residue and no stray staged temp files;
+   - the diff matches the task's intent (spot-read key files).
+4. **Retry once** — on verify failure, append the failure evidence to the brief and re-feed copilot a single time.
+5. **Take over** — still failing? The driver implements the task itself via TDD (it has full tool access). Bulk labor is delegated, not abdicated — the batch must not stall on a weak worker.
+6. **Return** `{ok, detail}` — `detail` says whether copilot finished it, finished on retry, or the driver took over, plus a test summary.
+
+## Return-schema discipline
+
+The driver returns a small validated object (`{ok: boolean, detail: string}`) so the Workflow can branch deterministically. Copilot's own prose is NOT the return value — the driver distills it. This keeps the orchestrator's decisions off unstructured text.
+
+## Failure attribution
+
+If a batch stalls in implement, the journal's `*:task*:copilot` result `detail` tells you which task and whether it was copilot or the driver-takeover that failed — so the next resume can target that task, not re-run the whole batch.

--- a/custom-skills/multi-model-orchestration/harness-mechanics.md
+++ b/custom-skills/multi-model-orchestration/harness-mechanics.md
@@ -1,0 +1,53 @@
+# Workflow Harness Mechanics
+
+The `Workflow` tool runs a JS script in the background that orchestrates `agent()` calls. These are the mechanics that make a long, limit-prone, multi-round run survivable.
+
+## Journal & resume (the survival mechanism)
+
+- Every `Workflow` invocation writes a **journal** at `<transcriptDir>/journal.jsonl` and returns a `runId` (`wf_…`).
+- Each `agent()` call is keyed by a hash of its `(prompt, opts)`. On resume, an **unchanged** call replays its cached result instantly; the first changed/new call and everything after runs live.
+- **Resume:** re-invoke `Workflow({ scriptPath, resumeFromRunId })`. Same script + same args → ~100% cache hit; you only pay for what changed.
+- **Iterate cheaply:** the script is persisted to a file on every run (path returned in the result). Edit that file, re-invoke with `scriptPath` — don't resend the whole script inline.
+
+## Reading results
+
+- The tool result's `<result>` is the script's return value (may be truncated — the full copy is in the task output file).
+- `journal.jsonl`: `{"type":"result", "agentId", "result"}` per finished agent, plus `{"type":"started", "agentId"}` lines. The label→id map is on the `started` side; join on `agentId` to attribute a `result` to its labelled step.
+- **Before diagnosing an empty/surprising result, read the journal** — a cached result can itself be empty; don't assume.
+- Never `cat` the per-agent `agent-<id>.jsonl` transcripts into context; they overflow it. The journal's `result` lines are the digest you want.
+
+## Surviving session / rate limits
+
+Long runs hit them. Two complementary defenses:
+
+1. **Model tiering** keeps the frontier model's usage tiny (orchestration + hard fixes only), so its limit is hit last, if at all. When it IS hit, the failing agent is the only casualty — everything already merged stays merged.
+2. **Resume** picks up exactly where it stopped. When the frontier limit resets or you `/model` to a different tier, re-invoke with `resumeFromRunId`; merged batches are already recorded and skipped.
+
+**Between-run state hand-off:** when a batch was merged (or fixed outside the workflow) in a prior run, edit the script so that batch is a `Promise.resolve({merged:true, …})` (or gets a `skipImplement` flag). This makes the topology reflect reality and stops the next run redoing landed work. This is normal, expected editing between rounds — the run is a sequence of converging invocations, not one shot.
+
+## Determinism constraints (scripts are plain JS)
+
+- No `Date.now()` / `Math.random()` / argless `new Date()` — they break resume. Vary agents by index/label; stamp timestamps after the run.
+- Plain JS only (no TS types). Standard built-ins are available; no filesystem/Node API from the script body (do file ops inside `agent()` via Bash).
+- `parallel([...thunks])` is a barrier that never rejects — a failed thunk resolves to `null`; `.filter(Boolean)` before use.
+- Concurrency is capped (~cpu-2, ≤16); pass all items, they queue.
+
+## Topology as promises
+
+Express dependencies with plain promise chaining, not a DSL:
+
+```js
+const pA = runBatch('A')                 // independent, starts now
+const pB = Promise.resolve({merged:true})// already landed in a prior run
+const pC = pA.then(a => a.merged ? runBatch('C') : {merged:false, blocked:'upstream A'})
+const pRecovery = Promise.all([pA, pB]).then(([a,b]) =>
+  (a.merged && b.merged) ? runRecovery() : {merged:false, blocked:'upstream'})
+```
+
+Independent batches run concurrently; dependents await; **file-overlapping batches must be a serial chain** (A→C→D), because parallel edits to one file collide at rebase even if both "await A".
+
+## Worktree hygiene on resume
+
+- Test harnesses may drop residue (`.psc_tmp/`, `__pycache__`) into worktrees. Add them to `.git/info/exclude`.
+- A resume's worktree check must ignore untracked residue: `rm -rf "$wt/.psc_tmp"`, then only fail on non-`??` (tracked) changes. A naive "porcelain must be empty" check will wrongly block a clean branch buried under temp dirs.
+- `gh pr merge --delete-branch` can fail its local branch-delete when the primary repo has `main` checked out in another worktree; the remote squash-merge still succeeds — delete the remote branch explicitly and move on.

--- a/custom-skills/multi-model-orchestration/workflow-template.js
+++ b/custom-skills/multi-model-orchestration/workflow-template.js
@@ -1,0 +1,143 @@
+// Multi-model orchestration Workflow template.
+// Generalized from a real 9-issue / 6-PR run. Adapt BATCHES + topology to your work.
+// Roles by model: haiku=setup, sonnet=driver/verify/mechanical, copilot gpt-5.4=implement,
+// Codex gpt-5.6-sol=foreign merge gate, frontier(main loop)=hard fixes only.
+//
+// Pass this file to the Workflow tool via {scriptPath}. Edit + re-invoke with
+// {scriptPath, resumeFromRunId} to continue a run at zero re-cost.
+
+export const meta = {
+  name: 'multi-model-batches',
+  description: 'Multi-model batch pipeline: copilot implement, sonnet verify, Codex foreign gate, fail-closed auto-merge',
+  phases: [
+    { title: 'PR-A' }, { title: 'PR-B' }, { title: 'PR-C' },
+    { title: 'Recovery' }, { title: 'Closeout' },
+  ],
+}
+
+// --- resolve tool paths without hardcoding personal absolute paths ---
+// (In a real run, compute COMPANION inside an agent via:
+//   find "$HOME/.claude/plugins/cache" -name codex-companion.mjs -path '*codex*' | head -1)
+const COMPANION = '<codex-companion.mjs path — resolve at runtime, do not hardcode a personal path>'
+const WT_BASE = '<worktrees base dir>'   // e.g. a sibling dir of the repo
+const REPO = '<primary repo path>'
+
+const DRIFT = 'Plan line numbers are advisory; anchor by content. Adapt to current code, note deviations.'
+const TESTNOTE = 'Run tests in the worktree with PYTHONPATH=. python3 -m pytest (avoid editable-install pointing at main repo).'
+
+// One entry per PR batch. `phase` groups its agents in /workflows.
+const BATCHES = {
+  A: { plan: 'docs/plans/pr-a.md', branch: 'feature/a', tasks: 12, closes: 'Closes #15', phase: 'PR-A', title: 'fix: batch A' },
+  B: { plan: 'docs/plans/pr-b.md', branch: 'feature/b', tasks: 7,  closes: 'Closes #16', phase: 'PR-B', title: 'fix: batch B' },
+  C: { plan: 'docs/plans/pr-c.md', branch: 'feature/c', tasks: 7,  closes: 'Closes #19', phase: 'PR-C', title: 'fix: batch C' },
+}
+
+const STEP = { type: 'object', properties: { ok: { type: 'boolean' }, detail: { type: 'string' } }, required: ['ok', 'detail'] }
+const VERIFY = { type: 'object', properties: {
+  blocking: { type: 'array', items: { type: 'object', properties: { file: {type:'string'}, issue: {type:'string'}, fix_hint: {type:'string'} }, required: ['file','issue','fix_hint'] } },
+  notes: { type: 'array', items: { type: 'string' } } }, required: ['blocking','notes'] }
+const GATE = { type: 'object', properties: {
+  verdict: { type: 'string' }, blocking_findings: { type: 'array', items: { type: 'string' } }, absent: { type: 'boolean' } },
+  required: ['verdict','blocking_findings','absent'] }
+
+async function runBatch(key, opts = {}) {
+  const b = BATCHES[key], wt = `${WT_BASE}/${key.toLowerCase()}`, ph = b.phase
+  const skipImplement = !!opts.skipImplement   // set when the batch was fixed outside the workflow
+
+  // 1. worktree (haiku — trivial)
+  const setup = await agent(
+    skipImplement
+      ? `rm -rf ${wt}/.psc_tmp, then verify worktree ${wt} on branch ${b.branch}, >=${b.tasks} commits ahead of origin/main, and NO tracked changes (ignore untracked ?? residue). Return {ok, detail}.`
+      : `In ${REPO}: git fetch origin main; git worktree add ${wt} -b ${b.branch} origin/main (recreate if exists; delete stale branch first). Confirm ${wt}/${b.plan} exists. Return {ok, detail}.`,
+    { label: `${key}:worktree`, phase: ph, schema: STEP, model: 'haiku', effort: 'low' })
+  if (!setup?.ok) return { key, merged: false, blocked: `worktree: ${setup?.detail}` }
+
+  // 2. implement — copilot gpt-5.4 driven by a sonnet driver, one task at a time (skipped on resume-of-fixed)
+  if (!skipImplement) {
+    for (let t = 1; t <= b.tasks; t++) {
+      const r = await agent(
+        `You DRIVE copilot CLI to complete "### Task ${t}" of ${wt}/${b.plan} (only Task ${t}), in worktree ${wt}.
+1. Read the Task section. Write a brief file to scratch: working dir + TDD instruction (failing test→FAIL→minimal impl→PASS→commit per plan) + the full Task text + "${DRIFT}" + "${TESTNOTE}" + "stage ONLY files this task touched; never git add -A; never commit .psc_tmp/__pycache__".
+2. Run: cd ${wt} && timeout 1800 copilot --model gpt-5.4 -p "$(cat <brief>)" -s --allow-all-tools --add-dir ${wt}
+3. VERIFY (monitor): new commit exists; the task's tests actually PASS; no non-?? residue; diff matches intent.
+4. Verify fails → append evidence, re-feed copilot ONCE.
+5. Still failing → YOU implement it via TDD yourself.
+Return {ok, detail(copilot-done / retry-done / driver-takeover + test summary)}.`,
+        { label: `${key}:task${t}:copilot`, phase: ph, schema: STEP, model: 'sonnet' })
+      if (!r?.ok) return { key, merged: false, blocked: `Task ${t}: ${r?.detail}` }
+    }
+  }
+
+  // 3. full suite (sonnet)
+  const test = await agent(
+    `In ${wt}: PYTHONPATH=. python3 -m pytest -q and the repo's policy/lint check. All green → {ok:true}. Reds → fix per test intent (commit), ≤2 rounds, else {ok:false, detail}. ${TESTNOTE}`,
+    { label: `${key}:fulltest`, phase: ph, schema: STEP, model: 'sonnet' })
+  if (!test?.ok) return { key, merged: false, blocked: `fulltest: ${test?.detail}` }
+
+  // 4. 3-lens verify (sonnet ×3) — FAIL-CLOSED: any lens blocking stops the batch
+  const LENSES = [['correctness','logic/edge/state-machine holes vs plan+spec acceptance'],
+                  ['policy','changelog/lint/no personal paths/commit format/docs sync'],
+                  ['regression','breakage of existing tests/behavior/shared interfaces']]
+  for (let round = 0; round <= 2; round++) {
+    const v = await parallel(LENSES.map(([n, d]) => () =>
+      agent(`In ${wt}: adversarially review git diff origin/main...HEAD through ONLY the "${d}" lens, vs ${wt}/${b.plan}. Report only confident blocking issues. Return {blocking:[{file,issue,fix_hint}], notes:[]}.`,
+        { label: `${key}:verify:${n}:r${round}`, phase: ph, schema: VERIFY, model: 'sonnet' })))
+    const blocking = v.filter(Boolean).flatMap(x => x.blocking)
+    if (blocking.length === 0) break
+    if (round === 2) return { key, merged: false, blocked: `3-lens: ${blocking.length} blocking after 2 rounds` }
+    const fixed = await agent(`In ${wt}: fix these blocking findings (test + commit): ${JSON.stringify(blocking)}. Return {ok, detail}.`,
+      { label: `${key}:fix:r${round}`, phase: ph, schema: STEP })   // main-loop (frontier) model — a hard fix
+    if (!fixed?.ok) return { key, merged: false, blocked: `fix: ${fixed?.detail}` }
+  }
+
+  // 5. foreign gate (sonnet forwarder → Codex) — fail-closed, absence surfaced
+  let gate = await agent(
+    `Codex gate forwarder. cd ${wt}. Launch: node "${COMPANION}" adversarial-review --background --base origin/main "focus: challenge this branch's diff vs plan ${b.plan}". Poll status every 60s to completed/failed or 45min. Completed→distil [high] blocking_findings. Timeout→cancel, then task --resume "output the conclusion you already formed" once (10min). All fail→absent:true. Return {verdict, blocking_findings, absent}.`,
+    { label: `${key}:codex-gate`, phase: ph, schema: GATE, model: 'sonnet' })
+  if (gate && !gate.absent && gate.blocking_findings.length > 0) {
+    const fixed = await agent(`In ${wt}: fix Codex blocking findings (test + commit): ${gate.blocking_findings.join('\n')}. Return {ok, detail}.`,
+      { label: `${key}:codex-fix`, phase: ph, schema: STEP })       // frontier — hard fix
+    if (!fixed?.ok) return { key, merged: false, blocked: `codex-fix: ${fixed?.detail}` }
+    gate = await agent(`Codex gate forwarder (re-gate). cd ${wt}. Re-run adversarial-review on HEAD, same protocol. Return {verdict, blocking_findings, absent}.`,
+      { label: `${key}:codex-regate`, phase: ph, schema: GATE, model: 'sonnet' })
+    if (gate && !gate.absent && gate.blocking_findings.length > 0)
+      return { key, merged: false, blocked: `codex re-gate still blocking: ${gate.blocking_findings.join('; ')}` }
+  }
+  const codexAbsent = !gate || gate.absent
+
+  // 6. ship (sonnet): rebase → re-verify → PR → squash-merge → remove worktree
+  const ship = await agent(
+    `In ${wt} on ${b.branch}, serially (stop+return ok:false on any failure):
+1. git fetch origin main && git rebase origin/main (resolve conflicts by the plan's no-whole-line-overwrite merge rule).
+2. PYTHONPATH=. pytest -q green + policy check clean + changelog fragment present.
+3. git push -u origin ${b.branch} --force-with-lease.
+4. gh pr create --title "${b.title}" ${b.labels ? `--label ${b.labels} ` : ''}--body "${b.closes}${codexAbsent ? ' (NOTE: Codex gate ABSENT — merged on lens results, disclose)' : ' (Codex foreign gate passed)'}".
+5. gh pr merge --squash --delete-branch.
+6. cd ${REPO} && git worktree remove ${wt} --force.
+Return {ok, detail(PR url + merge SHA)}.`,
+    { label: `${key}:ship`, phase: ph, schema: STEP, model: 'sonnet' })
+  return ship?.ok ? { key, merged: true, detail: ship.detail, codexAbsent } : { key, merged: false, blocked: `ship: ${ship?.detail}`, codexAbsent }
+}
+
+// --- topology: independent batches concurrent; dependents await; file-overlapping = serial chain ---
+const pA = runBatch('A')
+const pB = runBatch('B')
+const pC = pA.then(a => a.merged ? runBatch('C') : { key: 'C', merged: false, blocked: 'upstream A blocked' })
+
+// Recovery / stateful ops (if any) await their code batches and touch REAL state — quiesce, back up, verify.
+const pRecovery = Promise.all([pA, pB]).then(([a, b]) => {
+  if (!a.merged || !b.merged) return { merged: false, blocked: `upstream A=${a.merged} B=${b.merged}` }
+  return agent(`In ${REPO} (main now has A+B). Run the recovery sequence: gate on a real probe FIRST (abort if it fails); quiesce all writers; take a verified-restorable backup; do the mutation; verify each step; halt on first failure WITHOUT rolling back merged code. Return {ok, detail(evidence + backup path)}.`,
+    { label: 'recovery', phase: 'Recovery', schema: STEP, model: 'sonnet' }).then(r => r?.ok ? { merged: true, detail: r.detail } : { merged: false, blocked: r?.detail })
+})
+
+const [a, b, c, rec] = await Promise.all([pA, pB, pC, pRecovery])
+const all = { A: a, B: b, C: c }
+log(`batches: ${Object.entries(all).map(([k, v]) => `${k}=${v.merged ? 'OK' : 'X'}`).join(' ')} recovery=${rec.merged ? 'OK' : 'X'}`)
+
+// Closeout: only close issues whose batch merged; partial → Refs + split; report gate-absent PRs.
+const closeout = await agent(
+  `In ${REPO}. Closeout: for MERGED batches confirm auto-close of their issues; for blocked batches leave an honest status comment, do NOT close. Conditional-close rule: full evidence → Closes; partial → Refs + open a follow-up issue. Batch results: ${JSON.stringify(Object.fromEntries(Object.entries(all).map(([k, v]) => [k, { merged: v.merged, note: v.detail || v.blocked }])))}. recovery=${rec.merged}. Return {ok, detail}.`,
+  { label: 'closeout', phase: 'Closeout', schema: STEP, model: 'sonnet' })
+
+return { batches: all, recovery: rec, closeout }


### PR DESCRIPTION
## 摘要

把本次 9-issue ultracode workflow 的實戰架構系統化成一個可重用 skill，放進 `custom-skills/multi-model-orchestration/`。

## 內容
- **SKILL.md** — 模型分工 roster（frontier 編排+硬修、sonnet driver/verify、copilot gpt-5.4 implement、Codex gpt-5.6-sol foreign gate、haiku 瑣事）、兩條 load-bearing invariant（異質 gate fail-closed、resume 不 restart）、邊界與行為約束
- **copilot-driver-contract.md** — copilot CLI 當 implement 勞力的 driver 監控機制（brief→run→verify→retry→takeover），即用戶問的「怎麼監控 copilot」
- **codex-gate-contract.md** — Codex forwarder（background→poll→45min cap→resume 兜底→fail-closed），含 model id gotcha
- **harness-mechanics.md** — Workflow journal/resume、撞 session limit 存活、determinism 約束、worktree 衛生
- **workflow-template.js** — 可執行的 6-batch 範本（路徑佔位、無個人絕對路徑）

## 驗證（RED/GREEN，writing-skills TDD）
- **RED**（clean-room、無 skill、純通用知識）：獨立推導出結構層（模型分層、異質 review、file-overlap 序列化），但 fail-closed gate **做反了**（讓作者側否決 foreign finding）、漏掉 gate 缺席揭露與 copilot driver 監控
- **GREEN**（有 skill）：六個不變量全中，且未過度套用
- 據 RED 失敗補強 fail-closed 反制條款（REFACTOR）

## 合規
- `tier: shareable`（R-21）：無個人絕對路徑，全用佔位符 ✓
- `python3 -m policy_check --repo .` 零 failure ✓
- changelog.d 碎片已附 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)