### PR TITLE
fix(atomizer): 強制 proposal 綁定來源語意

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - `hippo doctor` 新增 runtime 健康報告：global dream lock（`runtime/locks/dream.lock`）持鎖狀態＋dream/supervise 進程清單（PID/start time/cmdline/cwd），標記非 canonical 實例（interpreter-mismatch／cwd-missing／cwd-temp-worktree）；只報告，不自動 kill（#19）
 
 ### Fixed
+- Atomizer 以合法的 non-`_unknown` source project 作為歸屬 authority，即使 generated registry 尚未列出該 project 也不再降級成 `_unknown`；LLM proposal 必須與其宣告的 source fragments 有可驗證文字錨點，atomization skill 與 canonical response contract 已同步，output-contract／agent-instruction 汙染會使整份 response fail-closed，不再發布成知識 atom。
 - Atomizer distillation provenance 未顯式傳入 build 時，改讀取與 CLI／Dream 相同的 embedded/env build identity，不再於已安裝 wheel 的 promoted atom 與 processing ledger 留下 `build_commit: unknown`。
 - Recovery planning 可用 `--source-manifest` 沿用既有 manifest 的精確 frozen source set，再以目前 candidate 重建 pins/planned artifacts；避免 live archive 持續新增或更新中的 session 擴張既定 recovery scope 並永久觸發 target drift，authority manifest 變動則 fail closed。
 - Dream 的 run-level publication reconciliation 改只要求本輪 produced 且 retrieval-eligible 的 atoms 進入 metadata/FTS；`review` 等刻意 pool-excluded 產物另以 `produced_excluded` 計數，不再誤報遺失並把健康輪次降成 `partial`，獨立 index reconciliation 失敗仍會 fail-visible。

--- a/changelog.d/issue-34-semantic-grounding.md
+++ b/changelog.d/issue-34-semantic-grounding.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- 保留合法 source project authority，並拒絕未由宣告 source fragments grounding 的 LLM atoms，避免 output contract 或 agent instructions 被誤發布成知識。

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -23,6 +23,12 @@ wheel hash, until the main agent runs the artifact-bound and live checks.
 - Publication journals keep targets and relation edges invisible until a
   matching commit marker. Incomplete journals are recovered before the next
   atomization pass.
+- Atomization treats a valid non-`_unknown` source project as authoritative even
+  when the generated registry is stale. Every proposal must also retain a
+  deterministic textual anchor to its declared source fragments; prompt/output
+  contract leakage rejects the complete response before publication. The
+  packaged atomization skill and runtime prompt use the same canonical response
+  object contract.
 - `hippo recovery plan --source-manifest <prior-manifest>` 沿用先前已審查的
   frozen source set，但以目前安裝候選版重新產生 code/config/registry pins 與
   planned artifacts；live archive 後續新增的 active session 不會擴張既定

--- a/paulsha_hippo/atomizer/llm_promoter.py
+++ b/paulsha_hippo/atomizer/llm_promoter.py
@@ -21,7 +21,7 @@ from .agent_exec import (
     CachingAgentClient,
 )
 from .provenance import provenance_from_result, safe_provenance, sha256_text
-from .config import AtomizerConfig, is_safe_path_component
+from .config import AtomizerConfig, is_safe_path_component, is_valid_project_id
 from ..noise import is_generic_title
 from .promoter import Promoter
 from .slice_frontmatter import Slice
@@ -47,6 +47,17 @@ _PROMOTE_FAILURE_CATEGORIES = {
     "schema": "backend_unavailable",
     "unsafe": "backend_unavailable",
     "budget": "backend_unavailable",
+}
+
+_GROUNDING_WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.+-]{2,}")
+_GROUNDING_CJK_RE = re.compile(r"[\u3400-\u9fff]+")
+_GROUNDING_STOP_WORDS = {
+    "and", "are", "for", "from", "into", "one", "only", "that", "the",
+    "their", "then", "this", "use", "with",
+}
+_OUTPUT_CONTRACT_MARKERS = {
+    "disposition", "findings", "json", "markdown", "no_findings",
+    "reason", "schema_version",
 }
 
 
@@ -169,8 +180,77 @@ class LLMPromoter(Promoter):
             candidate = candidate._inner
         return candidate if isinstance(candidate, ExternalAgentRouter) else None
 
