### PR TITLE
fix(janitor): 接受 rich project identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Janitor 不再把合法的 remote-form rich project ID 誤判為 `raw-remote-key`，避免已採 hashed directory key 的 atom 讓 Dream 永久降為 `partial`。
+
 ## [0.1.1] - 2026-07-22
 
 ### Added

--- a/changelog.d/issue-34-janitor-rich-project.md
+++ b/changelog.d/issue-34-janitor-rich-project.md
@@ -1,0 +1,2 @@
+### Fixed
+- Janitor 不再把合法的 remote-form rich project ID 誤判為 `raw-remote-key`，避免已採 hashed directory key 的 atom 讓 Dream 永久降為 `partial`。

--- a/openspec/changes/issue-34-atomization-release/specs/atomization-release-integrity/spec.md
+++ b/openspec/changes/issue-34-atomization-release/specs/atomization-release-integrity/spec.md
@@ -193,3 +193,26 @@ The production recovery manifest SHALL enumerate every remaining batch and assig
 #### Scenario: Producer release does not over-claim consumption
 - **WHEN** all deterministic producer/release gates pass but no supported client completes an offered-to-Read trace
 - **THEN** `v0.1.1` MAY publish with automatic consumption downgraded, but Issue #34 SHALL remain open and release notes MUST state the unproven capability
+
+## MODIFIED Requirements
+
+### Requirement: Janitor hygiene lint for untitled titles
+
+Janitor scan SHALL perform read-only hygiene lint for a knowledge record whose
+frontmatter `title` equals `untitled`, emitting rule `title-untitled`. A
+registry-valid remote-form project ID containing `/` is canonical rich metadata
+and MUST NOT emit `raw-remote-key`; filesystem safety is enforced separately by
+the collision-resistant project directory key. Lint MUST NOT modify files or
+write lifecycle events. For machine-readable compatibility, `run_scan` SHALL
+continue returning `lint` fields `untitled` and `raw_remote_key`, with
+`raw_remote_key` equal to zero under this contract.
+
+#### Scenario: Remote-form project remains clean
+
+- **WHEN** a knowledge slice has a semantic title and project `github.com/hamanpaul/paulsha-hippo`
+- **THEN** janitor SHALL emit no lint warning and `raw_remote_key` SHALL remain zero
+
+#### Scenario: Untitled remote-form project reports only its title
+
+- **WHEN** a knowledge slice has `title: untitled` and a registry-valid remote-form project
+- **THEN** janitor SHALL emit exactly one `title-untitled` warning without modifying the slice or lifecycle ledger

--- a/paulsha_hippo/janitor/rules.py
+++ b/paulsha_hippo/janitor/rules.py
@@ -279,13 +279,9 @@ def plan_lint(records: list[KnowledgeRecord]) -> list[dict[str, Any]]:
                     "project": record.project,
                 }
             )
-        if "/" in record.project:
-            findings.append(
-                {
-                    "rule": LINT_RAW_REMOTE_KEY,
-                    "record_id": record.record_id,
-                    "path": str(record.path),
-                    "project": record.project,
-                }
-            )
+        # Remote-form project IDs are canonical metadata.  Filesystem placement
+        # uses a separate collision-resistant directory key, so a slash in the
+        # project ID is not itself a hygiene defect.  Keep the legacy
+        # raw_remote_key summary field for schema compatibility, but do not emit
+        # false-positive findings for valid rich IDs.
     return findings

--- a/tests/test_janitor_rules.py
+++ b/tests/test_janitor_rules.py
@@ -158,18 +158,16 @@ class LintRuleTests(unittest.TestCase):
         self.assertEqual(findings[0]["rule"], "title-untitled")
         self.assertEqual(findings[0]["record_id"], "sl-u1")
 
-    def test_raw_remote_project_key_is_flagged(self):
+    def test_remote_form_project_id_is_not_flagged(self):
         findings = rules.plan_lint([_lint_rec(rid="sl-r1", project="github.com/hamanpaul/testpilot")])
-        self.assertEqual(len(findings), 1)
-        self.assertEqual(findings[0]["rule"], "raw-remote-key")
-        self.assertEqual(findings[0]["project"], "github.com/hamanpaul/testpilot")
+        self.assertEqual(findings, [])
 
     def test_clean_record_yields_no_findings(self):
         self.assertEqual(rules.plan_lint([_lint_rec()]), [])
 
-    def test_both_rules_can_fire_on_one_record(self):
+    def test_remote_form_project_with_untitled_only_flags_title(self):
         findings = rules.plan_lint([_lint_rec(title="untitled", project="a/b")])
-        self.assertEqual({finding["rule"] for finding in findings}, {"title-untitled", "raw-remote-key"})
+        self.assertEqual({finding["rule"] for finding in findings}, {"title-untitled"})
 
     def test_findings_are_deterministic_and_sorted(self):
         first = _lint_rec(rid="sl-2", title="untitled")

--- a/tests/test_janitor_scanner.py
+++ b/tests/test_janitor_scanner.py
@@ -106,9 +106,9 @@ class ScannerLintTests(unittest.TestCase):
                 source_path_exists=lambda r: True,
             )
 
-            self.assertEqual(result["summary"]["lint"], {"untitled": 1, "raw_remote_key": 1})
+            self.assertEqual(result["summary"]["lint"], {"untitled": 1, "raw_remote_key": 0})
             lint_warnings = [warning for warning in result["warnings"] if warning.startswith("lint:")]
-            self.assertEqual(len(lint_warnings), 2)
+            self.assertEqual(len(lint_warnings), 1)
             self.assertTrue(slice_path.exists())
             self.assertEqual(lifecycle.read_events(root / "runtime" / "ledger" / "lifecycle.jsonl"), [])
 


### PR DESCRIPTION
## 摘要

修正 #34 live pre-soak 找到的契約衝突：rich remote-form project ID 是 canonical metadata，filesystem 已使用 collision-resistant hashed directory key，janitor 不應再因 `/` 誤報 `raw-remote-key` 並讓 Dream 永久降為 `partial`。保留 `raw_remote_key` summary 欄位為相容欄位，值固定為 0。

Refs #34
Refs #39

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過：1535 passed、4 skipped、151 subtests
- [x] `python3 -m policy_check --repo .`（含 PR context）由 CI 驗證；本機唯一 R-07 由 `release:patch` 處理
- [x] `openspec validate issue-34-atomization-release --strict` 通過
- [x] `changelog.d/issue-34-janitor-rich-project.md` 已新增
- [x] `VERSION` 維持 release candidate `0.1.1`
- [x] accepted OpenSpec delta 與 CHANGELOG 已同步；CLI help 不適用

## 風險與回復

變更只移除已過時的 advisory lint false positive，不修改 knowledge、ledger、project metadata 或 hashed filesystem placement。回復可 revert 此單一 commit。Production dry-run 掃描 606 張 knowledge，`raw_remote_key=0`、warnings 空。

`policy-exempt:issue-link` 理由：本 PR 僅修正 release gate，#34/#39 必須等三輪 scheduled soak、published artifact 與 final consumer Read 證據齊全後才關閉。