### PR TITLE
fix(hooks): 優先使用 installed interpreter authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - `paulsha_hippo.lib.session_readers`：`read_codex_rollout`/`read_copilot_history` 升格 lib API（hippo importer + paulshaclaw bro hook 兩使用者；adapters.base 保留 re-export）
 
 ### Fixed
+- Installed hooks 現在以有效的 `HIPPO_HOOK_PYTHON` 為 importer／recall authority；legacy nested hook venv 只在未設定候選 interpreter 時 fallback，避免新 hooks 啟動舊套件造成 split-surface。
 - Copilot CLI sessionEnd importer 現在會對 `events.jsonl` 尚未 flush 的實機時序做短且 bounded 的重讀，避免 prompt-mode 真 session 被過早判成 `empty-skip`。
 - #7 遞迴自捕捉：agent_exec 對蒸餾子程序注入 `HIPPO_SELF_SESSION=1`，5 個 capture hook（session_end×3／precompact×2）讀到即早退（layer 1）；importer 對 prompt 內容即 atomize skill 調用文本者 `self-skip`（layer 2）
 - #8 空 session 汙染：importer 對無 prompt/無 touched files/summary 空或佔位/turn≤1 的 session `empty-skip`，不寫 inbox、不入蒸餾佇列

--- a/changelog.d/issue-34-hook-python-authority.md
+++ b/changelog.d/issue-34-hook-python-authority.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- 修正 installed hooks 在 legacy nested venv 殘留時仍啟動舊 importer 的 split-surface，明確以 `HIPPO_HOOK_PYTHON` 為優先 authority。

--- a/paulsha_hippo/hooks/_wakeup_common.py
+++ b/paulsha_hippo/hooks/_wakeup_common.py
@@ -153,12 +153,12 @@ def offered_map_path(root: Path, tool: str, session_id: str) -> Path:
 
 def hippo_invocation(root: Path) -> list[str]:
     """Return an argv prefix that can invoke the hippo CLI in this deployment."""
-    venv_python = root / "hooks" / ".venv" / "bin" / "python"
-    if venv_python.exists():
-        return [str(venv_python), "-m", "paulsha_hippo"]
     configured_python = Path(os.environ.get("HIPPO_HOOK_PYTHON", ""))
     if configured_python.is_absolute() and configured_python.is_file() and os.access(configured_python, os.X_OK):
         return [str(configured_python), "-m", "paulsha_hippo"]
+    venv_python = root / "hooks" / ".venv" / "bin" / "python"
+    if venv_python.is_file() and os.access(venv_python, os.X_OK):
+        return [str(venv_python), "-m", "paulsha_hippo"]
     return ["python3", "-m", "paulsha_hippo"]
 
 
@@ -228,7 +228,11 @@ def fire_importer(root: Path, tool: str, queue_path: Path) -> None:
     """Fire-and-forget trigger the importer in the background."""
     venv_python = root / "hooks" / ".venv" / "bin" / "python"
     configured_python = Path(os.environ.get("HIPPO_HOOK_PYTHON", ""))
-    importer_python = venv_python if venv_python.exists() else configured_python
+    importer_python = configured_python if (
+        configured_python.is_absolute()
+        and configured_python.is_file()
+        and os.access(configured_python, os.X_OK)
+    ) else venv_python
     if not importer_python.is_absolute() or not importer_python.is_file() or not os.access(importer_python, os.X_OK):
         log_warn(root, tool, "hook importer interpreter unavailable; queue written but importer not triggered")
         return

--- a/paulsha_hippo/hooks/claude_session_end.py
+++ b/paulsha_hippo/hooks/claude_session_end.py
@@ -47,7 +47,11 @@ def _sanitize_id(value: str) -> str:
 def _fire_importer(root: Path, queue_path: Path) -> None:
     venv_python = root / "hooks" / ".venv" / "bin" / "python"
     configured_python = Path(os.environ.get("HIPPO_HOOK_PYTHON", ""))
-    importer_python = venv_python if venv_python.exists() else configured_python
+    importer_python = configured_python if (
+        configured_python.is_absolute()
+        and configured_python.is_file()
+        and os.access(configured_python, os.X_OK)
+    ) else venv_python
     if not importer_python.is_absolute() or not importer_python.is_file() or not os.access(importer_python, os.X_OK):
         _log_warn(root, "hook importer interpreter unavailable; queue written but importer not triggered")
         return

--- a/paulsha_hippo/hooks/codex_session_end.py
+++ b/paulsha_hippo/hooks/codex_session_end.py
@@ -50,7 +50,11 @@ def _sanitize_id(value: str) -> str:
 def _fire_importer(root: Path, queue_path: Path) -> None:
     venv_python = root / "hooks" / ".venv" / "bin" / "python"
     configured_python = Path(os.environ.get("HIPPO_HOOK_PYTHON", ""))
