### PR TITLE
fix(doctor): 補強外部 CLI shebang 執行鏈

### DIFF
--- a/changelog.d/issue-34-service-shebang.md
+++ b/changelog.d/issue-34-service-shebang.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `hippo doctor --fix-backend` 現在會辨識外部 CLI 的簡單 `/usr/bin/env <interpreter>` shebang；當 systemd service PATH 找不到該 interpreter 時，以互動環境解析出的絕對 interpreter 與 script 路徑重寫 profile argv，不引入 shell wrapper，也不接管外部 agent 的認證。
+- backend migration 在 atomic replace 前先驗證 canonical config 與改寫後 profiles，避免驗證失敗時留下已變更的無效設定。

--- a/paulsha_hippo/ops.py
+++ b/paulsha_hippo/ops.py
@@ -876,6 +876,7 @@ def _fix_backend_config(*, backup: bool = True) -> tuple[int, str]:
         return 1, "fix-backend: external_agents.profiles 不是 list"
 
     changes: list[tuple[str, str, str]] = []
+    service_path = _service_effective_path_env()
     for profile in profiles:
         if not isinstance(profile, dict) or profile.get("enabled", True) is not True:
             continue
@@ -884,7 +885,6 @@ def _fix_backend_config(*, backup: bool = True) -> tuple[int, str]:
         if not isinstance(argv, list) or not argv or not isinstance(argv[0], str):
             return 1, f"fix-backend: profile {profile_id} argv 無效"
         argv0 = argv[0]
-        service_path = _service_effective_path_env()
         absolute_command = Path(argv0)
         service_command = argv0 if (
             absolute_command.is_absolute()

--- a/paulsha_hippo/ops.py
+++ b/paulsha_hippo/ops.py
@@ -827,15 +827,42 @@ def _probe_backend_service_effective(*, live: bool = False) -> tuple[str, bool]:
     )
 
 
+def _env_shebang_interpreter(path: Path) -> str | None:
+    """Return a simple ``/usr/bin/env NAME`` interpreter, if present."""
+    try:
+        with path.open("rb") as handle:
+            first = handle.readline(256).decode("ascii").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not first.startswith("#!"):
+        return None
+    parts = first[2:].strip().split()
+    if (
+        len(parts) == 2
+        and parts[0] in {"/usr/bin/env", "/bin/env"}
+        and re.fullmatch(r"[A-Za-z0-9._+-]+", parts[1])
+    ):
+        return parts[1]
+    return None
+
+
 def _fix_backend_config(*, backup: bool = True) -> tuple[int, str]:
-    """把 canonical config 中 enabled profile 的 argv[0] 固定為可執行絕對路徑。"""
+    """Make enabled profile commands executable in the service environment.
+
+    Besides pinning ``argv[0]``, an external CLI with a simple
+    ``#!/usr/bin/env <interpreter>`` shebang is rewritten to an absolute
+    interpreter plus an absolute script path when systemd cannot resolve that
+    interpreter.  This keeps launcher/auth ownership external and uses no
+    shell wrapper.
+    """
+    from paulsha_hippo.agent_profiles import profiles_from_config
     from paulsha_hippo.atomizer import config as atomizer_config
 
     canonical = paths.atomizer_config_path()
     if not canonical.is_file():
         return 0, f"fix-backend: canonical config 不存在（{canonical}），無可遷移"
     try:
-        atomizer_config.load_config(override_path=None)
+        atomizer_config.load_config()
         import yaml
 
         document = yaml.safe_load(canonical.read_text(encoding="utf-8"))
@@ -857,9 +884,26 @@ def _fix_backend_config(*, backup: bool = True) -> tuple[int, str]:
         if not isinstance(argv, list) or not argv or not isinstance(argv[0], str):
             return 1, f"fix-backend: profile {profile_id} argv 無效"
         argv0 = argv[0]