-    def _response_validator(self):
-        return lambda raw: llm_output.parse_response(raw, self._projects)
+    @staticmethod
+    def _grounding_units(value: object) -> set[str]:
+        text = str(value or "")
+        units = {
+            token.casefold()
+            for token in _GROUNDING_WORD_RE.findall(text)
+            if token.casefold() not in _GROUNDING_STOP_WORDS
+        }
+        for run in _GROUNDING_CJK_RE.findall(text):
+            units.update(run[index:index + 2] for index in range(len(run) - 1))
+        return units
+
+    @classmethod
+    def _validate_grounding(
+        cls,
+        response: llm_output.ParsedResponse,
+        fragments: list[Fragment],
+    ) -> llm_output.ParsedResponse:
+        if response.disposition != "findings":
+            return response
+        fragments_by_index: dict[int, list[Fragment]] = {}
+        for fragment in fragments:
+            fragments_by_index.setdefault(fragment.fragment_index, []).append(fragment)
+        for index, proposal in enumerate(response.findings):
+            referenced = [
+                fragment
+                for fragment_index in proposal.source_fragment_indices
+                if fragment_index in fragments_by_index
+                for fragment in fragments_by_index[fragment_index]
+            ]
+            # Preserve the existing lenient out-of-range attribution contract:
+            # when every model-supplied index is invalid, the whole session is
+            # the only honest source authority available.
+            if not referenced:
+                referenced = list(fragments)
+            source_text = "\n".join(fragment.body for fragment in referenced)
+            # Tags are model-selected metadata, not source evidence.  Counting
+            # them would let an unrelated body pass by copying one source noun
+            # into a tag.
+            proposal_text = "\n".join((proposal.title, proposal.body))
+            source_units = cls._grounding_units(source_text)
+            proposal_units = cls._grounding_units(proposal_text)
+            leaked_contract = (
+                proposal_units & _OUTPUT_CONTRACT_MARKERS
+            ) - source_units
+            if len(leaked_contract) >= 3 or not (source_units & proposal_units):
+                raise llm_output.LlmOutputError(
+                    f"proposal {index} not grounded in declared source fragments"
+                )
+        return response
+
+    def _known_projects_for_fragments(self, fragments: list[Fragment]) -> list[str]:
+        projects = list(self._projects)
+        if fragments:
+            source_project = fragments[0].project
+            if (
+                source_project != "_unknown"
+                and is_valid_project_id(source_project)
+                and source_project not in projects
+            ):
+                projects.append(source_project)
+        return projects
+
+    def _response_validator(self, fragments: list[Fragment]):
+        known_projects = self._known_projects_for_fragments(fragments)
+
+        def validate(raw: str) -> llm_output.ParsedResponse:
+            response = llm_output.parse_response(raw, known_projects)
+            return self._validate_grounding(response, fragments)
+
+        return validate
 
     def _router_result(self) -> AgentRunResult | None:
         result = getattr(self._agent, "last_result", None)
@@ -275,7 +355,7 @@ class LLMPromoter(Promoter):
         self.last_raw_output = ""
         last_error: Exception | None = None
         attempted = 0
-        validator = self._response_validator()
+        validator = self._response_validator(chunk_fragments)
         router = self._router()
         for attempt in range(1, attempts + 1):
             attempted = attempt
@@ -426,7 +506,12 @@ class LLMPromoter(Promoter):
             )
             for chunk in chunks
         )
-        validator = self._response_validator()
+        session_fragments = [
+            part.as_fragment()
+            for chunk in chunks
+            for part in chunk.parts
+        ]
+        validator = self._response_validator(session_fragments)
         self.last_raw_output = ""
         try:
             if isinstance(self._agent, CachingAgentClient):
