### PR TITLE
fix(atomizer): 綁定 live build provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - `hippo doctor` 新增 runtime 健康報告：global dream lock（`runtime/locks/dream.lock`）持鎖狀態＋dream/supervise 進程清單（PID/start time/cmdline/cwd），標記非 canonical 實例（interpreter-mismatch／cwd-missing／cwd-temp-worktree）；只報告，不自動 kill（#19）
 
 ### Fixed
+- Atomizer distillation provenance 未顯式傳入 build 時，改讀取與 CLI／Dream 相同的 embedded/env build identity，不再於已安裝 wheel 的 promoted atom 與 processing ledger 留下 `build_commit: unknown`。
 - Recovery planning 可用 `--source-manifest` 沿用既有 manifest 的精確 frozen source set，再以目前 candidate 重建 pins/planned artifacts；避免 live archive 持續新增或更新中的 session 擴張既定 recovery scope 並永久觸發 target drift，authority manifest 變動則 fail closed。
 - Dream 的 run-level publication reconciliation 改只要求本輪 produced 且 retrieval-eligible 的 atoms 進入 metadata/FTS；`review` 等刻意 pool-excluded 產物另以 `produced_excluded` 計數，不再誤報遺失並把健康輪次降成 `partial`，獨立 index reconciliation 失敗仍會 fail-visible。
 - `install service` 生成的 systemd unit：`ExecStart` 綁定當前 interpreter（`sys.executable`），修正 pipx / venv 隔離安裝下寫死 `/usr/bin/env python3`（全域 python）import 不到 `paulsha_hippo`、導致 dream service 一觸發即 `exit 1`（ModuleNotFoundError）的問題。

--- a/changelog.d/issue-34-live-build-provenance.md
+++ b/changelog.d/issue-34-live-build-provenance.md
@@ -1,0 +1,1 @@
+Atomizer distillation provenance now uses the installed candidate's embedded build identity instead of recording `unknown` when callers omit an explicit build.

--- a/paulsha_hippo/atomizer/provenance.py
+++ b/paulsha_hippo/atomizer/provenance.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from .. import __version__
+from ..build_info import build_identity
 from ..agent_profiles import (
     AgentRunResult,
     RESPONSE_SCHEMA_VERSION,
@@ -77,6 +78,15 @@ def command_fingerprint(command: list[str] | tuple[str, ...]) -> str:
     return fingerprint_argv(command)
 
 
+def _runtime_build_commit() -> str:
+    """Resolve the same embedded/env build authority used by CLI and Dream."""
+    try:
+        value = str(build_identity().get("build_commit") or "").strip()
+    except Exception:  # pragma: no cover - provenance must remain persistable
+        return "unknown"
+    return value or "unknown"
+
+
 def provenance_from_result(
     result: AgentRunResult | None,
     *,
@@ -87,6 +97,7 @@ def provenance_from_result(
     fallback_reason: str | None = None,
     attempts: Sequence[AgentRunResult] | None = None,
 ) -> dict[str, Any]:
+    resolved_build = build if build is not None else _runtime_build_commit()
     if result is None:
         payload = {
             "profile_id": "unknown",
@@ -102,7 +113,7 @@ def provenance_from_result(
             "config_hash": config_hash,
             "skill_hash": skill_hash,
             "hippo_version": hippo_version,
-            "build_commit": build or "unknown",
+            "build_commit": resolved_build or "unknown",
             "fallback_reason": fallback_reason,
             "response_schema": RESPONSE_SCHEMA_VERSION,
         }
@@ -123,7 +134,7 @@ def provenance_from_result(
         "config_hash": config_hash,
         "skill_hash": skill_hash,
         "hippo_version": hippo_version,
-        "build_commit": build or "unknown",
+        "build_commit": resolved_build or "unknown",
         "fallback_reason": fallback_reason or result.fallback_reason,
         "response_schema": result.response_schema,
         "elapsed_seconds": round(float(result.elapsed_seconds), 6),

--- a/tests/test_distillation_provenance.py
+++ b/tests/test_distillation_provenance.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from paulsha_hippo.agent_profiles import AgentRunResult
+from paulsha_hippo.atomizer import provenance as provenance_module
 from paulsha_hippo.atomizer import slice_frontmatter
 from paulsha_hippo.atomizer.provenance import provenance_from_result, safe_provenance
 from paulsha_hippo.moc import frontmatter_io
@@ -114,3 +115,27 @@ def test_safe_provenance_does_not_accept_unbounded_stderr():
     safe = safe_provenance({"profile_id": "x", "stderr": "token=secret\n" + "x" * 1000})
     assert len(safe["stderr"]) <= 500
     assert "secret" not in safe["stderr"]
+
+
+def test_provenance_defaults_to_runtime_build_identity(monkeypatch):
+    monkeypatch.setattr(
+        provenance_module,
+        "build_identity",
+        lambda: {"build_commit": "installed-candidate-commit"},
+    )
+
+    value = provenance_from_result(None)
+
+    assert value["build_commit"] == "installed-candidate-commit"
+
+
+def test_explicit_provenance_build_overrides_runtime_identity(monkeypatch):
+    monkeypatch.setattr(
+        provenance_module,
+        "build_identity",
+        lambda: {"build_commit": "installed-candidate-commit"},
+    )
+
+    value = provenance_from_result(None, build="explicit-commit")
+
+    assert value["build_commit"] == "explicit-commit"


### PR DESCRIPTION
## 摘要

- 修正 final candidate 的 live Dream 實證：run-level build identity 正確，但 promoted atom／processing distiller provenance 留下 `build_commit: unknown`
- `provenance_from_result()` 未顯式指定 build 時，改讀與 CLI／Dream 相同的 embedded/env `build_info` authority
- 保留 explicit build override，並新增兩個 regression tests

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過（1525 passed、4 skipped、151 subtests）
- [x] `python3 -m policy_check --repo .`（本地僅有 pre-tag 預期 R-07；PR context 由 CI 驗證）
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片
- [x] `VERSION` 與 release 意圖一致（0.1.1 patch candidate）
- [x] 文件與 CLI help 不受影響；CHANGELOG 已同步

## 風險與回復

變更只影響持久化 provenance 的 build identity fallback，不改 router、prompt、cache identity 或 publication。若 runtime identity 讀取例外仍 fail-visible 為 `unknown`，不會中斷 atomization。合併後必須重建 wheel、重做 production recovery plan 與所有 artifact/live gates；舊候選不再有效。
