### PR TITLE
fix(importer): 引用 YAML 結尾冒號標題

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-22
+
 ### Added
 - #39 最終架構取代本節較早期的 backend 描述：runtime 僅接受 canonical external CLI profiles；Hippo 不再提供 `openai-compatible`／HTTP provider client，不讀取或轉送 API-key/OAuth/provider URL/credential env。舊名詞只保留在 migration 拒絕與歷史說明中。
 - Issue #34/#39 release-candidate implementation：external headless profile router、canonical atom title/project/provenance、publication recovery、quarantine/health、ownership-manifest force install 與 hash-bound artifact upgrade runner。Live service/recovery/soak/publish/consumer evidence 仍待候選 wheel 綁定後執行。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - `hippo doctor` 新增 runtime 健康報告：global dream lock（`runtime/locks/dream.lock`）持鎖狀態＋dream/supervise 進程清單（PID/start time/cmdline/cwd），標記非 canonical 實例（interpreter-mismatch／cwd-missing／cwd-temp-worktree）；只報告，不自動 kill（#19）
 
 ### Fixed
+- Importer 會引用 YAML 中以冒號結尾或接 flow delimiter 的 scalar，避免 fallback session title 讓 inbox frontmatter 無法解析並在每輪 Dream 重複隔離。
 - Atomizer 以合法的 non-`_unknown` source project 作為歸屬 authority，即使 generated registry 尚未列出該 project 也不再降級成 `_unknown`；LLM proposal 必須與其宣告的 source fragments 有可驗證文字錨點，atomization skill 與 canonical response contract 已同步，output-contract／agent-instruction 汙染會使整份 response fail-closed，不再發布成知識 atom。
 - Atomizer distillation provenance 未顯式傳入 build 時，改讀取與 CLI／Dream 相同的 embedded/env build identity，不再於已安裝 wheel 的 promoted atom 與 processing ledger 留下 `build_commit: unknown`。
 - Recovery planning 可用 `--source-manifest` 沿用既有 manifest 的精確 frozen source set，再以目前 candidate 重建 pins/planned artifacts；避免 live archive 持續新增或更新中的 session 擴張既定 recovery scope 並永久觸發 target drift，authority manifest 變動則 fail closed。

--- a/changelog.d/issue-34-frontmatter-trailing-colon.md
+++ b/changelog.d/issue-34-frontmatter-trailing-colon.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Importer 會引用 YAML 中以冒號結尾或接 flow delimiter 的 scalar，避免 fallback session title 讓 inbox frontmatter 無法解析並在每輪 Dream 重複隔離。

--- a/paulsha_hippo/importer/frontmatter.py
+++ b/paulsha_hippo/importer/frontmatter.py
@@ -40,6 +40,15 @@ def _needs_yaml_quotes(value: str) -> bool:
         return True
     if value[:2] in ("- ", "? ", ": ") or value in ("-", "?", ":"):
         return True
+    # A colon followed by whitespace, a flow delimiter, or end-of-scalar is a
+    # YAML mapping indicator.  The end-of-scalar case matters for fallback
+    # titles such as ``安裝 skill https:``; leaving it plain makes the whole
+    # inbox document unparsable on the next Dream pass.
+    for index, character in enumerate(value):
+        if character != ":":
+            continue
+        if index + 1 == len(value) or value[index + 1] in " \t[]{} ,":
+            return True
     return any(marker in value for marker in (": ", "#", "\"", "'", "\n", "\r"))
 
 

--- a/tests/test_frontmatter_resilience.py
+++ b/tests/test_frontmatter_resilience.py
@@ -90,6 +90,19 @@ class ImporterEscapingTests(unittest.TestCase):
         fm = _read_frontmatter_block(markdown)
         self.assertEqual(fm["title"], '{"verdict":"needs-attention"}')
 
+    def test_title_ending_in_colon_is_quoted_and_parseable(self):
+        session = {
+            "tool": "claude-code",
+            "session_id": "s-trailing-colon",
+            "assistant_summary": "semantic outcome remains separate",
+            "session_title": "安裝 brag skill https:",
+            "title_source": "fallback",
+        }
+        markdown = render_markdown(session, project="serialwrap")
+        self.assertIn('title: "安裝 brag skill https:"', markdown)
+        fm = _read_frontmatter_block(markdown)
+        self.assertEqual(fm["title"], "安裝 brag skill https:")
+
 
 class FrontmatterIoEscapingTests(unittest.TestCase):
     def test_dump_escapes_embedded_quotes_round_trip(self):


### PR DESCRIPTION
## 摘要

修正 release soak 發現的真實 importer frontmatter 缺陷：fallback session title 若以冒號結尾，原先會輸出成無效 YAML，導致每輪 Dream 重複隔離同一 inbox。現在只在 YAML mapping indicator 邊界引用 scalar，並以現場同款標題加入 round-trip regression。

Refs #34
Refs #39

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過（1535 passed、4 skipped、151 subtests）
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致（未發布的 0.1.1 候選；使用 `release:patch`）
- [x] 文件與 CLI help 已同步，或已說明不適用（內部 serializer，CLI 無變更）

## 政策豁免理由

`policy-exempt:issue-link`：#34/#39 必須等同一候選完成三輪自然 timer、發布與 OpenSpec archive 後一起閉合，本修正 PR 不得提前自動關閉。

## 風險與回復

變更僅擴大 YAML scalar 引用條件，不改資料模型。若回退此 commit，現場以冒號結尾的 fallback title 會再次產生不可解析 frontmatter；因此 release soak 必須以合併後新候選重跑。