### PR TITLE
fix(install): 清理舊版 pipx hooks

### DIFF
--- a/changelog.d/issue-34-legacy-pipx-hooks.md
+++ b/changelog.d/issue-34-legacy-pipx-hooks.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `hippo install all --force` 現在會辨識並清除舊版未標 `managedBy`、但透過 pipx Python 執行 Hippo script 的 Claude/Codex hook entries；保留不相關 wrapper，同一 event 最終只留下單一 managed hook。

--- a/paulsha_hippo/hooks/install.sh
+++ b/paulsha_hippo/hooks/install.sh
@@ -287,12 +287,11 @@ def _command_parts(command):
 
 def _is_python_interpreter(token):
     name = token.rsplit("/", 1)[-1]
-    if name == "python":
+    if name in {"python", "python3"}:
         return True
-    if not name.startswith("python"):
+    if not name.startswith("python3."):
         return False
-    suffix = name[len("python"):]
-    return bool(suffix) and all(part.isdigit() for part in suffix.split("."))
+    return all(part.isdigit() for part in name[len("python"):].split("."))
 
 def _is_managed_claude_hook(hook, script_markers):
     """Check if hook is managed by paulsha-memory for any of the given script names."""
@@ -414,12 +413,11 @@ def _command_parts(command):
 
 def _is_python_interpreter(token):
     name = token.rsplit("/", 1)[-1]
-    if name == "python":
+    if name in {"python", "python3"}:
         return True
-    if not name.startswith("python"):
+    if not name.startswith("python3."):
         return False
-    suffix = name[len("python"):]
-    return bool(suffix) and all(part.isdigit() for part in suffix.split("."))
+    return all(part.isdigit() for part in name[len("python"):].split("."))
 
 def _managed_hook(command, status_msg):
     return {

--- a/paulsha_hippo/hooks/install.sh
+++ b/paulsha_hippo/hooks/install.sh
@@ -285,6 +285,15 @@ def _command_parts(command):
         parts = parts[1:]
     return parts
 
+def _is_python_interpreter(token):
+    name = token.rsplit("/", 1)[-1]
+    if name == "python":
+        return True
+    if not name.startswith("python"):
+        return False
+    suffix = name[len("python"):]
+    return bool(suffix) and all(part.isdigit() for part in suffix.split("."))
+
 def _is_managed_claude_hook(hook, script_markers):
     """Check if hook is managed by paulsha-memory for any of the given script names."""
     if not isinstance(hook, dict):
@@ -297,7 +306,7 @@ def _is_managed_claude_hook(hook, script_markers):
     if not isinstance(command, str):
         return False
     parts = _command_parts(command)
-    if len(parts) != 2 or not parts[0].endswith("/hooks/.venv/bin/python"):
+    if len(parts) != 2 or not _is_python_interpreter(parts[0]):
         return False
     return any(parts[1].endswith(f"/hooks/{marker}") for marker in script_markers)
 
@@ -403,6 +412,15 @@ def _command_parts(command):
         parts = parts[1:]
     return parts
 
+def _is_python_interpreter(token):
+    name = token.rsplit("/", 1)[-1]
+    if name == "python":
+        return True
+    if not name.startswith("python"):
+        return False
+    suffix = name[len("python"):]
+    return bool(suffix) and all(part.isdigit() for part in suffix.split("."))
+
 def _managed_hook(command, status_msg):
     return {
         "type": "command",
@@ -427,7 +445,7 @@ def _is_managed_codex_hook(hook, managed_marker):
     parts = _command_parts(command)
     return (
         len(parts) in {2, 3}
-        and parts[0].endswith("/hooks/.venv/bin/python")
+        and _is_python_interpreter(parts[0])
         and parts[1].endswith(f"/hooks/{managed_marker}")
         and (len(parts) == 2 or parts[2] == "--subagent")
     )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -802,7 +802,16 @@ class InstallerTest(unittest.TestCase):
                                             "claude_user_prompt_submit.py"
                                         ),
                                         "timeout": 10,
-                                    }
+                                    },
+                                    {
+                                        "type": "command",
+                                        "command": (
+                                            f"/usr/bin/python2 "
+                                            f"{self.memory_root}/hooks/"
+                                            "claude_user_prompt_submit.py"
+                                        ),
+                                        "timeout": 10,
+                                    },
                                 ],
                             }
                         ],
@@ -840,8 +849,18 @@ class InstallerTest(unittest.TestCase):
                 for hook in entry.get("hooks", [])
                 if marker in hook.get("command", "")
             ]