@@ -493,7 +578,7 @@ class LLMPromoter(Promoter):
             chunks = budget.pack_prompt_chunks(
                 skill_text=self._skill,
                 fragments=fragments,
-                known_projects=self._projects,
+                known_projects=self._known_projects_for_fragments(fragments),
                 context_window=config.context_window,
                 max_input_tokens=config.max_input_tokens,
                 max_prompt_argv_bytes=config.max_prompt_argv_bytes,
@@ -549,7 +634,7 @@ class LLMPromoter(Promoter):
             for proposal in response.findings:
                 if (
                     first.project != "_unknown"
-                    and first.project in self._projects
+                    and is_valid_project_id(first.project)
                     and proposal.project != first.project
                 ):
                     _LOG.warning(

--- a/paulsha_hippo/atomizer/prompt.py
+++ b/paulsha_hippo/atomizer/prompt.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from .splitter import Fragment
 
-_CANONICAL_RESPONSE_SCHEMA = (
-    '{"schema_version":1,"disposition":"findings|no_findings",'
-    '"reason":null|string,"findings":[...]}'
+_CANONICAL_RESPONSE_EXAMPLE = (
+    '{"schema_version":1,"disposition":"no_findings",'
+    '"reason":"no durable findings","findings":[]}'
 )
 
 
@@ -36,7 +36,8 @@ def build_prompt(skill_text: str, fragments: list[Fragment], known_projects: lis
         parts.append(fragment.body)
         parts.append("")
     parts.append("## Output")
-    parts.append(f"Return ONLY this canonical JSON object shape: {_CANONICAL_RESPONSE_SCHEMA}")
+    parts.append("Return ONLY a canonical JSON object.")
+    parts.append(f"Valid no-findings example: {_CANONICAL_RESPONSE_EXAMPLE}")
     parts.append("Use disposition=findings with one or more findings and reason=null.")
     parts.append("Use disposition=no_findings only with findings=[] and a non-empty reason.")
     parts.append("The first character must be `{` and the last character must be `}`.")

--- a/paulsha_hippo/atomizer/skills/atomize-knowledge-slice.md
+++ b/paulsha_hippo/atomizer/skills/atomize-knowledge-slice.md
@@ -82,12 +82,16 @@ triggers:
 - 檢查所有 `title` 在同一批輸出內唯一且可互相引用。
 
 ## Output contract
-Return ONLY an inline JSON array.
-The first character of your response must be `[` and the last character must be `]`.
+Return ONLY this canonical JSON object shape:
+`{"schema_version":1,"disposition":"findings|no_findings","reason":null|string,"findings":[...]}`
+The first character of your response must be `{` and the last character must be `}`.
 Do NOT create files, write files, save files, or claim that you updated any file or index.
-Do NOT return prose, narration, summaries, markdown fences, or any text before or after the JSON array.
+Do NOT return prose, narration, summaries, markdown fences, or any text before or after the JSON object.
 
-Each item in the array must be an object with these fields:
+Use `disposition=findings` with one or more items in `findings` and `reason=null`.
+Use `disposition=no_findings` only with `findings=[]` and a non-empty string `reason`.
+
+Each item in `findings` must be an object with these fields:
 
 - `title`: slice 標題；短、穩定、可被其他 slices 以 `target_title` 參照。
 - `artifact_kind`: 必須是下列其中之一：`research`、`spec`、`roadmap`、`test`、`task`、`todo`、`plan`、`report`、`review`、`ship-record`、`gate-report`。
@@ -99,5 +103,5 @@ Each item in the array must be an object with these fields:
   - `{ "type": "relates_to", "target_title": "<another slice title>" }`
   - `{ "type": "mentions", "entity": "<stable entity name>" }`
 
-Inline example shape (for reference only; your actual response must still be only the array):
-`[{"title":"example overview","artifact_kind":"report","project":"paulshaclaw","tags":["atomizer","overview"],"body":"Distilled markdown content.","source_fragment_indices":[0,1],"relations":[{"type":"relates_to","target_title":"example detail"},{"type":"mentions","entity":"BRCM"}]}]`
+Inline example shape (for reference only; your actual response must still be only the object):
+`{"schema_version":1,"disposition":"findings","reason":null,"findings":[{"title":"example overview","artifact_kind":"report","project":"paulshaclaw","tags":["atomizer","overview"],"body":"Distilled markdown content.","source_fragment_indices":[0,1],"relations":[{"type":"relates_to","target_title":"example detail"},{"type":"mentions","entity":"BRCM"}]}]}`

--- a/paulsha_hippo/atomizer/skills/atomize-knowledge-slice.md
+++ b/paulsha_hippo/atomizer/skills/atomize-knowledge-slice.md
@@ -82,8 +82,9 @@ triggers:
 - 檢查所有 `title` 在同一批輸出內唯一且可互相引用。
 
 ## Output contract
-Return ONLY this canonical JSON object shape:
-`{"schema_version":1,"disposition":"findings|no_findings","reason":null|string,"findings":[...]}`
+Return ONLY a canonical JSON object.
+Valid no-findings example:
+`{"schema_version":1,"disposition":"no_findings","reason":"no durable findings","findings":[]}`
 The first character of your response must be `{` and the last character must be `}`.
 Do NOT create files, write files, save files, or claim that you updated any file or index.
 Do NOT return prose, narration, summaries, markdown fences, or any text before or after the JSON object.

--- a/tests/test_atomize_skill.py
+++ b/tests/test_atomize_skill.py
@@ -91,11 +91,11 @@ class SkillDocTests(unittest.TestCase):
 
         self.assertIn("## Output contract", body)
         _, output_contract = body.split("## Output contract", maxsplit=1)
-        self.assertIn("Return ONLY this canonical JSON object shape:", output_contract)
+        self.assertIn("Return ONLY a canonical JSON object.", output_contract)
         self.assertIn('"schema_version":1', output_contract)
-        self.assertIn('"disposition":"findings|no_findings"', output_contract)
-        self.assertIn('"reason":null|string', output_contract)
-        self.assertIn('"findings":[...]', output_contract)
+        self.assertIn('"disposition":"no_findings"', output_contract)
+        self.assertIn('"reason":"no durable findings"', output_contract)
+        self.assertIn('"findings":[]', output_contract)
         for field in (
             "title",
             "artifact_kind",
@@ -134,7 +134,7 @@ class SkillDocTests(unittest.TestCase):
         _, body = self._read_skill()
 
         _, output_contract = body.split("## Output contract", maxsplit=1)
-        self.assertIn("Return ONLY this canonical JSON object shape:", output_contract)
+        self.assertIn("Return ONLY a canonical JSON object.", output_contract)
         self.assertIn("The first character of your response must be `{` and the last character must be `}`.", output_contract)
         self.assertIn("Do NOT create files, write files, save files, or claim that you updated any file or index.", output_contract)
         self.assertIn("Do NOT return prose, narration, summaries, markdown fences, or any text before or after the JSON object.", output_contract)

--- a/tests/test_atomize_skill.py
+++ b/tests/test_atomize_skill.py
@@ -91,7 +91,11 @@ class SkillDocTests(unittest.TestCase):
 
         self.assertIn("## Output contract", body)
         _, output_contract = body.split("## Output contract", maxsplit=1)
-        self.assertIn("Return ONLY an inline JSON array.", output_contract)
+        self.assertIn("Return ONLY this canonical JSON object shape:", output_contract)
+        self.assertIn('"schema_version":1', output_contract)
+        self.assertIn('"disposition":"findings|no_findings"', output_contract)
+        self.assertIn('"reason":null|string', output_contract)
+        self.assertIn('"findings":[...]', output_contract)
         for field in (
             "title",
             "artifact_kind",
@@ -130,10 +134,10 @@ class SkillDocTests(unittest.TestCase):
         _, body = self._read_skill()
 
         _, output_contract = body.split("## Output contract", maxsplit=1)
-        self.assertIn("Return ONLY an inline JSON array.", output_contract)
-        self.assertIn("The first character of your response must be `[` and the last character must be `]`.", output_contract)
+        self.assertIn("Return ONLY this canonical JSON object shape:", output_contract)
+        self.assertIn("The first character of your response must be `{` and the last character must be `}`.", output_contract)
         self.assertIn("Do NOT create files, write files, save files, or claim that you updated any file or index.", output_contract)
-        self.assertIn("Do NOT return prose, narration, summaries, markdown fences, or any text before or after the JSON array.", output_contract)
+        self.assertIn("Do NOT return prose, narration, summaries, markdown fences, or any text before or after the JSON object.", output_contract)
         self.assertNotIn("```", output_contract)
 
 

--- a/tests/test_atomizer_grounding.py
+++ b/tests/test_atomizer_grounding.py
@@ -100,6 +100,31 @@ def test_prompt_contract_hallucination_rejects_the_whole_response():
         promoter.promote([source], cfg)
 
 
+def test_source_owned_output_contract_is_not_rejected_as_prompt_leakage():
+    cfg, _ = atomizer_config.load_config(override_path=None)
+    source = _fragment(
+        "The canonical JSON response uses schema_version, disposition, reason, and a findings "
+        "array; Markdown wrappers are forbidden."
+    )
+    promoter = LLMPromoter(
+        FakeAgentClient(
+            _response(
+                _finding(
+                    "Canonical response contract",
+                    "The JSON contract contains schema_version, disposition, reason, and findings "
+                    "without a Markdown wrapper.",
+                )
+            )
+        ),
+        skill_text="GROUNDING-SKILL",
+        known_projects=["paulsha-hippo"],
+    )
+
+    slices = promoter.promote([source], cfg)
+
+    assert len(slices) == 1
+
+
 @pytest.mark.parametrize(
     ("source_body", "finding_title", "finding_body"),
     [

--- a/tests/test_atomizer_grounding.py
+++ b/tests/test_atomizer_grounding.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from paulsha_hippo.atomizer import config as atomizer_config
+from paulsha_hippo.atomizer.agent_exec import FakeAgentClient
+from paulsha_hippo.atomizer.llm_promoter import LLMPromoter, PromoteError
+from paulsha_hippo.atomizer.splitter import Fragment
+
+
+def _fragment(body: str, *, project: str = "paulsha-hippo") -> Fragment:
+    return Fragment(
+        project=project,
+        source_agent="claude-code",
+        source_session="semantic-grounding",
+        source_artifact="report",
+        captured_at="2026-07-22T12:24:00Z",
+        provenance={"repo": "r", "commit": "c", "path": "p"},
+        fragment_index=0,
+        body=body,
+    )
+
+
+def _response(*findings: dict[str, object]) -> str:
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "disposition": "findings",
+            "reason": None,
+            "findings": list(findings),
+        }
+    )
+
+
+def _finding(title: str, body: str, *, project: str = "paulsha-hippo") -> dict[str, object]:
+    return {
+        "title": title,
+        "artifact_kind": "spec",
+        "project": project,
+        "tags": ["release"],
+        "body": body,
+        "source_fragment_indices": [0],
+        "relations": [],
+    }
+
+
+def test_valid_source_project_is_authoritative_even_when_registry_list_is_stale():
+    cfg, _ = atomizer_config.load_config(override_path=None)
+    source = _fragment(
+        "A release candidate binds one exact commit and wheel hash.",
+        project="paulsha-hippo",
+    )
+    promoter = LLMPromoter(
+        FakeAgentClient(
+            _response(
+                _finding(
+                    "Immutable release candidate",
+                    "The release candidate binds one exact commit and wheel hash.",
+                )
+            )
+        ),
+        skill_text="GROUNDING-SKILL",
+        known_projects=["paulshaclaw"],
+    )
+
+    slices = promoter.promote([source], cfg)
+
+    assert len(slices) == 1
+    assert slices[0].frontmatter["project"] == "paulsha-hippo"
+
+
+def test_prompt_contract_hallucination_rejects_the_whole_response():
+    cfg, _ = atomizer_config.load_config(override_path=None)
+    source = _fragment(
+        "A release candidate consists of one exact merge commit and one wheel SHA-256. "
+        "Build the wheel once and reuse the same bytes for verification and publication."
+    )
+    promoter = LLMPromoter(
+        FakeAgentClient(
+            _response(
+                _finding(
+                    "Immutable release artifact identity",
+                    "A release candidate is identified by one merge commit and one wheel SHA-256.",
+                ),
+                _finding(
+                    "Canonical findings JSON contract",
+                    "Return one inline JSON object with schema_version, disposition, reason, and a "
+                    "findings array. Emit no surrounding prose or Markdown.",
+                ),
+            )
+        ),
+        skill_text="GROUNDING-SKILL",
+        known_projects=["paulsha-hippo"],
+    )
+
+    with pytest.raises(PromoteError, match="not grounded"):
+        promoter.promote([source], cfg)
+
+
+@pytest.mark.parametrize(
+    ("source_body", "finding_title", "finding_body"),
+    [
+        (
+            "The release candidate uses an immutable wheel SHA-256 and exact merge commit.",
+            "Immutable candidate artifact",
+            "Keep the wheel SHA-256 and merge commit unchanged for publication.",
+        ),
+        (
+            "候選版本改變後，所有綁定舊產物的驗證證據都必須失效並重新執行。",
+            "候選版本漂移使證據失效",
+            "候選版本一旦漂移，舊產物的驗證證據必須失效並重跑。",
+        ),
+    ],
+)
+def test_grounded_english_and_cjk_paraphrases_are_accepted(
+    source_body: str,
+    finding_title: str,
+    finding_body: str,
+):
+    cfg, _ = atomizer_config.load_config(override_path=None)
+    promoter = LLMPromoter(
+        FakeAgentClient(_response(_finding(finding_title, finding_body))),
+        skill_text="GROUNDING-SKILL",
+        known_projects=["paulsha-hippo"],
+    )
+
+    slices = promoter.promote([_fragment(source_body)], cfg)
+
+    assert len(slices) == 1
+
+
+def test_grounding_uses_all_bounded_parts_of_a_declared_fragment():
+    cfg, _ = atomizer_config.load_config(override_path=None)
+    first_part = replace(
+        _fragment("The immutable wheel hash identifies the candidate."),
+        part_index=1,
+        part_count=2,
+    )
+    second_part = replace(
+        _fragment("Publication happens only after all readiness gates pass."),
+        part_index=2,
+        part_count=2,
+    )
+    promoter = LLMPromoter(
+        FakeAgentClient(
+            _response(
+                _finding(
+                    "Immutable candidate hash",
+                    "The immutable wheel hash identifies the release candidate.",
+                )
+            )
+        ),
+        skill_text="GROUNDING-SKILL",
+        known_projects=["paulsha-hippo"],
+    )
+
+    slices = promoter.promote([first_part, second_part], cfg)
+
+    assert len(slices) == 1

--- a/tests/test_atomizer_prompt.py
+++ b/tests/test_atomizer_prompt.py
@@ -22,7 +22,8 @@ def _frag(index, body):
 def _expected_output_footer() -> list[str]:
     return [
         "## Output",
-        'Return ONLY this canonical JSON object shape: {"schema_version":1,"disposition":"findings|no_findings","reason":null|string,"findings":[...]}',
+        'Return ONLY a canonical JSON object.',
+        'Valid no-findings example: {"schema_version":1,"disposition":"no_findings","reason":"no durable findings","findings":[]}',
         "Use disposition=findings with one or more findings and reason=null.",
         "Use disposition=no_findings only with findings=[] and a non-empty reason.",
         "The first character must be `{` and the last character must be `}`.",

--- a/tests/test_llm_promoter.py
+++ b/tests/test_llm_promoter.py
@@ -31,7 +31,7 @@ _TWO = (
 )
 _MERGE = (
     '[{"title":"m","artifact_kind":"report","project":"paulshaclaw","tags":[],'
-    '"body":"merged","source_fragment_indices":[0,1],"relations":[]}]'
+    '"body":"merged body","source_fragment_indices":[0,1],"relations":[]}]'
 )
 
 
@@ -58,7 +58,7 @@ def _frag(index: int) -> Fragment:
         captured_at="2026-06-02T00:00:00Z",
         provenance={"repo": "r", "commit": "c", "path": "p"},
         fragment_index=index,
-        body=f"b{index}",
+        body=f"body {chr(ord('a') + index)}",
     )
 
 
@@ -275,12 +275,12 @@ class LLMPromoterTests(unittest.TestCase):
 
         valid_0 = (
             '[{"title":"specific finding zero","artifact_kind":"report",'
-            '"project":"paulshaclaw","tags":[],"body":"body zero",'
+            '"project":"paulshaclaw","tags":[],"body":"body a",'
             '"source_fragment_indices":[0],"relations":[]}]'
         )
         valid_1 = (
             '[{"title":"specific finding one","artifact_kind":"report",'
-            '"project":"paulshaclaw","tags":[],"body":"body one",'
+            '"project":"paulshaclaw","tags":[],"body":"body b",'
             '"source_fragment_indices":[1],"relations":[]}]'
         )
         calls: list[tuple[str, str]] = []


### PR DESCRIPTION
## 摘要

- 讓合法且非 `_unknown` 的 source project 成為 session-local authority
- 在 cache／publication 前驗證 proposal 與宣告來源的 deterministic grounding
- 整批拒絕 output-contract／agent-instruction 汙染
- 同步 packaged atomization skill 與 canonical response object contract

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過（1533 passed, 4 skipped, 151 subtests）
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

## 風險與回復

Grounding gate 採 deterministic English/domain token 與 CJK bigram anchor，避免依賴第二次 LLM 判斷。任何 proposal 失敗都拒絕整份 response，讓既有 fallback／park 機制處理。回復方式為 revert 此 PR；不含資料遷移。