-    importer_python = venv_python if venv_python.exists() else configured_python
+    importer_python = configured_python if (
+        configured_python.is_absolute()
+        and configured_python.is_file()
+        and os.access(configured_python, os.X_OK)
+    ) else venv_python
     if not importer_python.is_absolute() or not importer_python.is_file() or not os.access(importer_python, os.X_OK):
         _log_warn(root, "hook importer interpreter unavailable; queue written but importer not triggered")
         return

--- a/paulsha_hippo/hooks/copilot_session_end.py
+++ b/paulsha_hippo/hooks/copilot_session_end.py
@@ -80,7 +80,11 @@ def _supplement_from_history(payload: dict, session_id: str, config_root: Path) 
 def _fire_importer(root: Path, queue_path: Path) -> None:
     venv_python = root / "hooks" / ".venv" / "bin" / "python"
     configured_python = Path(os.environ.get("HIPPO_HOOK_PYTHON", ""))
-    importer_python = venv_python if venv_python.exists() else configured_python
+    importer_python = configured_python if (
+        configured_python.is_absolute()
+        and configured_python.is_file()
+        and os.access(configured_python, os.X_OK)
+    ) else venv_python
     if not importer_python.is_absolute() or not importer_python.is_file() or not os.access(importer_python, os.X_OK):
         _log_warn(root, "hook importer interpreter unavailable; queue written but importer not triggered")
         return

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -337,6 +337,42 @@ class HookQueueWriterTest(unittest.TestCase):
                 [sys.executable, "-m", "paulsha_hippo"],
             )
 
+    def test_invalid_installed_interpreter_falls_back_to_nested_venv(self):
+        from paulsha_hippo.hooks import (
+            _wakeup_common,
+            claude_session_end,
+            codex_session_end,
+            copilot_session_end,
+        )
+
+        queue_path = self.memory_root / "runtime" / "queue" / "capture.json"
+        nested_python = self.memory_root / "hooks" / ".venv" / "bin" / "python"
+        nested_python.parent.mkdir(parents=True)
+        nested_python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        nested_python.chmod(0o700)
+        env = {"HIPPO_HOOK_PYTHON": str(self.memory_root / "missing-python")}
+        fire_calls = (
+            (claude_session_end._fire_importer, (self.memory_root, queue_path)),
+            (codex_session_end._fire_importer, (self.memory_root, queue_path)),
+            (copilot_session_end._fire_importer, (self.memory_root, queue_path)),
+            (_wakeup_common.fire_importer, (self.memory_root, "codex", queue_path)),
+        )
+        with mock.patch.dict(os.environ, env), mock.patch("subprocess.Popen") as popen:
+            for fire, args in fire_calls:
+                fire(*args)
+
+        self.assertEqual(popen.call_count, 4)
+        for call in popen.call_args_list:
+            argv = call.args[0]
+            self.assertEqual(argv[0], str(nested_python))
+            self.assertEqual(argv[1:3], ["-m", "paulsha_hippo.importer.cli"])
+
+        with mock.patch.dict(os.environ, env):
+            self.assertEqual(
+                _wakeup_common.hippo_invocation(self.memory_root),
+                [str(nested_python), "-m", "paulsha_hippo"],
+            )
+
 
 # ---------------------------------------------------------------------------
 # Installer / Uninstaller tests

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -301,7 +301,7 @@ class HookQueueWriterTest(unittest.TestCase):
         queue_file = self._queue_capture("claude-code", "claude-novenv-001")
         self.assertTrue(queue_file.exists())
 
-    def test_installed_interpreter_drives_background_importer_without_nested_venv(self):
+    def test_installed_interpreter_overrides_stale_nested_venv(self):
         from paulsha_hippo.hooks import (
             _wakeup_common,
             claude_session_end,
@@ -310,6 +310,10 @@ class HookQueueWriterTest(unittest.TestCase):
         )
 
         queue_path = self.memory_root / "runtime" / "queue" / "capture.json"
+        stale_python = self.memory_root / "hooks" / ".venv" / "bin" / "python"
+        stale_python.parent.mkdir(parents=True)
+        stale_python.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+        stale_python.chmod(0o700)
         env = {"HIPPO_HOOK_PYTHON": sys.executable}
         fire_calls = (
             (claude_session_end._fire_importer, (self.memory_root, queue_path)),


### PR DESCRIPTION
## 摘要

修正 installed hooks 在 legacy `hooks/.venv` 仍存在時，background importer 與 recall invocation 會繞過 `HIPPO_HOOK_PYTHON`、啟動舊套件的 split-surface。有效的 configured interpreter 現在是唯一優先 authority；legacy nested venv 只在 configured interpreter 不可用時 fallback。

## 驗證

- [x] 已新增或更新必要測試，且 focused 86 tests 通過；完整 suite 由 CI 執行
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用（無 CLI/help 介面變更）

## 風險與回復

只改 interpreter 選擇優先序；configured 路徑不存在或不可執行時仍回到 nested venv。回復可 revert 本 PR，不含 migration 或資料格式變更。