-        if Path(argv0).is_absolute() or shutil.which(
-            argv0, path=_service_effective_path_env()
-        ) is not None:
+        service_path = _service_effective_path_env()
+        absolute_command = Path(argv0)
+        service_command = argv0 if (
+            absolute_command.is_absolute()
+            and absolute_command.is_file()
+            and os.access(argv0, os.X_OK)
+        ) else shutil.which(argv0, path=service_path)
+        interactive_command = service_command or shutil.which(argv0)
+        if interactive_command is not None:
+            interpreter = _env_shebang_interpreter(Path(interactive_command))
+            if interpreter and shutil.which(interpreter, path=service_path) is None:
+                try:
+                    interpreter_path = resolve_backend_argv([interpreter])[0]
+                except BackendUnavailableError as exc:
+                    return 1, f"fix-backend: profile {profile_id}: {exc}"
+                command_path = os.path.abspath(interactive_command)
+                argv[:] = [interpreter_path, command_path, *argv[1:]]
+                changes.append((profile_id, argv0, f"{interpreter_path} {command_path}"))
+                continue
+        if service_command is not None:
             continue
         try:
             resolved = resolve_backend_argv([argv0])[0]
@@ -869,6 +913,11 @@ def _fix_backend_config(*, backup: bool = True) -> tuple[int, str]:
         changes.append((profile_id, argv0, resolved))
     if not changes:
         return 0, "fix-backend: enabled profiles 已為 service-effective，無可遷移"
+
+    try:
+        profiles_from_config(profiles)
+    except Exception as exc:
+        return 1, f"fix-backend: migrated profiles 無效：{exc}"
 
     backup_path = canonical.with_name(canonical.name + ".bak")
     if backup and not backup_path.exists():

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1195,6 +1195,45 @@ class FixBackendMigrationTests(unittest.TestCase):
             self.assertEqual(canonical.read_bytes(), original)
             self.assertFalse(canonical.with_name(canonical.name + ".bak").exists())
 
+    def test_fix_backend_snapshots_service_path_once_for_all_profiles(self):
+        import yaml
+
+        with TemporaryDirectory() as tmp:
+            canonical = self._write_config(tmp)
+            document = yaml.safe_load(canonical.read_text(encoding="utf-8"))
+            enabled_ids = {"claude", "codex"}
+            executables = {}
+            for profile in document["external_agents"]["profiles"]:
+                profile["enabled"] = profile["id"] in enabled_ids
+                if profile["enabled"]:
+                    profile["argv"][0] = profile["id"]
+                    executable = Path(tmp) / "interactive-bin" / profile["id"]
+                    executable.parent.mkdir(parents=True, exist_ok=True)
+                    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                    executable.chmod(0o755)
+                    executables[profile["id"]] = str(executable)
+            canonical.write_text(
+                yaml.safe_dump(document, sort_keys=False, allow_unicode=True),
+                encoding="utf-8",
+            )
+
+            def fake_which(cmd, path=None):
+                if cmd in executables:
+                    return None if path is not None else executables[cmd]
+                return None
+
+            with mock.patch.dict("os.environ", self._env(tmp)), \
+                 mock.patch.object(
+                     ops,
+                     "_service_effective_path_env",
+                     return_value="/usr/bin:/bin",
+                 ) as service_path, \
+                 mock.patch.object(ops.shutil, "which", side_effect=fake_which):
+                code, _ = ops._fix_backend_config()
+
+            self.assertEqual(code, 0)
+            service_path.assert_called_once_with()
+
     def test_fix_backend_without_canonical_config_fails_closed(self):
         with TemporaryDirectory() as tmp:
             with mock.patch.dict("os.environ", self._env(tmp)), \

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1124,6 +1124,77 @@ class FixBackendMigrationTests(unittest.TestCase):
             # 第二輪 no-op：備份仍是第一輪存下的原始裸命令版
             self.assertIn("  - claude\n", backup.read_text(encoding="utf-8"))
 