-            self.assertEqual(len(matching), 1)
-            self.assertEqual(matching[0].get("managedBy"), "paulsha-memory")
+            managed = [
+                hook for hook in matching
+                if hook.get("managedBy") == "paulsha-memory"
+            ]
+            self.assertEqual(len(managed), 1)
+            if event == "UserPromptSubmit":
+                self.assertTrue(
+                    any(
+                        hook.get("command", "").startswith("/usr/bin/python2 ")
+                        for hook in matching
+                    )
+                )
 
     # ------------------------------------------------------------------
     # Full install — Codex config

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -775,6 +775,74 @@ class InstallerTest(unittest.TestCase):
             ],
         )
 
+    def test_reinstall_replaces_unmarked_pipx_claude_consumption_hooks(self):
+        settings_path = self.config_root / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        pipx_python = "/opt/pipx/venvs/paulsha-hippo/bin/python"
+
+        def old_command(script):
+            return (
+                f"PSC_MEMORY_ROOT={self.memory_root} "
+                f"PSC_CONFIG_ROOT={self.config_root} "
+                f"HIPPO_HOOK_PYTHON={pipx_python} "
+                f"{pipx_python} {self.memory_root}/hooks/{script}"
+            )
+
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "UserPromptSubmit": [
+                            {
+                                "matcher": "",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": old_command(
+                                            "claude_user_prompt_submit.py"
+                                        ),
+                                        "timeout": 10,
+                                    }
+                                ],
+                            }
+                        ],
+                        "PostToolUse": [
+                            {
+                                "matcher": "Read",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": old_command(
+                                            "claude_post_tool_use.py"
+                                        ),
+                                        "timeout": 10,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = _run_install(self.base_args)
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        for event, marker in (
+            ("UserPromptSubmit", "claude_user_prompt_submit.py"),
+            ("PostToolUse", "claude_post_tool_use.py"),
+        ):
+            matching = [
+                hook
+                for entry in settings["hooks"][event]
+                for hook in entry.get("hooks", [])
+                if marker in hook.get("command", "")
+            ]
+            self.assertEqual(len(matching), 1)
+            self.assertEqual(matching[0].get("managedBy"), "paulsha-memory")
+
     # ------------------------------------------------------------------
     # Full install — Codex config
     # ------------------------------------------------------------------
@@ -998,10 +1066,12 @@ class InstallerTest(unittest.TestCase):
         new_memory_root = self.root / "memory-new"
         hooks_path = self.config_root / ".codex" / "hooks.json"
         hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        pipx_python = "/opt/pipx/venvs/paulsha-hippo/bin/python"
         old_stop = (
             f"PSC_MEMORY_ROOT={old_memory_root} "
             f"PSC_CONFIG_ROOT={self.config_root} "
-            f"{old_memory_root}/hooks/.venv/bin/python {old_memory_root}/hooks/codex_session_end.py"
+            f"HIPPO_HOOK_PYTHON={pipx_python} "
+            f"{pipx_python} {old_memory_root}/hooks/codex_session_end.py"
         )
         old_subagent = old_stop + " --subagent"
         hooks_path.write_text(


### PR DESCRIPTION
## 摘要

- 修正 `install all --force` 無法辨識舊版 unmarked pipx Python hook command 的 cleanup 缺口。
- Claude/Codex reconciliation 現在接受 `python`、`python3`、`python3.x` interpreter shape，但仍要求 command 精確指向對應 Hippo hook script，避免吃掉不相關 wrapper。
- 新增 production-shape regression tests，確保 consumer hooks exactly-once 且新 entry 帶 `managedBy=paulsha-memory`。

這是 issues 34 與 39 共同 release closure 在 production `--force` install 後、consumer Read 前檢出的 blocker；不在本 PR merge 時提早關閉 issues。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過（1516 passed、4 skipped、151 subtests）
- [x] focused hooks/default-runtime：78 passed
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片
- [x] `VERSION` 與 release 意圖一致（0.1.1 patch candidate）
- [x] 文件與 CLI help 不適用：CLI surface 不變，changelog 已記錄 cleanup 行為

## 風險與回復

- 只把「Python interpreter + 精確 Hippo hook script」視為 legacy managed command；含 script 名稱但由 custom wrapper 執行的既有 hook 仍保留。
- production 目前仍運行上一顆 exact candidate；本 PR merge 後會重建 wheel，再透過同一 transaction reinstall 清掉 duplicate entries。
- Issue-link exemption 理由：本 PR 是 closure chain blocker 修補，不能提早關閉 issues 34/39。
