### PR TITLE
fix(policy): redaction openai_key/anthropic_key 加 lookbehind 免誤遮 task-* slug

### DIFF
--- a/changelog.d/57-redaction-openai-key-lookbehind.md
+++ b/changelog.d/57-redaction-openai-key-lookbehind.md
@@ -1,0 +1,2 @@
+### Fixed
+- redaction：`openai_key` / `anthropic_key` 規則 pattern 加前置 negative lookbehind `(?<![A-Za-z0-9])`，避免 `sk-` 出現在字串內部（最常見為 wiki-link slug 的 `ta`sk-`routing`）時整行被誤判 `[REDACTED LINE: openai_key]`，靜默劣化 task-* 記憶的 recall 品質（#57）。真憑證（前接空白/引號/`=`/行首）仍照抓。

--- a/paulsha_hippo/policy/secrets.yaml
+++ b/paulsha_hippo/policy/secrets.yaml
@@ -3,8 +3,8 @@
   "gitleaks": {"enabled": true, "binary": "gitleaks"},
   "rules": [
     {"id": "github_pat", "detector": "regex", "pattern": "(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})", "severity": "high", "description": "GitHub token"},
-    {"id": "openai_key", "detector": "regex", "pattern": "sk-[A-Za-z0-9_-]{16,}", "severity": "high", "description": "OpenAI-like API key"},
-    {"id": "anthropic_key", "detector": "regex", "pattern": "sk-ant-[A-Za-z0-9_-]{16,}", "severity": "high", "description": "Anthropic API key"},
+    {"id": "openai_key", "detector": "regex", "pattern": "(?<![A-Za-z0-9])sk-[A-Za-z0-9_-]{16,}", "severity": "high", "description": "OpenAI-like API key"},
+    {"id": "anthropic_key", "detector": "regex", "pattern": "(?<![A-Za-z0-9])sk-ant-[A-Za-z0-9_-]{16,}", "severity": "high", "description": "Anthropic API key"},
     {"id": "aws_access_key", "detector": "regex", "pattern": "AKIA[0-9A-Z]{16}", "severity": "high", "description": "AWS access key"},
     {"id": "bearer_token", "detector": "regex", "pattern": "(?i)Authorization:\\s*Bearer\\s+\\S+", "severity": "high", "description": "Bearer token"},
     {"id": "jwt", "detector": "regex", "pattern": "eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+", "severity": "high", "description": "JWT"},

--- a/tests/test_stage2_memory_policy.py
+++ b/tests/test_stage2_memory_policy.py
@@ -200,6 +200,31 @@ class RedactionTests(unittest.TestCase):
         self.assertEqual(result.stage, "hook")
         self.assertEqual(result.hits[0].line_no, 2)
 
+    def test_openai_key_rule_does_not_redact_task_slug_substring(self):
+        # #57: `sk-` inside a wiki-link slug (e.g. ta`sk-`routing) must not
+        # trip the openai_key rule and destroy the whole line at recall time.
+        mod = load_policy(self)
+        policy = mod.load_policy(override_path=None)
+        text = (
+            "- [[custom-skills-task-routing-map--sl-abcdef0123456789|routing]]\n"
+            "- [[agents-md-task-routing--sl-fedcba9876543210|AGENTS.md routing]]\n"
+        )
+        result = mod.redact_lines(text, policy=policy, session_ref="s", boundary="external_to_raw")
+        self.assertEqual(result.hit_count, 0)
+        self.assertNotIn("[REDACTED LINE:", result.text)
+        self.assertIn("task-routing-map", result.text)
+
+    def test_openai_key_rule_still_redacts_a_real_key(self):
+        # A genuine key (boundary before `sk-` is `=`, not alphanumeric) must
+        # still be caught after the #57 lookbehind fix.
+        mod = load_policy(self)
+        policy = mod.load_policy(override_path=None)
+        text = "OPENAI_API_KEY=sk-proj-abcdef0123456789ABCDEF\n"
+        result = mod.redact_lines(text, policy=policy, session_ref="s", boundary="external_to_raw")
+        self.assertEqual(result.hit_count, 1)
+        self.assertNotIn("sk-proj-abcdef0123456789ABCDEF", result.text)
+        self.assertIn("[REDACTED LINE:", result.text)
+
     def test_regex_patterns_are_compiled_once_per_rule(self):
         mod = load_policy(self)
         policy = mod.load_policy(override_path=None)


### PR DESCRIPTION
## 摘要

修 `paulsha_hippo/policy/secrets.yaml` 的 `openai_key` / `anthropic_key` redaction 規則過寬問題（Closes #57）。

原 pattern `sk-[A-Za-z0-9_-]{16,}` 對 `sk-` 前無邊界檢查，會匹配任意字串內部的子字串——最常見受害者是 wiki-link slug 裡的 `ta`sk-`routing`（如 `[[custom-skills-task-routing-map--sl-xxxx|...]]`），導致該行在 recall/offer 時整行被替換成 `[REDACTED LINE: openai_key x1]`，靜默劣化所有 task-* 記憶的檢索品質。

實測：以 naive pattern 掃 memory 樹得 204 個「命中」全為 slug 誤報；嚴格 pattern 重掃 0 筆真憑證。

## 修法

兩個 `sk-` 規則加前置 negative lookbehind `(?<![A-Za-z0-9])`：
- `task-routing` 中的 `sk-` 前為字母 → 拒絕
- 真 key（前接空白／引號／`=`／行首）→ 照抓

## 驗證

- [x] 新增測試：`task-routing-map--sl-...` slug 不觸發 `openai_key`（hit_count=0）
- [x] 新增測試：`OPENAI_API_KEY=sk-<32+ alnum>` 仍觸發（hit_count=1、原文被遮蔽）
- [x] 既有 redaction 測試全綠（`Authorization: Bearer sk-...` 不受影響）
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] `changelog.d/` 已有碎片

## 風險與回復

純 pattern 收窄（更保守的匹配），不影響真憑證遮蔽；rollback = revert 本 PR。
