### PR TITLE
fix(importer): 重試 Copilot session flush 競態

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - `paulsha_hippo.lib.session_readers`：`read_codex_rollout`/`read_copilot_history` 升格 lib API（hippo importer + paulshaclaw bro hook 兩使用者；adapters.base 保留 re-export）
 
 ### Fixed
+- Copilot CLI sessionEnd importer 現在會對 `events.jsonl` 尚未 flush 的實機時序做短且 bounded 的重讀，避免 prompt-mode 真 session 被過早判成 `empty-skip`。
 - #7 遞迴自捕捉：agent_exec 對蒸餾子程序注入 `HIPPO_SELF_SESSION=1`，5 個 capture hook（session_end×3／precompact×2）讀到即早退（layer 1）；importer 對 prompt 內容即 atomize skill 調用文本者 `self-skip`（layer 2）
 - #8 空 session 汙染：importer 對無 prompt/無 touched files/summary 空或佔位/turn≤1 的 session `empty-skip`，不寫 inbox、不入蒸餾佇列
 - wheel/pipx 情境 `hippo install hooks`：repo_root 無 pyproject 時 importer venv 改複製已解包套件（原 pip install -e 必失敗）；sample yaml 隨包（config-samples/）

--- a/changelog.d/issue-34-copilot-flush-race.md
+++ b/changelog.d/issue-34-copilot-flush-race.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- 修正 Copilot CLI sessionEnd hook 與 `events.jsonl` 最終 flush 的競態，避免有效真 session 被誤記為 `empty-skip`。

--- a/paulsha_hippo/importer/adapters/copilot.py
+++ b/paulsha_hippo/importer/adapters/copilot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 from paulsha_hippo import paths
@@ -16,6 +17,24 @@ from .base import (
 )
 
 
+_SESSION_END_FLUSH_RETRY_DELAYS = (0.05, 0.1, 0.2, 0.4)
+
+
+def _has_conversation(extracted: dict[str, object]) -> bool:
+    return bool(extracted.get("user_prompts") or extracted.get("assistant_messages"))
+
+
+def _read_session_end_history(config_root: object, session_id: str) -> dict[str, object]:
+    """Bounded retry for Copilot's sessionEnd-before-events-flush ordering."""
+    extracted = read_copilot_history(config_root, session_id)
+    for delay in _SESSION_END_FLUSH_RETRY_DELAYS:
+        if _has_conversation(extracted):
+            break
+        time.sleep(delay)
+        extracted = read_copilot_history(config_root, session_id)
+    return extracted
+
+
 def extract(queue_path: str | Path) -> AdapterResult:
     payload = read_payload(queue_path)
     session_id = string_or_empty(payload.get("sessionId")) or string_or_empty(payload.get("session_id"))
@@ -26,7 +45,11 @@ def extract(queue_path: str | Path) -> AdapterResult:
     )
     extract_from = payload
     if session_id:
-        extracted = {k: v for k, v in read_copilot_history(config_root, session_id).items() if v}
+        if str(payload.get("capture_scope") or "session_end") == "session_end":
+            history = _read_session_end_history(config_root, session_id)
+        else:
+            history = read_copilot_history(config_root, session_id)
+        extracted = {k: v for k, v in history.items() if v}
         if extracted:
             extract_from = {**payload, **extracted}
     return build_session(

--- a/tests/test_copilot_current_layout.py
+++ b/tests/test_copilot_current_layout.py
@@ -59,6 +59,34 @@ def test_copilot_adapter_retries_session_end_flush_race(tmp_path, monkeypatch):
     assert sleeps == [0.05]
 
 
+def test_copilot_adapter_flush_retry_is_bounded(tmp_path, monkeypatch):
+    queue = tmp_path / "queue.json"
+    queue.write_text(json.dumps({
+        "tool": "copilot-cli",
+        "session_id": "s-empty",
+        "psc_config_root": str(tmp_path),
+        "capture_scope": "session_end",
+        "cwd": str(tmp_path),
+    }), encoding="utf-8")
+    calls = 0
+    sleeps: list[float] = []
+
+    def empty_history(*_):
+        nonlocal calls
+        calls += 1
+        return {"user_prompts": [], "assistant_messages": [], "assistant_summary": ""}
+
+    monkeypatch.setattr(copilot_adapter, "read_copilot_history", empty_history)
+    monkeypatch.setattr(copilot_adapter.time, "sleep", sleeps.append)
+
+    result = copilot_adapter.extract(queue)
+
+    assert result.session["user_prompts"] == []
+    assert result.session["assistant_messages"] == []
+    assert calls == 5
+    assert sleeps == [0.05, 0.1, 0.2, 0.4]
+
+
 @pytest.mark.parametrize("layout", ["current", "legacy"])
 def test_copilot_layout_runs_through_importer_inbox_and_atom(tmp_path, monkeypatch, layout):
     copilot_root = tmp_path / ".copilot"

--- a/tests/test_copilot_current_layout.py
+++ b/tests/test_copilot_current_layout.py
@@ -6,6 +6,7 @@ import pytest
 
 from paulsha_hippo.atomizer import config as atomizer_config
 from paulsha_hippo.atomizer import pipeline as atomizer_pipeline
+from paulsha_hippo.importer.adapters import copilot as copilot_adapter
 from paulsha_hippo.importer import pipeline as importer_pipeline
 from paulsha_hippo.importer import title as importer_title
 from paulsha_hippo.lib.session_readers import read_copilot_history
@@ -28,6 +29,34 @@ def test_current_copilot_session_state_events_are_read(tmp_path):
     assert result["user_prompts"] == ["fix UART"]
     assert result["assistant_messages"] == ["root cause found"]
     assert result["assistant_summary"] == "root cause found"
+
+
+def test_copilot_adapter_retries_session_end_flush_race(tmp_path, monkeypatch):
+    queue = tmp_path / "queue.json"
+    queue.write_text(json.dumps({
+        "tool": "copilot-cli",
+        "session_id": "s-race",
+        "psc_config_root": str(tmp_path),
+        "capture_scope": "session_end",
+        "cwd": str(tmp_path),
+    }), encoding="utf-8")
+    snapshots = iter([
+        {"user_prompts": [], "assistant_messages": [], "assistant_summary": ""},
+        {
+            "user_prompts": ["verify producer"],
+            "assistant_messages": ["producer verified"],
+            "assistant_summary": "producer verified",
+        },
+    ])
+    sleeps: list[float] = []
+    monkeypatch.setattr(copilot_adapter, "read_copilot_history", lambda *_: next(snapshots))
+    monkeypatch.setattr(copilot_adapter.time, "sleep", sleeps.append)
+
+    result = copilot_adapter.extract(queue)
+
+    assert result.session["user_prompts"] == ["verify producer"]
+    assert result.session["assistant_messages"] == ["producer verified"]
+    assert sleeps == [0.05]
 
 
 @pytest.mark.parametrize("layout", ["current", "legacy"])


### PR DESCRIPTION
## 摘要

修正 Copilot CLI 的 sessionEnd hook 先於 `events.jsonl` 最終 flush 時，真實 prompt-mode session 會被 importer 過早判成 `empty-skip` 的競態。只在 session-end capture 對空 conversation 做 0.05/0.1/0.2/0.4 秒 bounded 重讀；precompact 與其他 agent 不受影響。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過（1526 passed、4 skipped、151 subtests）
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用（無 CLI/help 介面變更）

## 風險與回復

變更只增加最多 0.75 秒的 session-end 空內容等待；若仍無內容，維持既有 empty-skip。回復可直接 revert 本 PR，不涉及資料格式或 migration。