+    def test_fix_backend_pins_missing_env_shebang_interpreter_without_shell(self):
+        import yaml
+
+        with TemporaryDirectory() as tmp:
+            canonical = self._write_config(tmp)
+            document = yaml.safe_load(canonical.read_text(encoding="utf-8"))
+            for profile in document["external_agents"]["profiles"]:
+                profile["enabled"] = profile["id"] == "codex"
+                if profile["id"] == "codex":
+                    profile["argv"][0] = "codex"
+            canonical.write_text(
+                yaml.safe_dump(document, sort_keys=False, allow_unicode=True),
+                encoding="utf-8",
+            )
+            script = Path(tmp) / "service-bin" / "codex"
+            script.parent.mkdir(parents=True)
+            script.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+            script.chmod(0o755)
+            node = Path(tmp) / "interactive-bin" / "node"
+            node.parent.mkdir(parents=True)
+            node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            node.chmod(0o755)
+
+            def fake_which(cmd, path=None):
+                if cmd == "codex":
+                    return str(script)
+                if cmd == "node":
+                    return None if path is not None else str(node)
+                return None
+
+            with mock.patch.dict("os.environ", self._env(tmp)), \
+                 mock.patch.object(ops, "_service_manager_environment",
+                                   return_value={"PATH": str(script.parent)}), \
+                 mock.patch.object(ops.shutil, "which", side_effect=fake_which):
+                code, _ = ops._fix_backend_config()
+
+            self.assertEqual(code, 0)
+            migrated = yaml.safe_load(canonical.read_text(encoding="utf-8"))
+            codex = next(
+                profile for profile in migrated["external_agents"]["profiles"]
+                if profile["id"] == "codex"
+            )
+            self.assertEqual(codex["argv"][:2], [str(node), str(script)])
+            self.assertNotIn("sh", codex["argv"][:2])
+
+    def test_fix_backend_validates_rewrite_before_replacing_config(self):
+        with TemporaryDirectory() as tmp:
+            canonical = self._write_config(tmp)
+            original = canonical.read_bytes()
+            exe = self._real_exe(tmp)
+
+            def fake_which(cmd, path=None):
+                if cmd != "claude":
+                    return None
+                return None if path is not None else str(exe)
+
+            with mock.patch.dict("os.environ", self._env(tmp)), \
+                 mock.patch.object(ops, "_service_manager_environment",
+                                   return_value={"PATH": "/usr/bin:/bin"}), \
+                 mock.patch.object(ops.shutil, "which", side_effect=fake_which), \
+                 mock.patch(
+                     "paulsha_hippo.agent_profiles.profiles_from_config",
+                     side_effect=ValueError("invalid rewritten profile"),
+                 ):
+                code, message = ops._fix_backend_config()
+
+            self.assertEqual(code, 1)
+            self.assertIn("migrated profiles 無效", message)
+            self.assertEqual(canonical.read_bytes(), original)
+            self.assertFalse(canonical.with_name(canonical.name + ".bak").exists())
+
     def test_fix_backend_without_canonical_config_fails_closed(self):
         with TemporaryDirectory() as tmp:
             with mock.patch.dict("os.environ", self._env(tmp)), \


### PR DESCRIPTION
## 摘要

- 修正 external CLI 在 systemd service PATH 下可找到 launcher、卻找不到 `/usr/bin/env` shebang interpreter 時的 false-green。
- `doctor --fix-backend` 會把 profile argv 改寫為絕對 interpreter 加絕對 script 路徑，不使用 shell wrapper，也不接管 agent 認證。
- migration 改為先驗證 canonical config 與改寫後 profiles，再 atomic replace。

本 PR 是 issues 34 與 39 共同 release closure 的 service-effective blocker 修補；不在 merge 時提早關閉 issue，須待 final candidate、consumer Read 與 scheduled canary 證據完整後再閉合。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過（1514 passed、4 skipped、151 subtests）
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致（0.1.1 patch candidate）
- [x] 文件與 CLI help 已同步，或已說明不適用（內部 migration 修正，無 CLI surface 變更）

## 風險與回復

- 僅處理 simple `/usr/bin/env <interpreter>` shebang，其他複雜 shebang 維持原 fail-closed 行為。
- 寫入前驗證失敗不建立 backup、不取代 canonical config。
- production install、consumer Read、timer canary 與 tag 尚未執行；merge 後以 exact merge commit 重建候選包並完成 acceptance。
- Issue-link exemption 理由：本 PR 只是 closure chain 中的 blocker 修補，不能在 merge 時提前關閉 issues 34/39。
- Docs-sync exemption 理由：無公開 CLI 介面或操作流程變更，changelog 已記錄 runtime migration 行為。
