### PR TITLE
fix(dream): 修正 produced atom 索引對賬範圍

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - `hippo doctor` 新增 runtime 健康報告：global dream lock（`runtime/locks/dream.lock`）持鎖狀態＋dream/supervise 進程清單（PID/start time/cmdline/cwd），標記非 canonical 實例（interpreter-mismatch／cwd-missing／cwd-temp-worktree）；只報告，不自動 kill（#19）
 
 ### Fixed
+- Dream 的 run-level publication reconciliation 改只要求本輪 produced 且 retrieval-eligible 的 atoms 進入 metadata/FTS；`review` 等刻意 pool-excluded 產物另以 `produced_excluded` 計數，不再誤報遺失並把健康輪次降成 `partial`，獨立 index reconciliation 失敗仍會 fail-visible。
 - `install service` 生成的 systemd unit：`ExecStart` 綁定當前 interpreter（`sys.executable`），修正 pipx / venv 隔離安裝下寫死 `/usr/bin/env python3`（全域 python）import 不到 `paulsha_hippo`、導致 dream service 一觸發即 `exit 1`（ModuleNotFoundError）的問題。
 - `slugify()`/`target_name()` 檔名以 UTF-8 byte 上限（NAME_MAX 255）截斷且落在 code-point 邊界，`--<slice_id>.md` 尾段永不截斷——超長 LLM title 不再於 MOC reconcile rename 觸發 `ENAMETOOLONG` 中止整輪、導致 reindex 從未執行（#16 根因）。
 - MOC naming/linker 對單一壞 slice fail-soft：記 warning 跳過該 slice，不中止整輪 MOC pass。

--- a/changelog.d/issue-34-eligible-reconciliation.md
+++ b/changelog.d/issue-34-eligible-reconciliation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Dream 的 publication reconciliation 僅把 retrieval-eligible produced atoms 視為必須進 metadata/FTS 的集合；刻意排除的 review records 會獨立計數，不再造成 false `partial`。

--- a/paulsha_hippo/dream/cli.py
+++ b/paulsha_hippo/dream/cli.py
@@ -151,16 +151,31 @@ def _run(args: argparse.Namespace) -> int:
                 try:
                     audit = moc_census.audit_indexed_ids(memory_root)
                     indexed = set(audit.searchable_ids)
+                    coverage = result.get("index_coverage", {})
+                    reconciliation = moc_census.reconcile_index(memory_root, coverage)
+                    eligible = set(reconciliation.eligible_ids)
+                    if not reconciliation.ok:
+                        result.setdefault("warnings", []).append(
+                            "run-level index reconciliation failed "
+                            f"with {len(reconciliation.problems)} problem(s)"
+                        )
                 except Exception:
                     indexed = set()
-                missing = sorted(set(str(item) for item in produced) - indexed)
+                    eligible = set(str(item) for item in produced)
+                produced_ids = set(str(item) for item in produced)
+                expected_indexed = produced_ids & eligible
+                excluded = produced_ids - eligible
+                missing = sorted(expected_indexed - indexed)
                 if missing:
                     result.setdefault("warnings", []).append(
-                        f"run-level publication reconciliation missing {len(missing)} produced slice(s)"
+                        "run-level publication reconciliation missing "
+                        f"{len(missing)} eligible produced slice(s)"
                     )
                 result["produced_slice_ids"] = list(produced)
-                result["metadata_indexed"] = len(produced) - len(missing)
-                result["fts_indexed"] = len(produced) - len(missing)
+                result["produced_eligible"] = len(expected_indexed)
+                result["produced_excluded"] = len(excluded)
+                result["metadata_indexed"] = len(expected_indexed) - len(missing)
+                result["fts_indexed"] = len(expected_indexed) - len(missing)
             warnings = result.pop("warnings", [])
             return {
                 "summary": result,

--- a/tests/test_dream_cli_moc_warnings.py
+++ b/tests/test_dream_cli_moc_warnings.py
@@ -89,6 +89,67 @@ class DreamCliMocWarningsTest(unittest.TestCase):
                            f"Full payload: {json.dumps(payload, indent=2)}")
             self.assertIn("moc", payload["passes"])
 
+    def test_intentionally_excluded_produced_slice_is_not_missing(self):
+        """Review records are produced, but intentionally stay outside retrieval."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _seed_simple(root)
+            mock_moc_result = {
+                "renamed": True,
+                "linked": 0,
+                "mocs": True,
+                "faceout": True,
+                "indexed": True,
+                "warnings": [],
+                "index_coverage": {"scanned": 2},
+            }
+            audit = SimpleNamespace(searchable_ids={"sl-knowledge"})
+            reconciliation = SimpleNamespace(
+                ok=True,
+                problems=[],
+                eligible_ids={"sl-knowledge"},
+                indexed_ids={"sl-knowledge"},
+            )
+
+            buf = io.StringIO()
+            with patch(
+                "paulsha_hippo.atomizer.cli.atomizer_config.load_config",
+                return_value=(SimpleNamespace(default_promoter="identity"), "aaaa" * 10),
+            ), patch(
+                "paulsha_hippo.dream.cli.janitor_config.load_config",
+                return_value=(SimpleNamespace(), "bbbb" * 10),
+            ), patch(
+                "paulsha_hippo.dream.cli.atomizer_pipeline.run",
+                return_value={
+                    "summary": {"skipped": 0},
+                    "warnings": [],
+                    "produced_slice_ids": ["sl-knowledge", "sl-review"],
+                },
+            ), patch(
+                "paulsha_hippo.dream.cli.janitor_scanner.run_scan",
+                return_value={"summary": {"skipped": 0}, "warnings": []},
+            ), patch(
+                "paulsha_hippo.moc.runner.run_moc", return_value=mock_moc_result,
+            ), patch(
+                "paulsha_hippo.moc.census.audit_indexed_ids", return_value=audit,
+            ), patch(
+                "paulsha_hippo.moc.census.reconcile_index", return_value=reconciliation,
+            ), redirect_stdout(buf):
+                rc = cli.main([
+                    "dream", "run", "--memory-root", str(root),
+                    "--now", "2026-06-02T05:00:00Z",
+                ])
+
+            self.assertEqual(rc, 0)
+            payload = json.loads(buf.getvalue())
+            self.assertEqual(payload["status"], "ok")
+            summary = payload["passes"]["moc"]
+            self.assertEqual(summary["produced_eligible"], 1)
+            self.assertEqual(summary["produced_excluded"], 1)
+            self.assertEqual(summary["metadata_indexed"], 1)
+            self.assertEqual(summary["fts_indexed"], 1)
+            self.assertNotIn("warnings", payload["passes"]["moc"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

- 將 Dream run-level publication reconciliation 收斂到本輪 produced 且 retrieval-eligible 的 atoms。
- review record 等 intentional pool exclusions 改以 `produced_excluded` 顯式計數，不再誤報遺失。
- 獨立 index reconciliation 若有問題仍會產生 warning，維持 fail-visible。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過（1517 passed、4 skipped、151 subtests）
- [x] `python3 -m policy_check --repo .` 已執行；本地唯一 failure 為候選版尚無 v0.1.1 tag，交由 PR 的 `release:patch` context 驗證
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片
- [x] `VERSION` 與 0.1.1 release candidate 意圖一致
- [x] CHANGELOG 已同步；CLI help 不適用

## 風險與回復

不修改 knowledge、ledger 或 index 資料格式；只修正健康對賬集合與增加計數欄位。若有異常可 revert 此單一 commit。合併後會重建候選 wheel，舊候選 evidence 依 artifact-bound 規則失效並重跑。