### PR TITLE
feat(memory): 完成消費訊號的檢索與保留回饋

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Janitor 不再把合法的 remote-form rich project ID 誤判為 `raw-remote-key`，避免已採 hashed directory key 的 atom 讓 Dream 永久降為 `partial`。
+- `moc.search.search()` 排序鍵改為 `(adjusted_score, base_score, slice_id)` 三段式穩定鍵；先前僅以單一 `bm25 - 0.1*link_weight` 鍵排序，usage boost 造成同分時退回插入序而非以 `base_score` 決勝，違反 issue #41 v5 排序不變式（BLOCKER #7）。
 
 ## [0.1.1] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@
 
 ### Fixed
 - Janitor 不再把合法的 remote-form rich project ID 誤判為 `raw-remote-key`，避免已採 hashed directory key 的 atom 讓 Dream 永久降為 `partial`。
-- `moc.search.search()` 排序鍵改為 `(adjusted_score, base_score, slice_id)` 三段式穩定鍵；先前僅以單一 `bm25 - 0.1*link_weight` 鍵排序，usage boost 造成同分時退回插入序而非以 `base_score` 決勝，違反 issue #41 v5 排序不變式（BLOCKER #7）。
-- usage ledger（`offered.jsonl`／`memory_usage.jsonl`）解析改為逐行 streaming iterator，不再以 `Path.read_text().splitlines()` 一次載入整檔；I/O、UTF-8、單行 parse 錯誤 fail-soft 且不改寫 ledger；malformed/非 object/缺漏或空白身分/無效或窗口外時間戳改記入固定鍵集合的有界診斷 counter（issue #41 v5 BLOCKER #1–#4）。
+- `moc.search.search()` 有 boost 時使用 `(adjusted_score, base_score, slice_id)` 穩定鍵，無有效 boost（含舊 schema fallback）則維持 legacy base-score one-key stable ordering。
+- usage ledger（`offered.jsonl`／`memory_usage.jsonl`）改為 binary per-line UTF-8 streaming；metadata/open/read、decode 與單行 parse 錯誤 fail-soft 且不改寫 ledger，壞行不再吞掉周邊合法行。offered/read 的未來、窗口外時間與 `(unknown)` tool/session/slice identity 一律排除並記固定鍵 bounded diagnostics。
 
 ### Added
-- `moc.search` 新增 usage-boost 排序：`slice_meta` 增加 `read_count`／`last_read_at`，`search()` 對舊索引以 schema introspection fallback；`usage_boost = min(0.04, 0.01*log2(1+read_count))`，無正 boost 時走 legacy fast path，`base_score` 間距 > `0.04` 不被反轉。
-- janitor retention base 改為 `max(captured_at, active_since_ts, valid last_read_at)`，`ttl_expired` detail 新增 `ttl_base`／`source`；`read` 只延長 active 記錄保留時鐘，不重新啟用已 decayed slice；scanner 新增 usage ledger 診斷警告，僅於 counter > 0 時輸出（issue #41 v5）。
+- `moc.search` 新增可注入 UTC `usage_now`／`usage_window_days` 的 usage-boost index metadata；預設窗口 30 天，`usage_boost = min(0.04, 0.01*log2(1+read_count))`，`base_score` 間距 > `0.04` 不被反轉。
+- janitor retention base 改為 `max(captured_at, active_since_ts, valid last_read_at)`；future read 不得延長 TTL，`superseded`／`source_invalid` 優先序與 read 不 reactivation 維持不變。CLI usage/funnel 以 one-shot raw iterators 折疊 compact per-session/per-slice state，不再保留 ledger-wide raw row lists。
 
 ## [0.1.1] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 ### Fixed
 - Janitor 不再把合法的 remote-form rich project ID 誤判為 `raw-remote-key`，避免已採 hashed directory key 的 atom 讓 Dream 永久降為 `partial`。
 - `moc.search.search()` 排序鍵改為 `(adjusted_score, base_score, slice_id)` 三段式穩定鍵；先前僅以單一 `bm25 - 0.1*link_weight` 鍵排序，usage boost 造成同分時退回插入序而非以 `base_score` 決勝，違反 issue #41 v5 排序不變式（BLOCKER #7）。
+- usage ledger（`offered.jsonl`／`memory_usage.jsonl`）解析改為逐行 streaming iterator，不再以 `Path.read_text().splitlines()` 一次載入整檔；I/O、UTF-8、單行 parse 錯誤 fail-soft 且不改寫 ledger；malformed/非 object/缺漏或空白身分/無效或窗口外時間戳改記入固定鍵集合的有界診斷 counter（issue #41 v5 BLOCKER #1–#4）。
+
+### Added
+- `moc.search` 新增 usage-boost 排序：`slice_meta` 增加 `read_count`／`last_read_at`，`search()` 對舊索引以 schema introspection fallback；`usage_boost = min(0.04, 0.01*log2(1+read_count))`，無正 boost 時走 legacy fast path，`base_score` 間距 > `0.04` 不被反轉。
+- janitor retention base 改為 `max(captured_at, active_since_ts, valid last_read_at)`，`ttl_expired` detail 新增 `ttl_base`／`source`；`read` 只延長 active 記錄保留時鐘，不重新啟用已 decayed slice；scanner 新增 usage ledger 診斷警告，僅於 counter > 0 時輸出（issue #41 v5）。
 
 ## [0.1.1] - 2026-07-22
 

--- a/changelog.d/issue-41-usage-feedback-loop-v5-sonnet.md
+++ b/changelog.d/issue-41-usage-feedback-loop-v5-sonnet.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `moc.search.search()` 排序鍵改為 `(adjusted_score, base_score, slice_id)` 三段式穩定鍵；先前僅以單一 `bm25 - 0.1*link_weight` 鍵排序，usage boost 造成同分時退回插入序而非以 `base_score` 決勝，違反 issue #41 v5 排序不變式（BLOCKER #7）。

--- a/changelog.d/issue-41-usage-feedback-loop-v5-sonnet.md
+++ b/changelog.d/issue-41-usage-feedback-loop-v5-sonnet.md
@@ -1,3 +1,10 @@
 ### Fixed
 
 - `moc.search.search()` 排序鍵改為 `(adjusted_score, base_score, slice_id)` 三段式穩定鍵；先前僅以單一 `bm25 - 0.1*link_weight` 鍵排序，usage boost 造成同分時退回插入序而非以 `base_score` 決勝，違反 issue #41 v5 排序不變式（BLOCKER #7）。
+- usage ledger（`offered.jsonl`／`memory_usage.jsonl`）解析改為逐行 streaming iterator（`paulsha_hippo/ledger/usage.py`），不再以 `Path.read_text().splitlines()` 一次載入整檔；I/O、UTF-8、單行 parse 錯誤 fail-soft 且不改寫 ledger（BLOCKER #1/#4）。
+- malformed JSON、非 object 行、缺漏/空白 `tool`／`session`／`sl_id`、無法解析／未來／窗口外時間戳皆不得 cross-match，改記入固定鍵集合的有界診斷 counter（BLOCKER #2/#3）。
+
+### Added
+
+- `moc.search` 新增 usage-boost 排序：`slice_meta` 增加 `read_count`／`last_read_at` 欄位，`search()` 以 schema introspection 對舊索引 fallback 為 legacy 6 欄查詢；`usage_boost = min(0.04, 0.01*log2(1+read_count))`，無正 boost 時走 legacy fast path，`base_score` 間距超過 `0.04` 時不會被 boost 反轉。
+- janitor retention base 改為 `max(captured_at, active_since_ts, valid last_read_at)`，`ttl_expired` 事件 detail 新增 `ttl_base`／`source`；`read` 只延長已 active 記錄的保留時鐘，不會重新啟用已 decayed 的 slice（`superseded`／`source_invalid` 優先序不變）。scanner 新增 usage ledger 診斷警告，僅在對應 counter > 0 時輸出。

--- a/changelog.d/issue-41-usage-feedback-loop-v5-sonnet.md
+++ b/changelog.d/issue-41-usage-feedback-loop-v5-sonnet.md
@@ -1,10 +1,10 @@
 ### Fixed
 
-- `moc.search.search()` 排序鍵改為 `(adjusted_score, base_score, slice_id)` 三段式穩定鍵；先前僅以單一 `bm25 - 0.1*link_weight` 鍵排序，usage boost 造成同分時退回插入序而非以 `base_score` 決勝，違反 issue #41 v5 排序不變式（BLOCKER #7）。
-- usage ledger（`offered.jsonl`／`memory_usage.jsonl`）解析改為逐行 streaming iterator（`paulsha_hippo/ledger/usage.py`），不再以 `Path.read_text().splitlines()` 一次載入整檔；I/O、UTF-8、單行 parse 錯誤 fail-soft 且不改寫 ledger（BLOCKER #1/#4）。
-- malformed JSON、非 object 行、缺漏/空白 `tool`／`session`／`sl_id`、無法解析／未來／窗口外時間戳皆不得 cross-match，改記入固定鍵集合的有界診斷 counter（BLOCKER #2/#3）。
+- `moc.search.search()` 有 boost 時使用 `(adjusted_score, base_score, slice_id)` 穩定鍵；無有效 boost（含舊 schema fallback）維持 legacy base-score one-key stable ordering。
+- usage ledger 改用 binary per-line UTF-8 streaming；metadata/open/read、decode、parse error fail-soft，壞行不吞合法鄰行，CLI 不保留 ledger-wide raw row lists。
+- offered/read 的 malformed、future/out-of-window 與 `(unknown)` tool/session/sl_id 不得 cross-match，統一記固定鍵 bounded diagnostics。
 
 ### Added
 
-- `moc.search` 新增 usage-boost 排序：`slice_meta` 增加 `read_count`／`last_read_at` 欄位，`search()` 以 schema introspection 對舊索引 fallback 為 legacy 6 欄查詢；`usage_boost = min(0.04, 0.01*log2(1+read_count))`，無正 boost 時走 legacy fast path，`base_score` 間距超過 `0.04` 時不會被 boost 反轉。
-- janitor retention base 改為 `max(captured_at, active_since_ts, valid last_read_at)`，`ttl_expired` 事件 detail 新增 `ttl_base`／`source`；`read` 只延長已 active 記錄的保留時鐘，不會重新啟用已 decayed 的 slice（`superseded`／`source_invalid` 優先序不變）。scanner 新增 usage ledger 診斷警告，僅在對應 counter > 0 時輸出。
+- index build 新增 keyword-only UTC `usage_now`／`usage_window_days` 注入，預設窗口 30 天；usage boost 上限 0.04。
+- janitor retention 使用 valid `last_read_at`，future read 不延長 TTL；`superseded`／`source_invalid` 優先序、read 不 reactivation 與 scanner positive-only warning 維持不變。

--- a/docs/cross-cli-capability-matrix.md
+++ b/docs/cross-cli-capability-matrix.md
@@ -14,6 +14,30 @@
 - applied：`hippo usage mark-applied` 寫入的 `kind:"applied"` 明確是 explicit acknowledgement，不可當作 read/citation proxy（not a read or citation proxy）；有沒有 read 不會改寫已定義的 citation 與 conversion。
 - `--json` 是契約化輸出；`offered/read/applied` 是 runtime state，live counts are runtime state，文檔不得以 live counts 固定（not fixed）為 source contract。
 
+## usage feedback 對 retrieval / janitor 的影響
+
+- `read` 是同一 `(tool, logical session, slice_id)` 在合法 `offered` 之後，
+  由實際 Read tool 產生且落在觀測窗口內的事件；session citation 是由此
+  attribution 派生的 session-level 指標。`applied` 仍只是 agent 的顯式
+  acknowledgement，不是 read，也不是 citation proxy。
+- retrieval index rebuild 預設只聚合最近 30 天的合法 read；operator 或
+  測試可對 build 注入 UTC `usage_now` 與 `usage_window_days`，以相同
+  clock/window 重現同一份 index metadata。
+- ranking 使用
+  `base_score = bm25 - 0.1 * link_weight`、
+  `usage_boost = min(0.04, 0.01 * log2(1 + read_count))`、
+  `adjusted_score = base_score - usage_boost`。boost 上限 0.04，因此不會反轉
+  `base_score` 差距大於 0.04 的結果；沒有有效 read 時沿用 legacy stable
+  ordering。
+- janitor 的 TTL base 是
+  `max(captured_at, active_since_ts, valid last_read_at)`；read 只延長 active
+  slice 的 retention，不會復活 decayed slice，也不能蓋過
+  `superseded` / definite `source_invalid`。future 或窗口外 read 不構成
+  retention evidence。
+- ledger 解析採 binary per-line UTF-8 fail-soft：單一壞行、metadata/open/read
+  I/O 錯誤只增加固定鍵的 bounded diagnostics，其他合法行仍會處理；
+  scanner 只在 counter 大於零時輸出一則彙整 warning。ledger 全程唯讀。
+
 | 能力 | claude-code | codex | copilot-cli |
 |---|---|---|---|
 | session-start 注入 | supported（SessionStart，既有佈署） | inconclusive（文件列 `SessionStart`；headless probe 對照組未 fire） | supported（文件列 `sessionStart`/`SessionStart`；probe FIRED） |

--- a/docs/superpowers/plans/2026-07-27-issue-41-usage-feedback-loop-v5-sonnet.md
+++ b/docs/superpowers/plans/2026-07-27-issue-41-usage-feedback-loop-v5-sonnet.md
@@ -3,7 +3,7 @@ status: accepted
 work_item: issue-41-usage-feedback-loop-v5-sonnet
 supersedes: issue-41-usage-feedback-loop-v4
 base_sha: b4a317f9bfa38708eabbdb31e083dfc3b6e4c044
-model: claude-sonnet-5
+model: codex-native-subagent
 created: 2026-07-27
 ---
 
@@ -12,16 +12,23 @@ created: 2026-07-27
 ## 角色與範圍
 
 - v5 是 `Issue #41` 的 planning authority；完整承接 v4 已接受契約，不增刪產品 scope。
-- 本任務為 planning-only：**除七件 authority 外，不得修改任何其他檔案**；後續 builder 依本 plan 修改 code/test/docs/changelog。
+- 使用者已於 2026-07-27 明確終止 Cortex lifecycle，改由主 Codex agent 以
+  writing-plan → TDD → Codex native subagent → preflight-ci → PR → merge
+  直接收尾；這只取代執行流程，不改產品契約。
 - `base_sha` 固定為 `b4a317f9bfa38708eabbdb31e083dfc3b6e4c044`。
+- direct closeout 基底為 local candidate
+  `6af69a418b334728c0deb50c601857fd1dbed236`，工作分支固定為
+  `feature/41-issue-41-usage-feedback-loop-v5-sonnet`。
 - builder 實作不得改變 `issue #18` 已完成 funnel、`applied` 行為、`hooks` 及 runtime safety。
-- v5 只修正 lifecycle 身分與 builder provider：v4 的 source-owner 競態留下 persisted block；依使用者指示改由 `claude/claude-sonnet-5` 執行 build，Agy 與 Luna gate 不變。
-- 成本護欄：Claude builder 只允許一次初跑與至多一次 repair；第二次仍有未處置 BLOCKER/MAJOR 時停在 `needs_human`，不得自動生成 v6。
+- subagent 寫入邊界只允許本 worktree 內 issue #41 的 code/test/docs/changelog；
+  主 agent 負責 plan、RED 證據、exact-head review、preflight、PR 與 merge。
 
 ## v4 承接＋v5 正式取代欄位
 
 - `Issue #41` 契約完整承接 v4 的 `offered/read/applied` 基礎、usage feedback score 公式（`base/boost`）及全部機械化驗收要求。
-- v5 正式 `supersede` `issue-41-usage-feedback-loop-v4`；變更原因僅為清除 persisted-block 並切換 builder provider，不放寬大檔 streaming、fail-soft、診斷鍵有界、scanner 無零值雜訊與 strict validation。
+- v5 正式 `supersede` `issue-41-usage-feedback-loop-v4`；不放寬大檔
+  streaming、fail-soft、診斷鍵有界、scanner 無零值雜訊與 strict
+  validation。
 
 ## v5 BLOCKER/MAJOR Closure（最多 8 條）
 
@@ -34,22 +41,60 @@ created: 2026-07-27
 7. [MAJOR] ranking 與衰減不變式固定：`usage_boost = min(0.04, 0.01 * log2(1 + read_count))`，無 boost 時走 legacy fast path；有 boost 時 stable key `(adjusted_score, base_score, slice_id)`；`base_gap > 0.04` 不可反轉。
 8. [MAJOR] 實作與審查完成時需證明：focused tests、`pytest --ignore=tests/installed`、installed-fixture wheel gate、`openspec validate --all --strict`、`python3 -m policy_check --repo .`、`git diff --check` 全綠。
 
+## 6af69a4 exact-candidate RED 缺口
+
+以下缺口均已用 candidate 實測或靜態 call-chain 證實，不能以既有綠燈
+suite 抵銷：
+
+1. UTF-8 壞行會令 text buffer 在逐行 yield 前失敗，周邊合法 JSONL 行被
+   一併丟棄；必須改成 binary line read + per-line UTF-8 decode，壞行計入
+   fixed diagnostic 後繼續。
+2. offered event 未檢查 future/out-of-window，過期 offer 仍可與窗口內 read
+   cross-match。
+3. `valid_identity()` 只拒絕 `(unknown)` tool，仍接受 `(unknown)` logical
+   session 與 slice id。
+4. boosted ranking 的第二排序欄位使用 raw BM25，而非權威指定的
+   `base_score = bm25 - 0.1*link_weight`。
+5. `_read_usage_jsonl()`、`_load_usage_rows()` 與 offered timestamp index 仍
+   materialize ledger-wide lists；必須把原始 ledger rows 保持 iterator，僅
+   保留輸出所需的 per-session/per-slice compact aggregates。
+6. index build 使用不可注入的 `datetime.now()`；必須提供 keyword-only
+   `usage_now` / `usage_window_days` 注入點，預設仍採 UTC now，讓 dream/index
+   rebuild 與測試可重現。
+7. `iter_ledger_events()` 在 `try` 外呼叫 `Path.exists()`；filesystem
+   metadata I/O 失敗仍會逸出，違反 ledger 全流程 fail-soft。
+8. 無正 boost 的 fast path 額外加入 raw BM25 / slice id tie-break，改變
+   legacy base-score 同分時的 stable input order。
+9. janitor 直接接受 future `last_read_at` 作為 TTL base，會令過期記憶被
+   無限期保留，違反 malformed/future usage evidence fail-closed。
+
 ## Tasks
 
 以下為 RED→GREEN 交付順序（本卡可直接交 builder）：
 
-1. [RED] 規格階段：確認 v4 七件 authority 與 main 相關程式後，建立內容等價的 v5 七件 authority。
-2. [RED] 以函式入口為核心建 `usage aggregation → search scoring → janitor` 三段 anchor 清單：
+1. [RED] 以函式入口為核心維持 `usage aggregation → search scoring → janitor` 三段 anchor：
    - `paulsha_hippo/cli.py`: `_read_usage_jsonl`, `_load_usage_rows`, `_funnel_read_attribution`, `_usage_mark_applied`
    - `paulsha_hippo/moc/search.py`: `_build_index_locked`, `search`
    - `paulsha_hippo/janitor/scanner.py`: `run_scan`
    - `paulsha_hippo/janitor/rules.py`: `plan_scan`
-3. [RED] 明訂診斷鍵全集（例如 `json_decode_error`、`non_object`、`missing_tool`、`missing_session`、`missing_sl_id`、`invalid_ts`、`future_event`、`window_older`、`window_future`、`read_without_offered`），要求有界、可對帳且不無限擴張。
-4. [RED] 在任務文檔中明確指定測試集合：malformed JSON、missing keys、invalid UTF-8/OSError、large ledger/no-read_text、no-zero-warning、legacy DB fallback、stable ranking、0.04 bound、janitor priority/retention、無 ledger mutation。
-5. [GREEN] builder 必須將「這 7 件 v5 authority」與實作變更放在同一個 commit。
-6. [GREEN] Agy reviewer 必須先完整閱讀此 frozen plan 與七件 authority，然後再核對實作與測試結果。
-7. [GREEN] 實作階段：Claude Sonnet 5 builder 以最小 patch 實現 v5 requirements；保留 v4 已接受結果，不重複變更非目標模組。
-8. [GREEN] `changelog.d` 與 `CHANGELOG.md [Unreleased]` 補齊；`VERSION` 僅在 release label 下調整。
+2. [RED] 新增會在 `6af69a4` 失敗的 focused regressions：
+   - UTF-8 壞行前後合法行都必須 yield；
+   - future/out-of-window offer 不得歸因且 counter 可對帳；
+   - `(unknown)` tool/session/sl_id 全部拒絕；
+   - ledger loader 回傳 iterator 而非 row list；
+   - boosted exact tie 以 `(adjusted_score, base_score, slice_id)` 決勝；
+   - injected `usage_now/window_days` 精確傳到 aggregation；
+   - filesystem metadata I/O fail-soft、no-boost legacy stable order、future
+     janitor evidence fail-closed。
+3. [GREEN] Codex subagent 只修 RED 所證 call chain，保留 #18 funnel 輸出、
+   hook/argv safety、temp DB/flock/atomic replace 與 legacy DB fallback。
+4. [GREEN] 更新 operator docs、`changelog.d`、`CHANGELOG.md [Unreleased]`；
+   `VERSION` 不變。
+5. [VERIFY] 先 focused tests，再一次完整
+   `pytest --ignore=tests/installed`；另跑 built-wheel installed fixture、
+   OpenSpec strict、policy、diff check 與 preflight-ci。
+6. [DELIVER] PR 使用 zh-TW conventional title/body，body 包含 `Closes #41`；
+   current-head checks、review threads 與 mergeability 全部通過後才 merge。
 
 ## v5 預期輸出
 
@@ -57,3 +102,5 @@ created: 2026-07-27
 - `openspec validate --all --strict` 必過
 - `pytest --ignore=tests/installed` 必過；在已建置 candidate wheel 的正確環境補跑 installed-fixture
 - `python3 -m policy_check --repo .` 與 `git diff --check` 必過
+- PR-aware preflight-ci 必過，PR 以 merge commit 落到 `main` 並由
+  `Closes #41` 關閉 issue。

--- a/docs/superpowers/plans/2026-07-27-issue-41-usage-feedback-loop-v5-sonnet.md
+++ b/docs/superpowers/plans/2026-07-27-issue-41-usage-feedback-loop-v5-sonnet.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+work_item: issue-41-usage-feedback-loop-v5-sonnet
+supersedes: issue-41-usage-feedback-loop-v4
+base_sha: b4a317f9bfa38708eabbdb31e083dfc3b6e4c044
+model: claude-sonnet-5
+created: 2026-07-27
+---
+
+# Issue #41 usage feedback loop v5 計畫
+
+## 角色與範圍
+
+- v5 是 `Issue #41` 的 planning authority；完整承接 v4 已接受契約，不增刪產品 scope。
+- 本任務為 planning-only：**除七件 authority 外，不得修改任何其他檔案**；後續 builder 依本 plan 修改 code/test/docs/changelog。
+- `base_sha` 固定為 `b4a317f9bfa38708eabbdb31e083dfc3b6e4c044`。
+- builder 實作不得改變 `issue #18` 已完成 funnel、`applied` 行為、`hooks` 及 runtime safety。
+- v5 只修正 lifecycle 身分與 builder provider：v4 的 source-owner 競態留下 persisted block；依使用者指示改由 `claude/claude-sonnet-5` 執行 build，Agy 與 Luna gate 不變。
+- 成本護欄：Claude builder 只允許一次初跑與至多一次 repair；第二次仍有未處置 BLOCKER/MAJOR 時停在 `needs_human`，不得自動生成 v6。
+
+## v4 承接＋v5 正式取代欄位
+
+- `Issue #41` 契約完整承接 v4 的 `offered/read/applied` 基礎、usage feedback score 公式（`base/boost`）及全部機械化驗收要求。
+- v5 正式 `supersede` `issue-41-usage-feedback-loop-v4`；變更原因僅為清除 persisted-block 並切換 builder provider，不放寬大檔 streaming、fail-soft、診斷鍵有界、scanner 無零值雜訊與 strict validation。
+
+## v5 BLOCKER/MAJOR Closure（最多 8 條）
+
+1. [BLOCKER] JSONL 來源讀取必須是逐行 iterator；禁止 `Path.read_text().splitlines()`，禁止將任一 ledger 全量載入 list。必須加入「`Path.read_text` 被 monkeypatch 成失敗」與「超大 ledger」二種回歸測試，驗證 bounded-memory 與逐行處理。
+2. [BLOCKER] `malformed JSON`、`non-object`、缺少或空白 `tool/session/sl_id`、`invalid timestamp`、`future`、`out-of-window` 不得 cross-match；每種失敗必須更新固定 key 的 bounded counter，counter 集合有界，禁止無限 key。
+3. [BLOCKER] offered/read 同時驗證時序與身份：`offered` 須先行，`read` 必須落在 `window` 內；`(unknown)` 或空字串不得形成可比對 identity，不能用作配對 key。
+4. [BLOCKER] I/O、UTF-8、單行 parse error 必須 fail-soft；不得中止 index rebuild、search、janitor；ledger 不得被改寫。
+5. [BLOCKER] scanner/janitor 警示只在 counter > 0 時輸出，禁止每次 scan 都輸出零值 noise。
+6. [MAJOR] module docstring 必須保持 `__doc__` 真實欄位，不能因無關格式修正造成噪音 churn；changelog 文字需修正為準確實作語意。
+7. [MAJOR] ranking 與衰減不變式固定：`usage_boost = min(0.04, 0.01 * log2(1 + read_count))`，無 boost 時走 legacy fast path；有 boost 時 stable key `(adjusted_score, base_score, slice_id)`；`base_gap > 0.04` 不可反轉。
+8. [MAJOR] 實作與審查完成時需證明：focused tests、`pytest --ignore=tests/installed`、installed-fixture wheel gate、`openspec validate --all --strict`、`python3 -m policy_check --repo .`、`git diff --check` 全綠。
+
+## Tasks
+
+以下為 RED→GREEN 交付順序（本卡可直接交 builder）：
+
+1. [RED] 規格階段：確認 v4 七件 authority 與 main 相關程式後，建立內容等價的 v5 七件 authority。
+2. [RED] 以函式入口為核心建 `usage aggregation → search scoring → janitor` 三段 anchor 清單：
+   - `paulsha_hippo/cli.py`: `_read_usage_jsonl`, `_load_usage_rows`, `_funnel_read_attribution`, `_usage_mark_applied`
+   - `paulsha_hippo/moc/search.py`: `_build_index_locked`, `search`
+   - `paulsha_hippo/janitor/scanner.py`: `run_scan`
+   - `paulsha_hippo/janitor/rules.py`: `plan_scan`
+3. [RED] 明訂診斷鍵全集（例如 `json_decode_error`、`non_object`、`missing_tool`、`missing_session`、`missing_sl_id`、`invalid_ts`、`future_event`、`window_older`、`window_future`、`read_without_offered`），要求有界、可對帳且不無限擴張。
+4. [RED] 在任務文檔中明確指定測試集合：malformed JSON、missing keys、invalid UTF-8/OSError、large ledger/no-read_text、no-zero-warning、legacy DB fallback、stable ranking、0.04 bound、janitor priority/retention、無 ledger mutation。
+5. [GREEN] builder 必須將「這 7 件 v5 authority」與實作變更放在同一個 commit。
+6. [GREEN] Agy reviewer 必須先完整閱讀此 frozen plan 與七件 authority，然後再核對實作與測試結果。
+7. [GREEN] 實作階段：Claude Sonnet 5 builder 以最小 patch 實現 v5 requirements；保留 v4 已接受結果，不重複變更非目標模組。
+8. [GREEN] `changelog.d` 與 `CHANGELOG.md [Unreleased]` 補齊；`VERSION` 僅在 release label 下調整。
+
+## v5 預期輸出
+
+- `openspec validate issue-41-usage-feedback-loop-v5-sonnet --strict` 必過（active change）
+- `openspec validate --all --strict` 必過
+- `pytest --ignore=tests/installed` 必過；在已建置 candidate wheel 的正確環境補跑 installed-fixture
+- `python3 -m policy_check --repo .` 與 `git diff --check` 必過

--- a/docs/superpowers/workstreams/issue-41-usage-feedback-loop-v5-sonnet/todo.md
+++ b/docs/superpowers/workstreams/issue-41-usage-feedback-loop-v5-sonnet/todo.md
@@ -1,0 +1,62 @@
+---
+status: accepted
+work_item: issue-41-usage-feedback-loop-v5-sonnet
+---
+
+# Issue #41 usage feedback loop v5 / todo
+
+## Tasks
+
+本清單是 v5 的 accepted execution plan。
+
+## 權威檔目標（7 件，僅新增）
+
+- `docs/superpowers/plans/2026-07-27-issue-41-usage-feedback-loop-v5-sonnet.md`
+- `docs/superpowers/workstreams/issue-41-usage-feedback-loop-v5-sonnet/todo.md`
+- `openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/.openspec.yaml`
+- `openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/proposal.md`
+- `openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/design.md`
+- `openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md`
+- `openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/specs/stage2-memory-usage-feedback/spec.md`
+
+## 執行前置
+
+- [x] 已鎖定 builder：`claude/claude-sonnet-5`（effort high；一次初跑＋至多一次 repair）。
+- [x] 已核定 `base_sha=b4a317f9bfa38708eabbdb31e083dfc3b6e4c044`。
+- [x] v5 完整承接 v4 七份 authority；切換 provider 不改產品 scope。
+- [x] planning 階段只允許此 7 件 authority；實作與程式變更後續再提交。
+
+## 目前狀態
+
+- [x] planning authority 7 件建立。
+- [ ] 實作（code）未開始。
+- [ ] focused tests 未開始。
+- [ ] full tests 未開始。
+- [ ] policy/diff gates 未開始。
+- [ ] 實作層審核未開始。
+
+## 共識邊界
+
+- 保留已接受 v4 契約：
+  - 來源 `runtime/ledger/offered.jsonl` 與 `runtime/ledger/memory_usage.jsonl`
+  - 僅 `(tool, logical session, slice_id)` 的 prior offer 後 `source=read`、非 applied、窗口內事件可計 read
+  - unoffered/direct、cited/matched、malformed/future 不可計入
+  - 以 `read_count`、`last_read_at` 聚合；`ttl = max(captured_at, active_since_ts, valid last_read_at)`
+- v5 新增機械化門檻：
+  - streaming iterator、bounded diagnostics、identity 空值保護、scanner no-zero-warning、`CHANGELOG` 文案修正、`read` 不 reactivation。
+
+## 需求缺口（只列 BLOCKER/MAJOR）
+
+- [ ] BLOCKER：I/O/UTF-8/single-line parse fail-soft 全流程
+- [ ] BLOCKER：malformed/non-object/missing key/timestamp/window 規則與 fixed counter
+- [ ] BLOCKER：`Path.read_text` 失敗與大檔 streaming regression
+- [ ] MAJOR：module docstring/格式最小 churn
+- [ ] MAJOR：legacy DB fallback、ranking stable、janitor priority retention detail
+- [ ] MAJOR：scanner zero-warning gate（counter==0 不輸出）
+
+## 審查與交付條件（v5）
+
+- Builder 必須在同一 commit 中提交這 7 件 authority 與實作變更，並讓 reviewer 可直接 checkout 閱讀。
+- Agy reviewer 必須先讀這套 frozen plan（7 件 authority）後，再做 code/spec/janitor/funnel 驗收。
+- Agy BLOCKER/MAJOR 只列最多 8 條；未處置缺口 FAIL；有界殘餘風險不獨立 FAIL。
+- Claude 第二次 build/repair 後仍未通過即停在 `needs_human`；不得自動建立 v6。

--- a/docs/superpowers/workstreams/issue-41-usage-feedback-loop-v5-sonnet/todo.md
+++ b/docs/superpowers/workstreams/issue-41-usage-feedback-loop-v5-sonnet/todo.md
@@ -32,10 +32,11 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 
 - [x] planning authority 7 件建立。
 - [x] initial candidate `6af69a4` 已建立，但 exact-candidate audit 判定未完成。
-- [x] direct RED regressions 完成：focused run 為 `14 failed, 72 passed,
+- [x] direct RED regressions 完成：focused run 為 `14 failed, 79 passed,
   1 subtests passed`，並確認均在 `6af69a4` call chain 失敗。
-- [ ] Codex subagent GREEN implementation 完成。
-- [ ] focused / full / installed-wheel tests 通過。
+- [x] Codex subagent bounded GREEN implementation 完成。
+- [x] focused tests：`91 passed, 3 subtests passed`。
+- [ ] full / installed-wheel tests 通過。
 - [ ] OpenSpec / policy / diff / preflight-ci gates 通過。
 - [ ] PR current-head review/checks 通過並 merge。
 
@@ -51,20 +52,20 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 
 ## 需求缺口（只列 BLOCKER/MAJOR）
 
-- [ ] BLOCKER：I/O/UTF-8/single-line parse fail-soft 全流程
-- [ ] BLOCKER：malformed/non-object/missing key/timestamp/window 規則與 fixed counter
-- [ ] BLOCKER：`Path.read_text` 失敗與大檔 streaming regression
-- [ ] BLOCKER：不得保留 ledger-wide row lists；只允許 iterator +
+- [x] BLOCKER：I/O/UTF-8/single-line parse fail-soft 全流程
+- [x] BLOCKER：malformed/non-object/missing key/timestamp/window 規則與 fixed counter
+- [x] BLOCKER：`Path.read_text` 失敗與大檔 streaming regression
+- [x] BLOCKER：不得保留 ledger-wide row lists；只允許 iterator +
   compact aggregate state
-- [ ] BLOCKER：future/out-of-window offer 與 `(unknown)` session/sl_id
+- [x] BLOCKER：future/out-of-window offer 與 `(unknown)` session/sl_id
   不得 cross-match
-- [ ] MAJOR：module docstring/格式最小 churn
-- [ ] MAJOR：boosted stable key 第二欄必須是 `base_score`
-- [ ] MAJOR：index build 必須可注入 `usage_now/window_days`
-- [ ] MAJOR：no-boost fast path 維持 legacy base-score stable order
-- [ ] MAJOR：future `last_read_at` 不得延長 janitor TTL
-- [ ] MAJOR：legacy DB fallback、janitor priority retention detail
-- [ ] MAJOR：scanner zero-warning gate（counter==0 不輸出）
+- [x] MAJOR：module docstring/格式最小 churn
+- [x] MAJOR：boosted stable key 第二欄必須是 `base_score`
+- [x] MAJOR：index build 必須可注入 `usage_now/window_days`
+- [x] MAJOR：no-boost fast path 維持 legacy base-score stable order
+- [x] MAJOR：future `last_read_at` 不得延長 janitor TTL
+- [x] MAJOR：legacy DB fallback、janitor priority retention detail
+- [x] MAJOR：scanner zero-warning gate（counter==0 不輸出）
 
 ## 審查與交付條件（v5 direct）
 

--- a/docs/superpowers/workstreams/issue-41-usage-feedback-loop-v5-sonnet/todo.md
+++ b/docs/superpowers/workstreams/issue-41-usage-feedback-loop-v5-sonnet/todo.md
@@ -36,8 +36,10 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
   1 subtests passed`，並確認均在 `6af69a4` call chain 失敗。
 - [x] Codex subagent bounded GREEN implementation 完成。
 - [x] focused tests：`91 passed, 3 subtests passed`。
-- [ ] full / installed-wheel tests 通過。
-- [ ] OpenSpec / policy / diff / preflight-ci gates 通過。
+- [x] canonical preflight 完整 `tests/`（含 clean-wheel installed fixture）
+  通過，tests gate `104.80s`。
+- [x] OpenSpec strict / policy / diff / local preflight-ci 全部通過；
+  engine exact pin `hamanpaul/paulsha-conventions@451c268`（v1.0.14）。
 - [ ] PR current-head review/checks 通過並 merge。
 
 ## 共識邊界

--- a/docs/superpowers/workstreams/issue-41-usage-feedback-loop-v5-sonnet/todo.md
+++ b/docs/superpowers/workstreams/issue-41-usage-feedback-loop-v5-sonnet/todo.md
@@ -7,7 +7,7 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 
 ## Tasks
 
-本清單是 v5 的 accepted execution plan。
+本清單是 v5 的 accepted direct execution plan。
 
 ## 權威檔目標（7 件，僅新增）
 
@@ -21,19 +21,23 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 
 ## 執行前置
 
-- [x] 已鎖定 builder：`claude/claude-sonnet-5`（effort high；一次初跑＋至多一次 repair）。
+- [x] 使用者已終止 Cortex lifecycle，改由主 Codex agent +
+  Codex native subagent direct closeout。
 - [x] 已核定 `base_sha=b4a317f9bfa38708eabbdb31e083dfc3b6e4c044`。
 - [x] v5 完整承接 v4 七份 authority；切換 provider 不改產品 scope。
-- [x] planning 階段只允許此 7 件 authority；實作與程式變更後續再提交。
+- [x] worktree / branch 寫入邊界固定為
+  `feature/41-issue-41-usage-feedback-loop-v5-sonnet`。
 
 ## 目前狀態
 
 - [x] planning authority 7 件建立。
-- [ ] 實作（code）未開始。
-- [ ] focused tests 未開始。
-- [ ] full tests 未開始。
-- [ ] policy/diff gates 未開始。
-- [ ] 實作層審核未開始。
+- [x] initial candidate `6af69a4` 已建立，但 exact-candidate audit 判定未完成。
+- [x] direct RED regressions 完成：focused run 為 `14 failed, 72 passed,
+  1 subtests passed`，並確認均在 `6af69a4` call chain 失敗。
+- [ ] Codex subagent GREEN implementation 完成。
+- [ ] focused / full / installed-wheel tests 通過。
+- [ ] OpenSpec / policy / diff / preflight-ci gates 通過。
+- [ ] PR current-head review/checks 通過並 merge。
 
 ## 共識邊界
 
@@ -50,13 +54,23 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 - [ ] BLOCKER：I/O/UTF-8/single-line parse fail-soft 全流程
 - [ ] BLOCKER：malformed/non-object/missing key/timestamp/window 規則與 fixed counter
 - [ ] BLOCKER：`Path.read_text` 失敗與大檔 streaming regression
+- [ ] BLOCKER：不得保留 ledger-wide row lists；只允許 iterator +
+  compact aggregate state
+- [ ] BLOCKER：future/out-of-window offer 與 `(unknown)` session/sl_id
+  不得 cross-match
 - [ ] MAJOR：module docstring/格式最小 churn
-- [ ] MAJOR：legacy DB fallback、ranking stable、janitor priority retention detail
+- [ ] MAJOR：boosted stable key 第二欄必須是 `base_score`
+- [ ] MAJOR：index build 必須可注入 `usage_now/window_days`
+- [ ] MAJOR：no-boost fast path 維持 legacy base-score stable order
+- [ ] MAJOR：future `last_read_at` 不得延長 janitor TTL
+- [ ] MAJOR：legacy DB fallback、janitor priority retention detail
 - [ ] MAJOR：scanner zero-warning gate（counter==0 不輸出）
 
-## 審查與交付條件（v5）
+## 審查與交付條件（v5 direct）
 
-- Builder 必須在同一 commit 中提交這 7 件 authority 與實作變更，並讓 reviewer 可直接 checkout 閱讀。
-- Agy reviewer 必須先讀這套 frozen plan（7 件 authority）後，再做 code/spec/janitor/funnel 驗收。
-- Agy BLOCKER/MAJOR 只列最多 8 條；未處置缺口 FAIL；有界殘餘風險不獨立 FAIL。
-- Claude 第二次 build/repair 後仍未通過即停在 `needs_human`；不得自動建立 v6。
+- subagent 只寫 issue #41 worktree；主 agent 獨立逐條驗證 authority 與 RED。
+- 未處置 BLOCKER/MAJOR 不得開 PR；既有 suite 綠燈不能取代缺口測試。
+- local preflight-ci、GitHub current-head checks、review threads 與 mergeability
+  全綠後才 merge。
+- PR body 必須以 `Closes #41` 建立原生 closure link；merge 後驗證 issue
+  closed 與 main merge ancestry。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/.openspec.yaml
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/.openspec.yaml
@@ -1,0 +1,10 @@
+status: accepted
+work_item: issue-41-usage-feedback-loop-v5-sonnet
+schema: spec-driven
+created: 2026-07-27
+supersedes: issue-41-usage-feedback-loop-v4
+lifecycle_base: b4a317f9bfa38708eabbdb31e083dfc3b6e4c044
+# Active pre-archive change: issue-41 v5 feedback loop authority
+# OpenSpec strict validation 必須識別 issue-41-usage-feedback-loop-v5-sonnet 為 active change。
+# Builder 需將 7 件 authority 與實作同 commit；Agy reviewer 需先讀取 frozen plan/authority。
+# v5 僅清除 v4 persisted-block 並改用 claude/claude-sonnet-5 builder；產品契約不變。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/design.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/design.md
@@ -1,0 +1,82 @@
+---
+status: accepted
+work_item: issue-41-usage-feedback-loop-v5-sonnet
+---
+
+# Issue #41 usage feedback loop v5 設計
+
+## Decisions
+
+以下決策為 v5 的 accepted design authority。
+
+## 1) 流程與 Function anchors
+
+- 讀取來源：`runtime/ledger/offered.jsonl`、`runtime/ledger/memory_usage.jsonl`。
+- `usage aggregation` 與 `usage funnel` 錨點：
+  - `paulsha_hippo/cli.py::_read_usage_jsonl`
+  - `paulsha_hippo/cli.py::_load_usage_rows`
+  - `paulsha_hippo/cli.py::_funnel_read_attribution`
+  - `paulsha_hippo/cli.py::_usage_mark_applied`
+- ranking 錨點：
+  - `paulsha_hippo/moc/search.py::_build_index_locked`
+  - `paulsha_hippo/moc/search.py::search`
+- janitor 錨點：
+  - `paulsha_hippo/janitor/scanner.py::run_scan`
+  - `paulsha_hippo/janitor/rules.py::plan_scan`
+
+## 2) v5 不能變更但可修正的行為
+
+- 保留 `#18` usage funnel 行為。
+- 保留 `applied` 與 `read` 分離。
+- 保留 hook/argv/runtime safety。
+- 保留既有 DB 發佈流程（flock、temp db、`os.replace`）與 no-in-place migration。
+
+## 3) v5 聚合規則（逐行 + bounded diagnostics）
+
+- `_read_usage_jsonl` 必須改為 line iterator，逐行 parse。
+- `offered`、`source=read` 及 `kind != applied` 先行過濾，但每條仍需檢查 identity 與時間窗。
+- offered/read 配對條件同時要求：
+  - `tool` 非空且非 `(unknown)`
+  - `logical session` 非空
+  - `sl_id` 非空
+  - offered timestamp 先於 read
+  - 時間窗合法
+- 任一條件失敗則不 cross-match，並累加對應 fixed key counter。
+- 所有錯誤（IO、decode、parse）都採 fail-soft，不阻斷後續處理。
+
+## 4) Ranking 設計（含 0.04 bound）
+
+- `base_score = bm25 - 0.1 * link_weight`
+- `usage_boost = min(0.04, 0.01 * log2(1 + read_count))`
+- `adjusted_score = base_score - usage_boost`
+- 全部 `usage_boost == 0` 時使用既有 legacy 路徑（速度與 ordering 相容）。
+- 有 boost 時以 `(adjusted_score, base_score, slice_id)` 排序，且原始 base 相差 > 0.04 禁反轉。
+
+## 5) Index / DB 相容
+
+- 新 temp DB `slice_meta` 增加 `read_count INTEGER NOT NULL DEFAULT 0`、`last_read_at TEXT NULL`。
+- 讀舊 DB 時以 schema introspection fallback。
+- 任何 schema 缺欄位不做 in-place migration。
+
+## 6) Janitor 保持可觀測性
+
+- `run_scan` 將 stats 傳遞給 `plan_scan`；`plan_scan` 以 `superseded`、`source_invalid`、`ttl` 優先級；`ttl_base` 與 `source` 寫入 decision detail。
+- `read` 不得讓 decayed/superseded/source-invalid slice 重新 active。
+- 當 `read_count == 0` 不得產生負向 decay。
+- scan 警示僅輸出在 counter > 0。
+
+## 7) 變更可測邏輯（交付給 builder）
+
+- malformed JSON / non-object / missing key / window invalid 的固定 counter 與行為。
+- 大 ledger + `Path.read_text` monkeypatch 回歸。
+- no-zero warning。
+- legacy DB fallback。
+- stable ranking 與 0.04 bound。
+- janitor priority/retention。
+- 不改寫 ledger。
+
+## 8) 交付後治理
+
+- OpenSpec strict validation 以 `issue-41-usage-feedback-loop-v5-sonnet` 作為 active change。
+- builder 實作與這 7 件 authority 必須放在同一 commit；reviewer checkout 需可直接閱讀 frozen plan + 7 件權威文件。
+- Agy reviewer 只接受先閱讀本 plan 及其 7 件權威文件後的 review 結論；無法處置缺口視為 FAIL。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/design.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/design.md
@@ -34,6 +34,8 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 ## 3) v5 聚合規則（逐行 + bounded diagnostics）
 
 - `_read_usage_jsonl` 必須改為 line iterator，逐行 parse。
+- `_load_usage_rows` 只回傳 raw offered / usage iterators 與 bounded
+  diagnostics；不得回傳 ledger-wide offered/read/applied row lists。
 - `offered`、`source=read` 及 `kind != applied` 先行過濾，但每條仍需檢查 identity 與時間窗。
 - offered/read 配對條件同時要求：
   - `tool` 非空且非 `(unknown)`
@@ -42,14 +44,20 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
   - offered timestamp 先於 read
   - 時間窗合法
 - 任一條件失敗則不 cross-match，並累加對應 fixed key counter。
-- 所有錯誤（IO、decode、parse）都採 fail-soft，不阻斷後續處理。
+- 所有錯誤（IO、decode、parse）都採 fail-soft，不阻斷後續處理；UTF-8
+  以 binary line read 後逐行 decode，壞行前後的合法行仍須處理。
+- path existence/stat 等 metadata I/O 也在 fail-soft 邊界內，不得於
+  opening ledger 前逸出。
+- offered index 每個 identity 只保留判斷 prior offer 所需的單一 timestamp，
+  禁止 per-event timestamp list。
 
 ## 4) Ranking 設計（含 0.04 bound）
 
 - `base_score = bm25 - 0.1 * link_weight`
 - `usage_boost = min(0.04, 0.01 * log2(1 + read_count))`
 - `adjusted_score = base_score - usage_boost`
-- 全部 `usage_boost == 0` 時使用既有 legacy 路徑（速度與 ordering 相容）。
+- 全部 `usage_boost == 0` 時使用既有 legacy base-score one-key stable
+  路徑，不新增 raw BM25 / slice id tie-break（速度與 ordering 相容）。
 - 有 boost 時以 `(adjusted_score, base_score, slice_id)` 排序，且原始 base 相差 > 0.04 禁反轉。
 
 ## 5) Index / DB 相容
@@ -57,11 +65,14 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 - 新 temp DB `slice_meta` 增加 `read_count INTEGER NOT NULL DEFAULT 0`、`last_read_at TEXT NULL`。
 - 讀舊 DB 時以 schema introspection fallback。
 - 任何 schema 缺欄位不做 in-place migration。
+- `build_index(..., *, usage_now=None, usage_window_days=30)` 將可重現時間
+  基準傳入 usage aggregation；`None` 才解析為目前 UTC。
 
 ## 6) Janitor 保持可觀測性
 
 - `run_scan` 將 stats 傳遞給 `plan_scan`；`plan_scan` 以 `superseded`、`source_invalid`、`ttl` 優先級；`ttl_base` 與 `source` 寫入 decision detail。
 - `read` 不得讓 decayed/superseded/source-invalid slice 重新 active。
+- `last_read_at > now` 視為無效 usage evidence，不得延長 TTL。
 - 當 `read_count == 0` 不得產生負向 decay。
 - scan 警示僅輸出在 counter > 0。
 
@@ -72,11 +83,14 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 - no-zero warning。
 - legacy DB fallback。
 - stable ranking 與 0.04 bound。
-- janitor priority/retention。
+- raw ledger loader 的 iterator contract 與 injected time/window。
+- janitor priority/retention 與 future evidence fail-closed。
 - 不改寫 ledger。
 
 ## 8) 交付後治理
 
 - OpenSpec strict validation 以 `issue-41-usage-feedback-loop-v5-sonnet` 作為 active change。
-- builder 實作與這 7 件 authority 必須放在同一 commit；reviewer checkout 需可直接閱讀 frozen plan + 7 件權威文件。
-- Agy reviewer 只接受先閱讀本 plan 及其 7 件權威文件後的 review 結論；無法處置缺口視為 FAIL。
+- exact candidate head 必須包含 authority、RED regressions 與實作；
+  reviewer checkout 需可直接閱讀 frozen plan 與權威文件。
+- current-head reviewer 必須先閱讀 frozen plan 與權威文件；無法處置缺口
+  視為 FAIL。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/proposal.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/proposal.md
@@ -7,8 +7,9 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 
 ## 目的
 
-- 建立 v5 planning authority，完整繼承 v4 已接受功能契約與機械化邊界；只清除 persisted-block 並切換 builder provider。
-- 指定 builder：`claude/claude-sonnet-5`（effort high；一次初跑＋至多一次 repair）。
+- 建立 v5 planning authority，完整繼承 v4 已接受功能契約與機械化邊界。
+- 2026-07-27 使用者明確終止 Cortex lifecycle，改由主 Codex agent 以
+  Codex native subagent、TDD、preflight-ci 與 PR direct closeout。
 
 ## supersede 與邊界
 
@@ -42,7 +43,13 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 - fail-soft：I/O、UTF-8、單行 parse 錯誤不應 abort rebuild/search/janitor。
 - scanner 輸出：僅 counter >0 產 warning。
 - module docstring：維持真實 `__doc__`，避免無關 formatting churn。
-- 測試必測：malformed JSON、missing keys、invalid UTF-8/OSError、large ledger/no-read_text、no-zero-warning、legacy DB fallback、stable ranking、0.04 bound、janitor priority/retention、無 ledger mutation。
+- 測試必測：malformed JSON、missing keys、invalid UTF-8/OSError（含
+  filesystem metadata I/O）、large ledger/no-read_text、no-zero-warning、
+  legacy DB fallback 與 stable no-boost order、stable boosted ranking、0.04
+  bound、future janitor evidence fail-closed、janitor priority/retention、
+  無 ledger mutation。
+- 重建時間基準：index build 必須接受 keyword-only 的 UTC `usage_now` /
+  `usage_window_days` 注入，預設行為仍使用目前 UTC 時間。
 
 ## 驗證門檻
 
@@ -53,12 +60,13 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 - `openspec validate --all --strict`
 - `python3 -m policy_check --repo .`
 - `git diff --check`
-- builder 實作與七件 authority 必須同一 commit。
+- exact candidate 必須包含七件 authority、RED tests 與實作。
 
 ## 審查鏈
 
-- builder 後置 `agy/gemini-3.6-flash-high`（verification / code-review / adversarial）
-- final exact candidate 由 `codex/gpt-5.6-luna(max)`（`model_reasoning_effort=max`）PASS
-- Agy reviewer 必須先閱讀 frozen plan/todo/spec/design/tasks 與七件 authority（plan-only artifacts），再對照驗收結果。
-- Agy 判準：未處置缺陷/缺口 FAIL；承認且有界列管殘餘風險不獨立 FAIL。
-- 第二次 Claude build/repair 後仍有未處置 BLOCKER/MAJOR 即停在 `needs_human`，不得自動生成 v6。
+- Codex native subagent 依 RED 實作，主 agent 逐條獨立驗證 frozen
+  plan/todo/spec/design/tasks。
+- 未處置缺陷/缺口 FAIL；不得以既有 suite 綠燈、過期 reviewer 報告或
+  Cortex 狀態代替 exact-head evidence。
+- preflight-ci、PR current-head checks、review threads 與 mergeability
+  全綠後才 merge。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/proposal.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/proposal.md
@@ -1,0 +1,64 @@
+---
+status: accepted
+work_item: issue-41-usage-feedback-loop-v5-sonnet
+---
+
+# Issue #41 usage feedback loop 計畫提案
+
+## 目的
+
+- 建立 v5 planning authority，完整繼承 v4 已接受功能契約與機械化邊界；只清除 persisted-block 並切換 builder provider。
+- 指定 builder：`claude/claude-sonnet-5`（effort high；一次初跑＋至多一次 repair）。
+
+## supersede 與邊界
+
+- v5 明確 supersede `issue-41-usage-feedback-loop-v4`，後續實作必以 v5 為 active change。
+- `base reference`：`b4a317f9bfa38708eabbdb31e083dfc3b6e4c044`
+- 不允許改變 `issue #18` 的 read funnel、`applied` 分離、hook/ARGV/runtime safety。
+
+## Requirements
+
+以下核心要求完整保留：
+
+1. `runtime/ledger/offered.jsonl` 與 `runtime/ledger/memory_usage.jsonl` 作為唯一來源。
+2. 僅計入符合條件的 read：
+   - 相同 `(tool, logical_session, slice_id)` 有 prior offer
+   - `source = read`
+   - 非 `applied`
+   - `now - window <= ts <= now`
+3. `read_count` / `last_read_at` 為 per-slice 統計，changelog 外不變更輸出欄位。
+4. `base_score = bm25 - 0.1*link_weight`
+5. `usage_boost = min(0.04, 0.01*log2(1 + read_count))`
+6. `adjusted_score = base_score - usage_boost`
+7. `read` 無正 boost 時走 legacy fast path；有 boost 時 stable key `(adjusted_score, base_score, slice_id)`；`base_score` 間隔超過 `0.04` 不 reverse。
+8. 新 temp DB `slice_meta` 加 `read_count` / `last_read_at`，舊 DB 以 schema introspection fallback。
+9. janitor retention base = `max(captured_at, active_since_ts, valid last_read_at)`，`superseded/source_invalid` 仍優先於 `ttl`，`read` 不可 re-activate。
+
+## v5 新增 BLOCKER/MAJOR 閉環
+
+- STREAMING：不得使用 `Path.read_text().splitlines()` 或一次讀入 list 的 ledger 解析。
+- 資料品質：`malformed JSON`、`non-object`、缺少/空白 `tool/session/sl_id`、`invalid/future/out-of-window` 直接排除。
+- 有界診斷：每個無法 cross-match 理由都記 fixed key counter；鍵集合有界。
+- fail-soft：I/O、UTF-8、單行 parse 錯誤不應 abort rebuild/search/janitor。
+- scanner 輸出：僅 counter >0 產 warning。
+- module docstring：維持真實 `__doc__`，避免無關 formatting churn。
+- 測試必測：malformed JSON、missing keys、invalid UTF-8/OSError、large ledger/no-read_text、no-zero-warning、legacy DB fallback、stable ranking、0.04 bound、janitor priority/retention、無 ledger mutation。
+
+## 驗證門檻
+
+- focused tests（由 builder 補齊）
+- `pytest --ignore=tests/installed`
+- installed-fixture wheel gate（於正確 built-wheel 環境）
+- `openspec validate issue-41-usage-feedback-loop-v5-sonnet --strict`
+- `openspec validate --all --strict`
+- `python3 -m policy_check --repo .`
+- `git diff --check`
+- builder 實作與七件 authority 必須同一 commit。
+
+## 審查鏈
+
+- builder 後置 `agy/gemini-3.6-flash-high`（verification / code-review / adversarial）
+- final exact candidate 由 `codex/gpt-5.6-luna(max)`（`model_reasoning_effort=max`）PASS
+- Agy reviewer 必須先閱讀 frozen plan/todo/spec/design/tasks 與七件 authority（plan-only artifacts），再對照驗收結果。
+- Agy 判準：未處置缺陷/缺口 FAIL；承認且有界列管殘餘風險不獨立 FAIL。
+- 第二次 Claude build/repair 後仍有未處置 BLOCKER/MAJOR 即停在 `needs_human`，不得自動生成 v6。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/specs/stage2-memory-usage-feedback/spec.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/specs/stage2-memory-usage-feedback/spec.md
@@ -14,7 +14,9 @@ The usage aggregation SHALL 使用逐行 iterator 載入 ledger，並對 I/O、U
 #### Scenario: streaming / regression 回歸
 
 - **WHEN** `runtime/ledger/offered.jsonl` 或 `runtime/ledger/memory_usage.jsonl` 使用超大檔、或 `Path.read_text` 被 monkeypatch 成拋例外
-- **THEN** 解析流程必須改為逐行 iterator，不得一次載入 list；讀取錯誤採 fail-soft，繼續處理其餘合法行，且不改寫 ledger。
+- **THEN** 解析流程必須改為逐行 iterator，不得一次載入 list；filesystem
+  metadata/open/read/decode 錯誤採 fail-soft，逐行 decode 且繼續處理其餘
+  合法行，並且不改寫 ledger。
 
 ### Requirement: invalid rows 與 bounded diagnostics
 
@@ -31,8 +33,19 @@ Attribution SHALL 僅接受 `(tool, logical session, sl_id)` 完整且先行 off
 
 #### Scenario: offered/read 對應規則
 
-- **WHEN** read 事件對應的 `(tool, logical_session, sl_id)` 缺漏或為 `(unknown)`，或 offered 時間晚於 read，或 read 時間不在窗口內
+- **WHEN** read 事件對應的 `(tool, logical_session, sl_id)` 缺漏或為 `(unknown)`，或 offered/read 任一時間為 future/out-of-window，或 offered 時間晚於 read
 - **THEN** 該 read 不得歸因到 slice，且不參與 `read_count/last_read_at` 聚合。
+
+### Requirement: usage 時間基準可注入
+
+Index build SHALL 接受可注入的 UTC 時間基準與窗口，並原樣傳至 usage
+aggregation；未注入時才使用目前 UTC 與預設窗口。
+
+#### Scenario: dream/index rebuild 可重現
+
+- **WHEN** caller 提供 `usage_now` 與 `usage_window_days`
+- **THEN** 相同 ledger 與相同輸入必須產生相同 `read_count/last_read_at`，
+  且 aggregation 必須使用 caller 提供的值。
 
 ### Requirement: ranking 穩定性與 0.04 上限
 
@@ -42,6 +55,12 @@ The ranking engine SHALL 使用 stable key 搭配 0.04 上限，且無 boost 時
 
 - **WHEN** 有 `read_count` 的 slice 需要計分
 - **THEN** 使用 `usage_boost = min(0.04, 0.01 * log2(1 + read_count))`，無 boost 時走 legacy fast path；有 boost 時 stable key `(adjusted_score, base_score, slice_id)`，且 `base_score` 間距超過 `0.04` 時不得反轉。
+
+#### Scenario: 無 boost 維持 legacy stable order
+
+- **WHEN** index 不含 usage 欄位，或結果集沒有任何正 `read_count`
+- **THEN** 排序只使用既有 base-score key，base-score 同分保持原輸入順序，
+  不得新增 raw BM25 或 slice id tie-break。
 
 ### Requirement: index compat / legacy fallback
 
@@ -59,7 +78,7 @@ janitor `scan` SHALL 維持 `superseded`、`source_invalid`、`ttl` 的決策優
 #### Scenario: superseded/source_invalid/ttl 順序
 
 - **WHEN** slice 同時觸發 `superseded` 與 `ttl`、或有 `source_invalid`
-- **THEN** `superseded` / `source_invalid` 優先於 `ttl`，`read` 不得 re-activate 已 decayed 的 slice；`ttl` 計算源自 `max(captured_at, active_since_ts, valid last_read_at)`，detail 記錄 `ttl_base` 與 `source`。
+- **THEN** `superseded` / `source_invalid` 優先於 `ttl`，`read` 不得 re-activate 已 decayed 的 slice；`ttl` 計算源自 `max(captured_at, active_since_ts, valid last_read_at)`，future/malformed `last_read_at` fail-closed，detail 記錄 `ttl_base` 與 `source`。
 
 ### Requirement: scanner 可觀測性與零值噪訊
 
@@ -79,11 +98,13 @@ The implementation SHALL 維護模組 docstring 真實性與回報欄位穩定�
 - **WHEN** 實作涉及模組說明更新
 - **THEN** 必須維持 `__doc__` 真實內容，不得引入無關格式 churn。
 
-### Requirement: 交付需同 commit 與 frozen plan 閱讀
+### Requirement: 交付需 exact-head 與 frozen plan 閱讀
 
-Builder 實作流程 SHALL 將這 7 件 authority 與實作變更放在同一 commit，供 Agy review 一次性審閱。
+交付流程 SHALL 以同一個 exact candidate head 包含本 change authority、
+regressions 與實作，供 current-head review 一次性審閱。
 
-#### Scenario: Agy review 前置
+#### Scenario: current-head review 前置
 
-- **WHEN** 實作交付 candidate 準備進行 Agy review
-- **THEN** builder 必須將這 7 件 authority 與實作改動放在同一 commit，並由 reviewer 先閱讀 frozen plan 與 7 件 authority 後再結論。
+- **WHEN** candidate 準備開 PR 或 merge
+- **THEN** reviewer 必須先閱讀 frozen plan 與 authority，再以 current head
+  的 code、tests、CI 與 review threads 作結論。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/specs/stage2-memory-usage-feedback/spec.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/specs/stage2-memory-usage-feedback/spec.md
@@ -1,0 +1,89 @@
+## Lifecycle mapping
+
+- Active change：`openspec/changes/issue-41-usage-feedback-loop-v5-sonnet`
+- Lifecycle base：`b4a317f9bfa38708eabbdb31e083dfc3b6e4c044`
+- Supersedes：`openspec/changes/issue-41-usage-feedback-loop-v4`
+- Scope spec：`stage2-memory-usage-feedback`
+
+## ADDED Requirements
+
+### Requirement: usage-ledger streaming 與 fail-soft 邊界
+
+The usage aggregation SHALL 使用逐行 iterator 載入 ledger，並對 I/O、UTF-8、單行 parse 錯誤採 fail-soft，不中止整體流程。
+
+#### Scenario: streaming / regression 回歸
+
+- **WHEN** `runtime/ledger/offered.jsonl` 或 `runtime/ledger/memory_usage.jsonl` 使用超大檔、或 `Path.read_text` 被 monkeypatch 成拋例外
+- **THEN** 解析流程必須改為逐行 iterator，不得一次載入 list；讀取錯誤採 fail-soft，繼續處理其餘合法行，且不改寫 ledger。
+
+### Requirement: invalid rows 與 bounded diagnostics
+
+The implementation SHALL 排除 malformed/non-object / invalid read/offered 事件，僅以有界 counter 作為診斷輸出，並不得影響合法事件。
+
+#### Scenario: malformed 與無效事件
+
+- **WHEN** 出現 malformed JSON、non-object、缺少或空白 `tool/session/sl_id`、`invalid`、`future`、`out-of-window`
+- **THEN** 該事件不得 cross-match，只能計入固定 key 的有界 counter，且不影響合法事件處理。
+
+### Requirement: identity 與時間窗匹配
+
+Attribution SHALL 僅接受 `(tool, logical session, sl_id)` 完整且先行 offer、且符合時間窗的 read；否則歸入未歸因統計。
+
+#### Scenario: offered/read 對應規則
+
+- **WHEN** read 事件對應的 `(tool, logical_session, sl_id)` 缺漏或為 `(unknown)`，或 offered 時間晚於 read，或 read 時間不在窗口內
+- **THEN** 該 read 不得歸因到 slice，且不參與 `read_count/last_read_at` 聚合。
+
+### Requirement: ranking 穩定性與 0.04 上限
+
+The ranking engine SHALL 使用 stable key 搭配 0.04 上限，且無 boost 時保留 legacy 行為。
+
+#### Scenario: boost 與排序
+
+- **WHEN** 有 `read_count` 的 slice 需要計分
+- **THEN** 使用 `usage_boost = min(0.04, 0.01 * log2(1 + read_count))`，無 boost 時走 legacy fast path；有 boost 時 stable key `(adjusted_score, base_score, slice_id)`，且 `base_score` 間距超過 `0.04` 時不得反轉。
+
+### Requirement: index compat / legacy fallback
+
+Index build SHALL 以 temp DB 重建；新欄位缺省值 SHALL 透過 schema introspection fallback 補值。
+
+#### Scenario: 舊 DB 不中斷
+
+- **WHEN** `slice_meta` 已是舊結構
+- **THEN** 以 schema introspection fallback 提供預設 `read_count=0`、`last_read_at=NULL`，並保留 flock、temp、atomic replace 行為。
+
+### Requirement: janitor 優先序與 retention
+
+janitor `scan` SHALL 維持 `superseded`、`source_invalid`、`ttl` 的決策優先順序，並 SHALL 輸出可觀測欄位（含 `ttl_base`、`source`）。
+
+#### Scenario: superseded/source_invalid/ttl 順序
+
+- **WHEN** slice 同時觸發 `superseded` 與 `ttl`、或有 `source_invalid`
+- **THEN** `superseded` / `source_invalid` 優先於 `ttl`，`read` 不得 re-activate 已 decayed 的 slice；`ttl` 計算源自 `max(captured_at, active_since_ts, valid last_read_at)`，detail 記錄 `ttl_base` 與 `source`。
+
+### Requirement: scanner 可觀測性與零值噪訊
+
+Scanner SHALL 只在 counter > 0 時輸出 warning，對零值維持靜默。
+
+#### Scenario: no-zero warning
+
+- **WHEN** 掃描器統計 counter 為零
+- **THEN** 不輸出多餘的零值 warning；當 counter > 0 才輸出對應 warning 並保留固定 key。
+
+### Requirement: docstring/churn 可讀性
+
+The implementation SHALL 維護模組 docstring 真實性與回報欄位穩定性，避免非必要格式變更。
+
+#### Scenario: `__doc__` 保持
+
+- **WHEN** 實作涉及模組說明更新
+- **THEN** 必須維持 `__doc__` 真實內容，不得引入無關格式 churn。
+
+### Requirement: 交付需同 commit 與 frozen plan 閱讀
+
+Builder 實作流程 SHALL 將這 7 件 authority 與實作變更放在同一 commit，供 Agy review 一次性審閱。
+
+#### Scenario: Agy review 前置
+
+- **WHEN** 實作交付 candidate 準備進行 Agy review
+- **THEN** builder 必須將這 7 件 authority 與實作改動放在同一 commit，並由 reviewer 先閱讀 frozen plan 與 7 件 authority 後再結論。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
@@ -49,14 +49,18 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
    - [x] focused：`91 passed, 3 subtests passed`。
 7. [GREEN] 交付前 run：
    - [x] focused issue #41 suite
-   - `pytest --ignore=tests/installed`
-   - installed-fixture wheel gate（於正確 built-wheel 環境）
-   - `openspec validate issue-41-usage-feedback-loop-v5-sonnet --strict`
-   - `openspec validate --all --strict`
-   - `python3 -m policy_check --repo .`
-   - `git diff --check`
+   - [x] canonical preflight `tests/`（含 clean-wheel installed fixture）
+   - [x] `openspec validate issue-41-usage-feedback-loop-v5-sonnet --strict`
+   - [x] `openspec validate --all --strict`
+   - [x] PR-metadata-aware policy gate
+   - [x] `git diff --check`
+   - [x] local `PREFLIGHT PASS`：
+     `hamanpaul/paulsha-conventions@451c268`（v1.0.14），tests gate
+     `104.80s`
 8. [GREEN] 主 agent exact-head 檢查：7 件 authority、RED、實作與
    OpenSpec strict validation 一致。
+   - [x] 主 agent call-chain review 與 focused + #18 funnel：
+     `101 passed, 3 subtests passed`
 9. [GREEN] 結案門檻：preflight-ci、PR current-head checks、review
    threads、mergeability 全綠；PR body `Closes #41`，merge 後 issue closed。
 

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
@@ -31,25 +31,32 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
    - 0.04 bound
    - janitor priority/retention
    - 無 ledger mutation
-5. [GREEN] `claude/claude-sonnet-5` 以最小 patch 套用 v4 contracts + v5 lifecycle/provider 變更：`moc/search.py::search()` 排序鍵改為 `(adjusted_score, base_score, slice_id)` 三段式穩定鍵，修復 BLOCKER #7 RED regression（`tests/test_moc_search.py::test_search_stable_sort_uses_base_score_before_slice_id`）。
-   - [x] repair（本次 candidate）：新增共用 `paulsha_hippo/ledger/usage.py`（逐行 streaming、`DIAG_KEYS` 有界診斷、identity/window 匹配、`collect_usage_reads` 聚合），`_read_usage_jsonl`／`_load_usage_rows`／`_usage_mark_applied` 改用該 iterator（不再 `Path.read_text().splitlines()`），`#18` funnel 輸出欄位不變（BLOCKER #1–#4）。
-   - [x] repair：`moc/search.py::_build_index_locked` 對 `slice_meta` 新增 `read_count`／`last_read_at` 並以 `collect_usage_reads` 填值；`search()` 以 `PRAGMA table_info` 對舊索引 schema fallback、`usage_boost=min(0.04,0.01*log2(1+read_count))`、無正 boost 時走 legacy fast path（BLOCKER #7、MAJOR #5/#8）。
-   - [x] repair：`janitor/rules.py::_ttl_base`／`_decide_decay`／`plan_scan` 納入 `last_read_map`，`ttl_base=max(captured_at, active_since_ts, valid last_read_at)`，`ttl_expired` detail 新增 `ttl_base`／`source`；`superseded`／`source_invalid` 優先序不變、`read` 不重新啟用已 decayed slice；`janitor/scanner.py::run_scan` 併入 usage 診斷、僅 counter>0 時輸出 warning（MAJOR #6、BLOCKER #5）。
-   - [x] repair：對應 regression tests（`tests/test_ledger_usage.py`、`tests/test_moc_search.py::UsageBoostRankingTests`、`tests/test_janitor_rules.py::UsageRetentionRuleTests`、`tests/test_janitor_scanner.py::UsageDiagnosticsWarningTests`、`tests/test_memory_usage_cli.py` 新增案例）。
-6. [GREEN] 交付前 run：
+5. [RED] direct closeout regressions：
+   - [x] UTF-8 壞行前後合法 JSONL 行持續處理。
+   - [x] future/out-of-window offer 排除並記 bounded counter。
+   - [x] `(unknown)` tool/session/sl_id 全部拒絕。
+   - [x] `_read_usage_jsonl` / `_load_usage_rows` 不回傳 ledger-wide lists。
+   - [x] boosted exact tie 以 `(adjusted_score, base_score, slice_id)` 決勝。
+   - [x] `usage_now/window_days` 可注入並傳至 aggregation。
+   - [x] filesystem metadata I/O fail-soft。
+   - [x] no-boost 同分維持 legacy stable order。
+   - [x] future `last_read_at` 不延長 janitor TTL。
+6. [GREEN] Codex native subagent 修復 RED；保留 #18 funnel/applied、
+   hook/argv/runtime safety、legacy DB、flock/temp/atomic replace 與 janitor
+   優先序。
+7. [GREEN] 交付前 run：
    - `pytest --ignore=tests/installed`
    - installed-fixture wheel gate（於正確 built-wheel 環境）
    - `openspec validate issue-41-usage-feedback-loop-v5-sonnet --strict`
    - `openspec validate --all --strict`
    - `python3 -m policy_check --repo .`
    - `git diff --check`
-7. [GREEN] reviewer candidate 檢查：7 件 authority + 實作同 commit，且 OpenSpec strict validation 可識別 active change；Agy reviewer 需先讀取這份 frozen plan 與 7 件 authority。
-8. [GREEN] 結案門檻：
-   - `agy/gemini-3.6-flash-high` verification / code-review / adversarial
-   - `codex/gpt-5.6-luna` final exact-head (`model_reasoning_effort=max`) PASS
-   - Claude 初跑後最多一次 repair；仍未通過則 `needs_human`，不得自動建立 v6
+8. [GREEN] 主 agent exact-head 檢查：7 件 authority、RED、實作與
+   OpenSpec strict validation 一致。
+9. [GREEN] 結案門檻：preflight-ci、PR current-head checks、review
+   threads、mergeability 全綠；PR body `Closes #41`，merge 後 issue closed。
 
-## Agy 審查規則（v5）
+## current-head 審查規則（v5）
 
 - 只列 BLOCKER/MAJOR，且最多 8 條。
 - 未處置缺陷/缺口為 FAIL。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
@@ -1,29 +1,52 @@
 ---
 status: accepted
 work_item: issue-41-usage-feedback-loop-v5-sonnet
-plan_ref: docs/superpowers/plans/2026-07-27-issue-41-usage-feedback-loop-v5-sonnet.md
 ---
 
 # Issue #41 usage feedback loop v5 tasks
 
-- [ ] [BLOCKER] JSONL 來源讀取逐行 iterator，禁止 `Path.read_text().splitlines()`；
-  bounded-memory 與 `Path.read_text` monkeypatch-fail 兩種回歸測試
-- [ ] [BLOCKER] malformed JSON／non-object／缺鍵或空白 tool-session-sl_id／invalid
-  timestamp／future／out-of-window 不得 cross-match；每種失敗更新固定 key 的
-  有界 counter
-- [ ] [BLOCKER] offered/read 同時驗證時序（offered 先行、read 落在 window 內）與
-  身份；`(unknown)` 或空字串不得形成可比對 identity
-- [ ] [BLOCKER] I/O、UTF-8、單行 parse error 必須 fail-soft，不得中止 index
-  rebuild/search/janitor，ledger 不得被改寫
-- [ ] [BLOCKER] scanner/janitor 警示只在 counter > 0 時輸出，禁止零值 noise
-- [ ] [MAJOR] module docstring 保持真實欄位；changelog 文字修正為準確實作語意
-- [x] [MAJOR] ranking 與衰減不變式：`usage_boost = min(0.04, 0.01 * log2(1 +
-  read_count))`；無 boost 時走 legacy fast path；有 boost 時 stable key 為
-  `(adjusted_score, base_score, slice_id)`；`base_gap > 0.04` 不可反轉。
-  — RED：`tests/test_moc_search.py::SearchTests::test_search_stable_sort_uses_base_score_before_slice_id`
-  重現目前 `paulsha_hippo/moc/search.py::search` 只用單一
-  `bm - 0.1 * link_weight` 排序鍵、無 `(adjusted_score, base_score, slice_id)`
-  tie-break，同分時退回插入序而非 base_score 排序。
-- [ ] [MAJOR] focused tests、`pytest --ignore=tests/installed`、installed-fixture
-  wheel gate、`openspec validate --all --strict`、`python3 -m policy_check
-  --repo .`、`git diff --check` 全綠證明
+## Tasks
+
+## RED→GREEN（順序）
+
+1. [RED] 導入 v5 planning authority 套件（本 7 件）並維持 `status: accepted`。
+2. [RED] 在 plan/proposal 明列 8 則 BLOCKER/MAJOR gate。
+3. [RED] 明定函式 entrypoint 與資料流：
+   - `paulsha_hippo/cli.py::_read_usage_jsonl`
+   - `paulsha_hippo/cli.py::_load_usage_rows`
+   - `paulsha_hippo/cli.py::_funnel_read_attribution`
+   - `paulsha_hippo/cli.py::_usage_mark_applied`
+   - `paulsha_hippo/moc/search.py::_build_index_locked`
+   - `paulsha_hippo/moc/search.py::search`
+   - `paulsha_hippo/janitor/scanner.py::run_scan`
+   - `paulsha_hippo/janitor/rules.py::plan_scan`
+4. [RED] 將新增測試邏輯定義為建置契約：
+   - malformed JSON
+   - missing keys
+   - invalid UTF-8/OSError
+   - large ledger/no-read_text
+   - no-zero-warning
+   - legacy DB fallback
+   - stable ranking
+   - 0.04 bound
+   - janitor priority/retention
+   - 無 ledger mutation
+5. [GREEN] `claude/claude-sonnet-5` 以最小 patch 套用 v4 contracts + v5 lifecycle/provider 變更：`moc/search.py::search()` 排序鍵改為 `(adjusted_score, base_score, slice_id)` 三段式穩定鍵，修復 BLOCKER #7 RED regression（`tests/test_moc_search.py::test_search_stable_sort_uses_base_score_before_slice_id`）。
+6. [GREEN] 交付前 run：
+   - `pytest --ignore=tests/installed`
+   - installed-fixture wheel gate（於正確 built-wheel 環境）
+   - `openspec validate issue-41-usage-feedback-loop-v5-sonnet --strict`
+   - `openspec validate --all --strict`
+   - `python3 -m policy_check --repo .`
+   - `git diff --check`
+7. [GREEN] reviewer candidate 檢查：7 件 authority + 實作同 commit，且 OpenSpec strict validation 可識別 active change；Agy reviewer 需先讀取這份 frozen plan 與 7 件 authority。
+8. [GREEN] 結案門檻：
+   - `agy/gemini-3.6-flash-high` verification / code-review / adversarial
+   - `codex/gpt-5.6-luna` final exact-head (`model_reasoning_effort=max`) PASS
+   - Claude 初跑後最多一次 repair；仍未通過則 `needs_human`，不得自動建立 v6
+
+## Agy 審查規則（v5）
+
+- 只列 BLOCKER/MAJOR，且最多 8 條。
+- 未處置缺陷/缺口為 FAIL。
+- 已明文承認且影響有界、列管為殘餘風險不單獨 FAIL。

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
@@ -44,7 +44,11 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
 6. [GREEN] Codex native subagent 修復 RED；保留 #18 funnel/applied、
    hook/argv/runtime safety、legacy DB、flock/temp/atomic replace 與 janitor
    優先序。
+   - [x] binary per-line fail-soft、bounded identity/window aggregation、
+     compact CLI folds、injectable index clock/window、ranking/TTL 修正完成。
+   - [x] focused：`91 passed, 3 subtests passed`。
 7. [GREEN] 交付前 run：
+   - [x] focused issue #41 suite
    - `pytest --ignore=tests/installed`
    - installed-fixture wheel gate（於正確 built-wheel 環境）
    - `openspec validate issue-41-usage-feedback-loop-v5-sonnet --strict`

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
@@ -1,0 +1,29 @@
+---
+status: accepted
+work_item: issue-41-usage-feedback-loop-v5-sonnet
+plan_ref: docs/superpowers/plans/2026-07-27-issue-41-usage-feedback-loop-v5-sonnet.md
+---
+
+# Issue #41 usage feedback loop v5 tasks
+
+- [ ] [BLOCKER] JSONL 來源讀取逐行 iterator，禁止 `Path.read_text().splitlines()`；
+  bounded-memory 與 `Path.read_text` monkeypatch-fail 兩種回歸測試
+- [ ] [BLOCKER] malformed JSON／non-object／缺鍵或空白 tool-session-sl_id／invalid
+  timestamp／future／out-of-window 不得 cross-match；每種失敗更新固定 key 的
+  有界 counter
+- [ ] [BLOCKER] offered/read 同時驗證時序（offered 先行、read 落在 window 內）與
+  身份；`(unknown)` 或空字串不得形成可比對 identity
+- [ ] [BLOCKER] I/O、UTF-8、單行 parse error 必須 fail-soft，不得中止 index
+  rebuild/search/janitor，ledger 不得被改寫
+- [ ] [BLOCKER] scanner/janitor 警示只在 counter > 0 時輸出，禁止零值 noise
+- [ ] [MAJOR] module docstring 保持真實欄位；changelog 文字修正為準確實作語意
+- [x] [MAJOR] ranking 與衰減不變式：`usage_boost = min(0.04, 0.01 * log2(1 +
+  read_count))`；無 boost 時走 legacy fast path；有 boost 時 stable key 為
+  `(adjusted_score, base_score, slice_id)`；`base_gap > 0.04` 不可反轉。
+  — RED：`tests/test_moc_search.py::SearchTests::test_search_stable_sort_uses_base_score_before_slice_id`
+  重現目前 `paulsha_hippo/moc/search.py::search` 只用單一
+  `bm - 0.1 * link_weight` 排序鍵、無 `(adjusted_score, base_score, slice_id)`
+  tie-break，同分時退回插入序而非 base_score 排序。
+- [ ] [MAJOR] focused tests、`pytest --ignore=tests/installed`、installed-fixture
+  wheel gate、`openspec validate --all --strict`、`python3 -m policy_check
+  --repo .`、`git diff --check` 全綠證明

--- a/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
+++ b/openspec/changes/issue-41-usage-feedback-loop-v5-sonnet/tasks.md
@@ -32,6 +32,10 @@ work_item: issue-41-usage-feedback-loop-v5-sonnet
    - janitor priority/retention
    - 無 ledger mutation
 5. [GREEN] `claude/claude-sonnet-5` 以最小 patch 套用 v4 contracts + v5 lifecycle/provider 變更：`moc/search.py::search()` 排序鍵改為 `(adjusted_score, base_score, slice_id)` 三段式穩定鍵，修復 BLOCKER #7 RED regression（`tests/test_moc_search.py::test_search_stable_sort_uses_base_score_before_slice_id`）。
+   - [x] repair（本次 candidate）：新增共用 `paulsha_hippo/ledger/usage.py`（逐行 streaming、`DIAG_KEYS` 有界診斷、identity/window 匹配、`collect_usage_reads` 聚合），`_read_usage_jsonl`／`_load_usage_rows`／`_usage_mark_applied` 改用該 iterator（不再 `Path.read_text().splitlines()`），`#18` funnel 輸出欄位不變（BLOCKER #1–#4）。
+   - [x] repair：`moc/search.py::_build_index_locked` 對 `slice_meta` 新增 `read_count`／`last_read_at` 並以 `collect_usage_reads` 填值；`search()` 以 `PRAGMA table_info` 對舊索引 schema fallback、`usage_boost=min(0.04,0.01*log2(1+read_count))`、無正 boost 時走 legacy fast path（BLOCKER #7、MAJOR #5/#8）。
+   - [x] repair：`janitor/rules.py::_ttl_base`／`_decide_decay`／`plan_scan` 納入 `last_read_map`，`ttl_base=max(captured_at, active_since_ts, valid last_read_at)`，`ttl_expired` detail 新增 `ttl_base`／`source`；`superseded`／`source_invalid` 優先序不變、`read` 不重新啟用已 decayed slice；`janitor/scanner.py::run_scan` 併入 usage 診斷、僅 counter>0 時輸出 warning（MAJOR #6、BLOCKER #5）。
+   - [x] repair：對應 regression tests（`tests/test_ledger_usage.py`、`tests/test_moc_search.py::UsageBoostRankingTests`、`tests/test_janitor_rules.py::UsageRetentionRuleTests`、`tests/test_janitor_scanner.py::UsageDiagnosticsWarningTests`、`tests/test_memory_usage_cli.py` 新增案例）。
 6. [GREEN] 交付前 run：
    - `pytest --ignore=tests/installed`
    - installed-fixture wheel gate（於正確 built-wheel 環境）

--- a/paulsha_hippo/cli.py
+++ b/paulsha_hippo/cli.py
@@ -13,6 +13,7 @@ from typing import Sequence
 
 from paulsha_hippo import paths
 from . import policy as memory_policy
+from .ledger import usage as usage_ledger
 from .moc import frontmatter_io as _fio
 from .moc import moc_builder as _moc_builder
 from .noise import classify_noise
@@ -817,38 +818,46 @@ def _rekey(args: argparse.Namespace) -> int:
     return 0
 
 
-def _read_usage_jsonl(path: Path, since: str | None) -> list[dict]:
-    """Read one usage ledger without changing it, using the existing since rule."""
+def _read_usage_jsonl(path: Path, since: str | None,
+                       diagnostics: dict[str, int] | None = None) -> list[dict]:
+    """Read one usage ledger without changing it, using the existing since rule.
+
+    v5 BLOCKER #1/#4: streams the ledger one line at a time via
+    ``ledger.usage.iter_ledger_events`` (no ``Path.read_text().splitlines()``,
+    no whole-file list materialization); I/O, UTF-8 and per-line parse errors
+    are fail-soft and never mutate the ledger. Malformed/non-object lines are
+    tallied into ``diagnostics`` (v5 BLOCKER #2) when the caller supplies a
+    bounded counter dict; otherwise a scratch one is used and discarded.
+    """
+    diag = diagnostics if diagnostics is not None else usage_ledger.new_diagnostics()
     out = []
-    if path.exists():
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(event, dict):
-                continue
-            if since and str(event.get("ts", "")) < since:
-                continue
-            out.append(event)
+    for event in usage_ledger.iter_ledger_events(path, diag):
+        if since and str(event.get("ts", "")) < since:
+            continue
+        out.append(event)
     return out
 
 
-def _load_usage_rows(root: Path, since: str | None) -> tuple[list[dict], list[dict], list[dict]]:
-    """Load offered/read/applied rows with the same event filters as ``_memory_usage``."""
+def _load_usage_rows(
+    root: Path, since: str | None,
+) -> tuple[list[dict], list[dict], list[dict], dict[str, int]]:
+    """Load offered/read/applied rows with the same event filters as ``_memory_usage``.
+
+    The fourth return value is the bounded parse-diagnostics counter
+    (v5 BLOCKER #2) accumulated across both ledgers; callers that don't
+    surface it may discard it.
+    """
     led = root / "runtime" / "ledger"
-    offered_rows = _read_usage_jsonl(led / "offered.jsonl", since)
-    usage_rows = _read_usage_jsonl(led / "memory_usage.jsonl", since)
+    diagnostics = usage_ledger.new_diagnostics()
+    offered_rows = _read_usage_jsonl(led / "offered.jsonl", since, diagnostics)
+    usage_rows = _read_usage_jsonl(led / "memory_usage.jsonl", since, diagnostics)
     used_rows = [
         event
         for event in usage_rows
         if event.get("source") == "read" and event.get("kind") != "applied"
     ]
     applied_rows = [event for event in usage_rows if event.get("kind") == "applied"]
-    return offered_rows, used_rows, applied_rows
+    return offered_rows, used_rows, applied_rows, diagnostics
 
 
 def _offered_items(event: dict) -> list:
@@ -883,7 +892,7 @@ def _memory_usage(args: argparse.Namespace) -> int:
         return 2
 
     root = Path(args.memory_root)
-    offered_rows, used_rows, applied_rows = _load_usage_rows(root, args.since)
+    offered_rows, used_rows, applied_rows, _load_diagnostics = _load_usage_rows(root, args.since)
 
     agg = defaultdict(lambda: {"offered_count": 0, "read_count": 0, "last_read": ""})
     sessions = set()
@@ -1229,7 +1238,7 @@ def _memory_usage_funnel(args: argparse.Namespace) -> int:
         return 2
 
     root = Path(args.memory_root)
-    offered_rows, used_rows, applied_rows = _load_usage_rows(root, args.since)
+    offered_rows, used_rows, applied_rows, _load_diagnostics = _load_usage_rows(root, args.since)
 
     offered_sessions, offered_by_tool, offered_slices = _funnel_offer_index(
         offered_rows
@@ -1375,27 +1384,24 @@ def _usage_mark_applied(args: argparse.Namespace) -> int:
 
     寫入前反查 offered.jsonl：同 (session_id, tool) 必須存在先行 offered 記錄，且
     slice_id 必須屬於那些 offered slices，否則 exit 1 並拒絕寫入偽造事件。
+
+    v5 BLOCKER #1/#4：offered.jsonl 以逐行 iterator 讀取（不使用
+    ``Path.read_text().splitlines()``），I/O 與單行 parse 錯誤 fail-soft，且此
+    函式只讀取 offered.jsonl，不會改寫它。
     """
     led_dir = Path(args.memory_root) / "runtime" / "ledger"
     session_seen = False
     offered_slices: set[str] = set()
     offered_path = led_dir / "offered.jsonl"
-    if offered_path.exists():
-        for line in offered_path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                e = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if e.get("session_id") != args.session_id or e.get("tool") != args.tool:
-                continue
-            session_seen = True
-            for offered in e.get("offered", []):
-                sid = offered.get("sl_id") if isinstance(offered, dict) else offered
-                if sid:
-                    offered_slices.add(str(sid))
+    diagnostics = usage_ledger.new_diagnostics()
+    for e in usage_ledger.iter_ledger_events(offered_path, diagnostics):
+        if e.get("session_id") != args.session_id or e.get("tool") != args.tool:
+            continue
+        session_seen = True
+        for offered in e.get("offered", []):
+            sid = offered.get("sl_id") if isinstance(offered, dict) else offered
+            if sid:
+                offered_slices.add(str(sid))
     if not session_seen:
         print(
             f"hippo usage mark-applied: error: 查無 (session_id={args.session_id}, "

--- a/paulsha_hippo/cli.py
+++ b/paulsha_hippo/cli.py
@@ -9,7 +9,7 @@ import sys
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Iterator, Sequence
 
 from paulsha_hippo import paths
 from . import policy as memory_policy
@@ -819,7 +819,7 @@ def _rekey(args: argparse.Namespace) -> int:
 
 
 def _read_usage_jsonl(path: Path, since: str | None,
-                       diagnostics: dict[str, int] | None = None) -> list[dict]:
+                       diagnostics: dict[str, int] | None = None) -> Iterator[dict]:
     """Read one usage ledger without changing it, using the existing since rule.
 
     v5 BLOCKER #1/#4: streams the ledger one line at a time via
@@ -830,34 +830,25 @@ def _read_usage_jsonl(path: Path, since: str | None,
     bounded counter dict; otherwise a scratch one is used and discarded.
     """
     diag = diagnostics if diagnostics is not None else usage_ledger.new_diagnostics()
-    out = []
     for event in usage_ledger.iter_ledger_events(path, diag):
         if since and str(event.get("ts", "")) < since:
             continue
-        out.append(event)
-    return out
+        yield event
 
 
 def _load_usage_rows(
     root: Path, since: str | None,
-) -> tuple[list[dict], list[dict], list[dict], dict[str, int]]:
-    """Load offered/read/applied rows with the same event filters as ``_memory_usage``.
+) -> tuple[Iterator[dict], Iterator[dict], dict[str, int]]:
+    """Return one-shot offered/usage iterators plus bounded parse diagnostics.
 
-    The fourth return value is the bounded parse-diagnostics counter
-    (v5 BLOCKER #2) accumulated across both ledgers; callers that don't
-    surface it may discard it.
+    Raw ledger rows remain streaming. Callers fold the iterators into compact
+    per-session/per-slice state instead of retaining ledger-wide row lists.
     """
     led = root / "runtime" / "ledger"
     diagnostics = usage_ledger.new_diagnostics()
     offered_rows = _read_usage_jsonl(led / "offered.jsonl", since, diagnostics)
     usage_rows = _read_usage_jsonl(led / "memory_usage.jsonl", since, diagnostics)
-    used_rows = [
-        event
-        for event in usage_rows
-        if event.get("source") == "read" and event.get("kind") != "applied"
-    ]
-    applied_rows = [event for event in usage_rows if event.get("kind") == "applied"]
-    return offered_rows, used_rows, applied_rows, diagnostics
+    return offered_rows, usage_rows, diagnostics
 
 
 def _offered_items(event: dict) -> list:
@@ -892,15 +883,31 @@ def _memory_usage(args: argparse.Namespace) -> int:
         return 2
 
     root = Path(args.memory_root)
-    offered_rows, used_rows, applied_rows, _load_diagnostics = _load_usage_rows(root, args.since)
+    offered_rows, usage_rows, _load_diagnostics = _load_usage_rows(root, args.since)
 
     agg = defaultdict(lambda: {"offered_count": 0, "read_count": 0, "last_read": ""})
     sessions = set()
+    by_tool: dict[str, dict] = {}
     for e in offered_rows:
         sessions.add(e.get("session_id"))
+        offered_items = _offered_items(e)
         for sid in _offered_slice_ids(e):
             agg[sid]["offered_count"] += 1
-    for e in used_rows:
+        t = by_tool.setdefault(_usage_tool_key(e), {"offered": 0, "read": 0, "applied": 0})
+        t["offered"] += len(offered_items)
+
+    applied_tools: set[str] = set()
+    total_reads = 0
+    for e in usage_rows:
+        tool = _usage_tool_key(e)
+        if e.get("kind") == "applied":
+            t = by_tool.setdefault(tool, {"offered": 0, "read": 0, "applied": 0})
+            t["applied"] += 1
+            applied_tools.add(tool)
+            continue
+        if e.get("source") != "read":
+            continue
+        t = by_tool.setdefault(tool, {"offered": 0, "read": 0, "applied": 0})
         # Count the session even when the read was not from an offered/attributable
         # slice, so avg_reads_per_session is not skewed by offered-only session counting.
         sessions.add(e.get("session_id"))
@@ -909,19 +916,8 @@ def _memory_usage(args: argparse.Namespace) -> int:
         agg[sid]["read_count"] += 1
         if ts > agg[sid]["last_read"]:
             agg[sid]["last_read"] = ts
-
-    by_tool: dict[str, dict] = {}
-    for e in offered_rows:
-        t = by_tool.setdefault(_usage_tool_key(e), {"offered": 0, "read": 0, "applied": 0})
-        t["offered"] += len(_offered_items(e))
-    for e in used_rows:
-        t = by_tool.setdefault(_usage_tool_key(e), {"offered": 0, "read": 0, "applied": 0})
         t["read"] += 1
-    applied_tools: set[str] = set()
-    for e in applied_rows:
-        t = by_tool.setdefault(_usage_tool_key(e), {"offered": 0, "read": 0, "applied": 0})
-        t["applied"] += 1
-        applied_tools.add(_usage_tool_key(e))
+        total_reads += 1
     for name, t in by_tool.items():
         if name not in applied_tools:
             t["applied"] = None  # 該 tool 無任何 applied 訊號 → n/a（不以內容猜測補值）
@@ -930,7 +926,6 @@ def _memory_usage(args: argparse.Namespace) -> int:
     slices.sort(key=lambda s: (s["read_count"], s["offered_count"]), reverse=True)
     never_read = sum(1 for s in slices if s["offered_count"] > 0 and s["read_count"] == 0)
     n = len(sessions)
-    total_reads = len(used_rows)
     summary = {
         "sessions": n, "slices": len(slices), "never_read": never_read,
         "total_reads": total_reads,
@@ -981,56 +976,16 @@ def _funnel_metrics(
     }
 
 
-def _funnel_unique_slice_coverage(
-    offered_rows: list[dict],
-    attributed_events: list[tuple[dict, str, str]],
-    included_sessions: set[str],
-) -> tuple[dict[str, int | float], dict[str, dict[str, int | float]]]:
-    offered_by_tool: dict[str, set[str]] = {}
-    read_by_tool: dict[str, set[str]] = {}
-    total_offered: set[str] = set()
-    total_read: set[str] = set()
-
-    for event in offered_rows:
-        session_key = _usage_logical_session_key(event)
-        if session_key not in included_sessions:
-            continue
-        tool = _usage_tool_key(event)
-        for slice_id in _offered_slice_ids(event):
-            if not slice_id:
-                continue
-            offered_by_tool.setdefault(tool, set()).add(slice_id)
-            total_offered.add(slice_id)
-
-    for event, session_key, slice_id in attributed_events:
-        if session_key not in included_sessions or not slice_id:
-            continue
-        tool = _usage_tool_key(event)
-        read_by_tool.setdefault(tool, set()).add(slice_id)
-        total_read.add(slice_id)
-
-    def _coverage(offered: set[str], read: set[str]) -> dict[str, int | float]:
-        offered_count = len(offered)
-        read_count = len(read)
-        return {
-            "offered": offered_count,
-            "read": read_count,
-            "read_rate": round(read_count * 100 / offered_count, 2)
-            if offered_count
-            else 0.0,
-        }
-
-    tool_coverage = {}
-    coverage_tools = set(_FUNNEL_TOOLS)
-    coverage_tools.update(offered_by_tool)
-    coverage_tools.update(read_by_tool)
-    for tool in sorted(coverage_tools):
-        tool_coverage[tool] = _coverage(
-            offered_by_tool.get(tool, set()),
-            read_by_tool.get(tool, set()),
-        )
-
-    return _coverage(total_offered, total_read), tool_coverage
+def _funnel_coverage(offered: set[str], read: set[str]) -> dict[str, int | float]:
+    offered_count = len(offered)
+    read_count = len(read)
+    return {
+        "offered": offered_count,
+        "read": read_count,
+        "read_rate": round(read_count * 100 / offered_count, 2)
+        if offered_count
+        else 0.0,
+    }
 
 
 def _usage_logical_session_key(event: dict) -> str:
@@ -1041,11 +996,14 @@ def _usage_logical_session_key(event: dict) -> str:
 
 
 def _funnel_offer_index(
-    offered_rows: list[dict],
-) -> tuple[set[str], dict[str, set[str]], dict[str, dict[str, list[str]]]]:
+    offered_rows: Iterator[dict],
+) -> dict[str, object]:
+    """Fold offered rows into compact per-session/per-slice state."""
     offered_sessions: set[str] = set()
     offered_by_tool: dict[str, set[str]] = {}
-    offered_slices: dict[str, dict[str, list[str]]] = {}
+    offered_slices: dict[str, dict[str, str]] = {}
+    offered_counts: dict[str, dict[str, int]] = {}
+    offered_unique: dict[str, dict[str, set[str]]] = {}
 
     for event in offered_rows:
         session_key = _usage_logical_session_key(event)
@@ -1055,51 +1013,64 @@ def _funnel_offer_index(
         offered_sessions.add(session_key)
         offered_by_tool.setdefault(tool, set()).add(session_key)
         session_slices = offered_slices.setdefault(session_key, {})
+        session_counts = offered_counts.setdefault(session_key, {})
+        tool_slices = offered_unique.setdefault(session_key, {}).setdefault(tool, set())
         offered_ts = str(event.get("ts") or "")
         for slice_id in _offered_slice_ids(event):
-            session_slices.setdefault(slice_id, []).append(offered_ts)
+            session_counts[slice_id] = session_counts.get(slice_id, 0) + 1
+            tool_slices.add(slice_id)
+            prior = session_slices.get(slice_id)
+            if offered_ts and (not prior or offered_ts < prior):
+                session_slices[slice_id] = offered_ts
+            elif prior is None:
+                session_slices[slice_id] = ""
 
-    return offered_sessions, offered_by_tool, offered_slices
+    return {
+        "offered_sessions": offered_sessions,
+        "offered_by_tool": offered_by_tool,
+        "offered_slices": offered_slices,
+        "offered_counts": offered_counts,
+        "offered_unique": offered_unique,
+    }
 
 
 def _funnel_read_attribution(
-    used_rows: list[dict],
-    offered_slices: dict[str, dict[str, list[str]]],
-) -> tuple[
-    list[tuple[dict, str, str]],
-    list[tuple[dict, str, str]],
-    set[str],
-    set[str],
-    dict[str, set[str]],
-    dict[str, dict[str, int | set[str]]],
-]:
-    """Separate reads of previously offered slices from direct reads.
+    usage_rows: Iterator[dict],
+    offered_slices: dict[str, dict[str, str]],
+) -> dict[str, object]:
+    """Fold read/applied rows into compact attribution state.
 
     A read is attributable only when the same logical session was offered the
     same slice and the read timestamp is strictly later than an offer
     timestamp.  Missing timestamps are conservatively treated as direct reads
     because the ledger cannot prove the required ordering.
     """
-    attributed_events: list[tuple[dict, str, str]] = []
-    direct_events: list[tuple[dict, str, str]] = []
+    attributed_event_count = 0
+    direct_event_count = 0
     attributed_sessions: set[str] = set()
     direct_sessions: set[str] = set()
     read_by_tool: dict[str, set[str]] = {}
     by_tool: dict[str, dict[str, int | set[str]]] = {}
+    attributed_counts: dict[str, dict[str, int]] = {}
+    read_unique: dict[str, dict[str, set[str]]] = {}
+    applied_sessions: set[str] = set()
+    applied_by_tool: dict[str, set[str]] = {}
 
-    for event in used_rows:
+    for event in usage_rows:
         session_key = _usage_logical_session_key(event)
+        tool = _usage_tool_key(event)
+        if event.get("kind") == "applied":
+            if session_key:
+                applied_sessions.add(session_key)
+                applied_by_tool.setdefault(tool, set()).add(session_key)
+            continue
+        if event.get("source") != "read":
+            continue
         slice_id = str(event.get("sl_id") or "")
         read_ts = str(event.get("ts") or "")
-        offer_times = offered_slices.get(session_key, {}).get(slice_id, [])
-        attributed = bool(
-            read_ts
-            and any(offer_ts and read_ts > offer_ts for offer_ts in offer_times)
-        )
-        target = attributed_events if attributed else direct_events
-        target.append((event, session_key, slice_id))
+        offer_ts = offered_slices.get(session_key, {}).get(slice_id, "")
+        attributed = bool(read_ts and offer_ts and read_ts > offer_ts)
 
-        tool = _usage_tool_key(event)
         stats = by_tool.setdefault(
             tool,
             {
@@ -1110,12 +1081,19 @@ def _funnel_read_attribution(
             },
         )
         if attributed:
+            attributed_event_count += 1
             stats["offer_then_read_events"] += 1
             if session_key:
                 attributed_sessions.add(session_key)
                 read_by_tool.setdefault(tool, set()).add(session_key)
                 stats["offer_then_read_sessions"].add(session_key)
+                session_counts = attributed_counts.setdefault(session_key, {})
+                session_counts[slice_id] = session_counts.get(slice_id, 0) + 1
+                read_unique.setdefault(session_key, {}).setdefault(tool, set()).add(
+                    slice_id
+                )
         else:
+            direct_event_count += 1
             stats["direct_read_events"] += 1
             if session_key:
                 direct_sessions.add(session_key)
@@ -1130,76 +1108,72 @@ def _funnel_read_attribution(
             "direct_read_sessions": len(stats["direct_read_sessions"]),
         }
 
-    return (
-        attributed_events,
-        direct_events,
-        attributed_sessions,
-        direct_sessions,
-        read_by_tool,
-        attribution_by_tool,
-    )
-
-
-def _funnel_top_slices(
-    offered_rows: list[dict],
-    attributed_events: list[tuple[dict, str, str]],
-    included_sessions: set[str],
-) -> list[dict]:
-    from collections import defaultdict
-
-    slices = defaultdict(lambda: {"offered_count": 0, "read_count": 0})
-    for event in offered_rows:
-        session_key = _usage_logical_session_key(event)
-        if session_key not in included_sessions:
-            continue
-        for slice_id in _offered_slice_ids(event):
-            slices[slice_id]["offered_count"] += 1
-    for _event, session_key, slice_id in attributed_events:
-        if session_key not in included_sessions or not slice_id:
-            continue
-        slices[slice_id]["read_count"] += 1
-
-    top_slices = []
-    for slice_id, counts in slices.items():
-        if counts["read_count"] == 0:
-            continue
-        offered_count = counts["offered_count"]
-        top_slices.append(
-            {
-                "slice_id": slice_id,
-                "offered_count": offered_count,
-                "read_count": counts["read_count"],
-                "read_offer_ratio": (
-                    round(counts["read_count"] / offered_count, 6)
-                    if offered_count
-                    else None
-                ),
-            }
-        )
-    top_slices.sort(
-        key=lambda item: (-item["read_count"], -item["offered_count"], item["slice_id"])
-    )
-    return top_slices[:_FUNNEL_TOP_N]
+    return {
+        "attributed_event_count": attributed_event_count,
+        "direct_event_count": direct_event_count,
+        "attributed_sessions": attributed_sessions,
+        "direct_sessions": direct_sessions,
+        "read_by_tool": read_by_tool,
+        "attribution_by_tool": attribution_by_tool,
+        "attributed_counts": attributed_counts,
+        "read_unique": read_unique,
+        "applied_sessions": applied_sessions,
+        "applied_by_tool": applied_by_tool,
+    }
 
 
 def _funnel_mode_report(
     *,
-    offered_rows: list[dict],
-    offered_sessions: set[str],
-    offered_by_tool: dict[str, set[str]],
-    attributed_read_sessions: set[str],
-    read_by_tool: dict[str, set[str]],
-    applied_sessions: set[str],
-    applied_by_tool: dict[str, set[str]],
-    attributed_events: list[tuple[dict, str, str]],
+    offer_state: dict[str, object],
+    read_state: dict[str, object],
     excluded_sessions: set[str],
 ) -> dict:
+    offered_sessions = offer_state["offered_sessions"]
+    offered_by_tool = offer_state["offered_by_tool"]
+    offered_counts = offer_state["offered_counts"]
+    offered_unique = offer_state["offered_unique"]
+    attributed_read_sessions = read_state["attributed_sessions"]
+    read_by_tool = read_state["read_by_tool"]
+    attributed_counts = read_state["attributed_counts"]
+    read_unique = read_state["read_unique"]
+    applied_sessions = read_state["applied_sessions"]
+    applied_by_tool = read_state["applied_by_tool"]
     included_sessions = offered_sessions - excluded_sessions
-    unique_slice_coverage, unique_slice_coverage_by_tool = _funnel_unique_slice_coverage(
-        offered_rows=offered_rows,
-        attributed_events=attributed_events,
-        included_sessions=included_sessions,
-    )
+
+    offered_slices_by_tool: dict[str, set[str]] = {}
+    read_slices_by_tool: dict[str, set[str]] = {}
+    total_offered: set[str] = set()
+    total_read: set[str] = set()
+    slice_counts: dict[str, dict[str, int]] = {}
+    for session_key in included_sessions:
+        for slice_id, count in offered_counts.get(session_key, {}).items():
+            total_offered.add(slice_id)
+            stats = slice_counts.setdefault(
+                slice_id, {"offered_count": 0, "read_count": 0}
+            )
+            stats["offered_count"] += count
+        for slice_id, count in attributed_counts.get(session_key, {}).items():
+            total_read.add(slice_id)
+            stats = slice_counts.setdefault(
+                slice_id, {"offered_count": 0, "read_count": 0}
+            )
+            stats["read_count"] += count
+        for tool, slice_ids in offered_unique.get(session_key, {}).items():
+            offered_slices_by_tool.setdefault(tool, set()).update(slice_ids)
+        for tool, slice_ids in read_unique.get(session_key, {}).items():
+            read_slices_by_tool.setdefault(tool, set()).update(slice_ids)
+
+    unique_slice_coverage = _funnel_coverage(total_offered, total_read)
+    unique_slice_coverage_by_tool = {}
+    coverage_tools = set(_FUNNEL_TOOLS)
+    coverage_tools.update(offered_slices_by_tool)
+    coverage_tools.update(read_slices_by_tool)
+    for tool in sorted(coverage_tools):
+        unique_slice_coverage_by_tool[tool] = _funnel_coverage(
+            offered_slices_by_tool.get(tool, set()),
+            read_slices_by_tool.get(tool, set()),
+        )
+
     by_tool = {}
     tool_names = set(_FUNNEL_TOOLS)
     tool_names.update(offered_by_tool)
@@ -1223,12 +1197,31 @@ def _funnel_mode_report(
     )
     summary["unique_slice_coverage"] = unique_slice_coverage
 
+    top_slices = []
+    for slice_id, counts in slice_counts.items():
+        if counts["read_count"] == 0:
+            continue
+        offered_count = counts["offered_count"]
+        top_slices.append(
+            {
+                "slice_id": slice_id,
+                "offered_count": offered_count,
+                "read_count": counts["read_count"],
+                "read_offer_ratio": (
+                    round(counts["read_count"] / offered_count, 6)
+                    if offered_count
+                    else None
+                ),
+            }
+        )
+    top_slices.sort(
+        key=lambda item: (-item["read_count"], -item["offered_count"], item["slice_id"])
+    )
+
     return {
         "summary": summary,
         "by_tool": by_tool,
-        "top_slices": _funnel_top_slices(
-            offered_rows, attributed_events, included_sessions
-        ),
+        "top_slices": top_slices[:_FUNNEL_TOP_N],
     }
 
 
@@ -1238,29 +1231,12 @@ def _memory_usage_funnel(args: argparse.Namespace) -> int:
         return 2
 
     root = Path(args.memory_root)
-    offered_rows, used_rows, applied_rows, _load_diagnostics = _load_usage_rows(root, args.since)
-
-    offered_sessions, offered_by_tool, offered_slices = _funnel_offer_index(
-        offered_rows
+    offered_rows, usage_rows, _load_diagnostics = _load_usage_rows(root, args.since)
+    offer_state = _funnel_offer_index(offered_rows)
+    read_state = _funnel_read_attribution(
+        usage_rows, offer_state["offered_slices"]
     )
-    (
-        attributed_events,
-        direct_events,
-        attributed_read_sessions,
-        direct_read_sessions,
-        read_by_tool,
-        attribution_by_tool,
-    ) = _funnel_read_attribution(used_rows, offered_slices)
-    applied_sessions: set[str] = set()
-    applied_by_tool: dict[str, set[str]] = {}
-
-    for event in applied_rows:
-        session_key = _usage_logical_session_key(event)
-        if not session_key:
-            continue
-        tool = _usage_tool_key(event)
-        applied_sessions.add(session_key)
-        applied_by_tool.setdefault(tool, set()).add(session_key)
+    offered_sessions = offer_state["offered_sessions"]
 
     from .ledger import processing
 
@@ -1271,36 +1247,24 @@ def _memory_usage_funnel(args: argparse.Namespace) -> int:
         if processing_states.get(session_key) == "no-findings"
     }
     with_noise = _funnel_mode_report(
-        offered_rows=offered_rows,
-        offered_sessions=offered_sessions,
-        offered_by_tool=offered_by_tool,
-        attributed_read_sessions=attributed_read_sessions,
-        read_by_tool=read_by_tool,
-        applied_sessions=applied_sessions,
-        applied_by_tool=applied_by_tool,
-        attributed_events=attributed_events,
+        offer_state=offer_state,
+        read_state=read_state,
         excluded_sessions=set(),
     )
     without_noise = _funnel_mode_report(
-        offered_rows=offered_rows,
-        offered_sessions=offered_sessions,
-        offered_by_tool=offered_by_tool,
-        attributed_read_sessions=attributed_read_sessions,
-        read_by_tool=read_by_tool,
-        applied_sessions=applied_sessions,
-        applied_by_tool=applied_by_tool,
-        attributed_events=attributed_events,
+        offer_state=offer_state,
+        read_state=read_state,
         excluded_sessions=noise_sessions,
     )
     modes = {"with_noise": with_noise, "without_noise": without_noise}
     selected_mode = "without-noise" if args.exclude_noise else "with-noise"
     selected = modes[selected_mode.replace("-", "_")]
     read_attribution = {
-        "offer_then_read_events": len(attributed_events),
-        "offer_then_read_sessions": len(attributed_read_sessions),
-        "direct_read_events": len(direct_events),
-        "direct_read_sessions": len(direct_read_sessions),
-        "by_tool": attribution_by_tool,
+        "offer_then_read_events": read_state["attributed_event_count"],
+        "offer_then_read_sessions": len(read_state["attributed_sessions"]),
+        "direct_read_events": read_state["direct_event_count"],
+        "direct_read_sessions": len(read_state["direct_sessions"]),
+        "by_tool": read_state["attribution_by_tool"],
     }
 
     report = {

--- a/paulsha_hippo/janitor/rules.py
+++ b/paulsha_hippo/janitor/rules.py
@@ -48,22 +48,36 @@ def _age_days(base: datetime, now: datetime) -> float:
     return delta.total_seconds() / 86400.0
 
 
-def _ttl_base(record: KnowledgeRecord, lc_info: dict[str, Any]) -> datetime | None:
-    """Determine TTL base timestamp for a record."""
+def _ttl_base(
+    record: KnowledgeRecord, lc_info: dict[str, Any], last_read_at: "str | None" = None,
+) -> "tuple[datetime, str] | None":
+    """Determine TTL base timestamp for a record and which input it came from.
+
+    v5 requirement #9: ``max(captured_at, active_since_ts, valid last_read_at)``
+    — a read only extends the retention clock of an already-active record
+    (this is only ever called for active records; decayed records go through
+    ``_decide_reactivation`` instead, so a read can never reactivate one).
+    """
     captured_dt = _parse_ts(record.captured_at)
     if captured_dt is None:
         return None
-    
+    base_dt, source = captured_dt, "captured_at"
+
     # Anti-flap: if record is active and since_ts is newer, use that
     state = lc_info.get("state", "active")
     if state == "active":
         since_ts = lc_info.get("since_ts")
         if since_ts:
             since_dt = _parse_ts(since_ts)
-            if since_dt and since_dt > captured_dt:
-                return since_dt
-    
-    return captured_dt
+            if since_dt and since_dt > base_dt:
+                base_dt, source = since_dt, "active_since_ts"
+
+    if last_read_at:
+        read_dt = _parse_ts(last_read_at)
+        if read_dt and read_dt > base_dt:
+            base_dt, source = read_dt, "last_read_at"
+
+    return base_dt, source
 
 
 def _decide_decay(
@@ -72,16 +86,23 @@ def _decide_decay(
     config: JanitorConfig,
     now: datetime,
     lc_info: dict[str, Any],
-    source_path_exists: SourcePathCheck
+    source_path_exists: SourcePathCheck,
+    last_read_at: "str | None" = None,
 ) -> dict[str, Any] | None:
-    """Decide if record should decay."""
+    """Decide if record should decay.
+
+    v5 requirement #9: ``superseded``/``source_invalid`` stay strictly higher
+    priority than ``ttl_expired`` (checked first, unconditionally on
+    ``last_read_at``) so a read can never keep an otherwise-superseded or
+    source-invalid record active.
+    """
     # Priority 1: superseded
     if config.decay_superseded and record.record_id in superseded_by:
         return {
             "reason": "superseded",
             "detail": {"superseded_by": superseded_by[record.record_id]}
         }
-    
+
     # Priority 2: source_invalid
     if config.check_provenance_path:
         path_result = source_path_exists(record)
@@ -90,22 +111,28 @@ def _decide_decay(
                 "reason": "source_invalid",
                 "detail": {"check": "provenance_path"}
             }
-    
+
     # Priority 3: ttl_expired
-    ttl_base = _ttl_base(record, lc_info)
-    if ttl_base is None:
+    ttl_result = _ttl_base(record, lc_info, last_read_at)
+    if ttl_result is None:
         return None
-    
+    ttl_base, ttl_source = ttl_result
+
     # Determine threshold
     threshold = config.default_decay_age_days
-    
+
     age = _age_days(ttl_base, now)
     if age > threshold:
         return {
             "reason": "ttl_expired",
-            "detail": {"age_days": age, "threshold_days": threshold}
+            "detail": {
+                "age_days": age,
+                "threshold_days": threshold,
+                "ttl_base": ttl_base.isoformat(),
+                "source": ttl_source,
+            }
         }
-    
+
     return None
 
 
@@ -208,13 +235,14 @@ def plan_scan(
     config: JanitorConfig,
     now: str,
     config_hash: str,
-    source_path_exists: SourcePathCheck = _default_source_path_exists
+    source_path_exists: SourcePathCheck = _default_source_path_exists,
+    last_read_map: "dict[str, str] | None" = None,
 ) -> list[dict[str, Any]]:
     """
     Plan decay/reactivation events for records.
-    
+
     Pure function that evaluates all records and returns event list.
-    
+
     Args:
         records: List of knowledge records to evaluate
         import_index: Mapping of source_key -> list of import events
@@ -223,10 +251,14 @@ def plan_scan(
         now: Current timestamp string (ISO format)
         config_hash: Hash of janitor config
         source_path_exists: Callable to check if source path exists
-    
+        last_read_map: record_id -> ISO ``last_read_at`` (v5 requirement #9);
+            only consulted for currently-active records, so a read can never
+            reactivate an already-decayed record.
+
     Returns:
         List of event dictionaries (decayed or reactivation)
     """
+    last_read_map = last_read_map or {}
     # Parse now with fallback
     now_dt = _parse_ts(now)
     if now_dt is None:
@@ -254,7 +286,10 @@ def plan_scan(
         
         if state == "active":
             # Evaluate decay
-            decision = _decide_decay(record, superseded_by, config, now_dt, lc_info, source_path_exists)
+            last_read_at = last_read_map.get(record.record_id)
+            decision = _decide_decay(
+                record, superseded_by, config, now_dt, lc_info, source_path_exists, last_read_at,
+            )
             if decision:
                 events.append(_decayed_event(record, decision, now, config_hash))
         else:

--- a/paulsha_hippo/janitor/rules.py
+++ b/paulsha_hippo/janitor/rules.py
@@ -49,7 +49,11 @@ def _age_days(base: datetime, now: datetime) -> float:
 
 
 def _ttl_base(
-    record: KnowledgeRecord, lc_info: dict[str, Any], last_read_at: "str | None" = None,
+    record: KnowledgeRecord,
+    lc_info: dict[str, Any],
+    last_read_at: "str | None" = None,
+    *,
+    now: "datetime | None" = None,
 ) -> "tuple[datetime, str] | None":
     """Determine TTL base timestamp for a record and which input it came from.
 
@@ -74,7 +78,7 @@ def _ttl_base(
 
     if last_read_at:
         read_dt = _parse_ts(last_read_at)
-        if read_dt and read_dt > base_dt:
+        if read_dt and (now is None or read_dt <= now) and read_dt > base_dt:
             base_dt, source = read_dt, "last_read_at"
 
     return base_dt, source
@@ -113,7 +117,7 @@ def _decide_decay(
             }
 
     # Priority 3: ttl_expired
-    ttl_result = _ttl_base(record, lc_info, last_read_at)
+    ttl_result = _ttl_base(record, lc_info, last_read_at, now=now)
     if ttl_result is None:
         return None
     ttl_base, ttl_source = ttl_result

--- a/paulsha_hippo/janitor/scanner.py
+++ b/paulsha_hippo/janitor/scanner.py
@@ -6,12 +6,14 @@ lifecycle events.
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
 from paulsha_hippo.janitor import record_source, rules
 from paulsha_hippo.janitor.config import JanitorConfig
 from paulsha_hippo.ledger import import_log, lifecycle
+from paulsha_hippo.ledger import usage as usage_ledger
 
 # Import statuses that carry new evidence and may reactivate a decayed record.
 _REACTIVATION_STATUSES = {"written", "updated"}
@@ -170,11 +172,30 @@ def run_scan(
     if import_bad_line_count:
         warnings.append(f"skipped {import_bad_line_count} bad line(s)")
 
+    # v5 requirement #9: fold last_read_at into janitor retention (ttl_base =
+    # max(captured_at, active_since_ts, valid last_read_at)); only ever
+    # applied to active records inside plan_scan, so a read can't reactivate
+    # an already-decayed one. Fail-soft/bounded and read-only against the
+    # ledger; a nonzero diagnostic is surfaced as a single warning (v5
+    # requirement: no zero-value warning noise).
+    now_dt = usage_ledger.parse_ts(now) or datetime.now(timezone.utc)
+    last_read_map_raw, usage_diag = usage_ledger.collect_usage_reads(memory_root, now_dt)
+    last_read_map = {sid: last_read for sid, (_count, last_read) in last_read_map_raw.items()}
+    nonzero_usage_diag = {key: count for key, count in usage_diag.items() if count > 0}
+    if nonzero_usage_diag:
+        warnings.append(f"usage ledger diagnostics: {nonzero_usage_diag}")
+
     # Plan scan
     if source_path_exists is None:
-        events = rules.plan_scan(records, import_index, lc_state, config, now, config_hash)
+        events = rules.plan_scan(
+            records, import_index, lc_state, config, now, config_hash,
+            last_read_map=last_read_map,
+        )
     else:
-        events = rules.plan_scan(records, import_index, lc_state, config, now, config_hash, source_path_exists)
+        events = rules.plan_scan(
+            records, import_index, lc_state, config, now, config_hash, source_path_exists,
+            last_read_map=last_read_map,
+        )
     lint_findings = rules.plan_lint(records)
     for finding in lint_findings:
         warnings.append(f"lint:{finding['rule']}: {finding['path']} (project={finding['project']})")

--- a/paulsha_hippo/ledger/usage.py
+++ b/paulsha_hippo/ledger/usage.py
@@ -1,0 +1,208 @@
+"""Shared usage-ledger streaming reader and bounded diagnostics (issue #41 v5).
+
+Centralizes the line-by-line JSONL parsing rules that ``paulsha_hippo/cli.py``
+(usage/funnel commands), ``paulsha_hippo/moc/search.py`` (usage-boost
+aggregation for ranking) and ``paulsha_hippo/janitor/scanner.py`` (retention
+``last_read_at``) all apply against ``runtime/ledger/offered.jsonl`` and
+``runtime/ledger/memory_usage.jsonl``, so the three surfaces share one
+fail-soft, bounded-diagnostic, identity/time-window implementation instead of
+three drifting copies.
+"""
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterator
+
+# Fixed, bounded diagnostic key set (v5 BLOCKER #2) — every reason a ledger
+# line/event fails to parse or cross-match maps to exactly one of these keys;
+# the key set itself never grows, so counters stay bounded regardless of how
+# many distinct malformed inputs are seen.
+DIAG_KEYS = (
+    "json_decode_error",
+    "non_object",
+    "missing_tool",
+    "missing_session",
+    "missing_sl_id",
+    "invalid_ts",
+    "future_event",
+    "window_older",
+    "read_without_offered",
+)
+
+# Usage-boost read_count/last_read_at aggregation only considers reads within
+# this many days of "now" — older reads still exist in the ledger but do not
+# feed the search ranking boost or the janitor retention base.
+USAGE_BOOST_WINDOW_DAYS = 30
+
+USAGE_BOOST_CAP = 0.04
+USAGE_BOOST_COEFFICIENT = 0.01
+
+
+def new_diagnostics() -> dict[str, int]:
+    """A fresh all-zero counter dict over the fixed :data:`DIAG_KEYS` set."""
+    return {key: 0 for key in DIAG_KEYS}
+
+
+def iter_ledger_events(path: Path, diagnostics: dict[str, int]) -> "Iterator[dict]":
+    """Yield JSON-object events from ``path`` one line at a time.
+
+    v5 BLOCKER #1/#4: never materializes the file as a single string/list
+    (no ``Path.read_text().splitlines()``) and never raises — a missing file,
+    an ``OSError``/``UnicodeDecodeError`` while opening or reading, or a
+    malformed/non-object line are all fail-soft: the ledger is only ever
+    opened for reading here, so a bad read can never mutate it, and whatever
+    lines were already readable are still yielded before/around the failure.
+    """
+    if not path.exists():
+        return
+    try:
+        handle = path.open("r", encoding="utf-8")
+    except OSError:
+        return
+    try:
+        while True:
+            try:
+                line = handle.readline()
+            except (OSError, UnicodeDecodeError):
+                return
+            if line == "":
+                return
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                diagnostics["json_decode_error"] += 1
+                continue
+            if not isinstance(event, dict):
+                diagnostics["non_object"] += 1
+                continue
+            yield event
+    finally:
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+def parse_ts(value: object) -> "datetime | None":
+    """Parse an ISO-8601 timestamp string; ``None`` for anything else."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def valid_identity(tool: object, session_id: object, slice_id: object) -> bool:
+    """v5 BLOCKER #3: ``(unknown)``/blank tool, session or slice id can't identify anything."""
+    tool_str = str(tool or "").strip()
+    if not tool_str or tool_str == "(unknown)":
+        return False
+    if not str(session_id or "").strip():
+        return False
+    if not str(slice_id or "").strip():
+        return False
+    return True
+
+
+def usage_boost(read_count: int) -> float:
+    """``min(0.04, 0.01 * log2(1 + read_count))``; 0.0 for non-positive counts."""
+    if read_count <= 0:
+        return 0.0
+    return min(USAGE_BOOST_CAP, USAGE_BOOST_COEFFICIENT * math.log2(1 + read_count))
+
+
+def _classify_missing_identity(diagnostics: dict[str, int], tool: object,
+                                session_id: object, slice_id: object) -> None:
+    tool_str = str(tool or "").strip()
+    if not tool_str or tool_str == "(unknown)":
+        diagnostics["missing_tool"] += 1
+    elif not str(session_id or "").strip():
+        diagnostics["missing_session"] += 1
+    else:
+        diagnostics["missing_sl_id"] += 1
+
+
+def collect_usage_reads(
+    memory_root: Path, now: datetime, window_days: int = USAGE_BOOST_WINDOW_DAYS,
+) -> "tuple[dict[str, tuple[int, str]], dict[str, int]]":
+    """Aggregate per-slice ``(read_count, last_read_at)`` for ranking/retention.
+
+    v5 requirement #2: a read only counts when the same
+    ``(tool, session_id, slice_id)`` triple has a prior ``offered`` event, the
+    usage event has ``source == "read"`` and ``kind != "applied"``, and the
+    read timestamp is both later than the offer and within
+    ``[now - window_days, now]``. Missing/``(unknown)`` identity, unparsable
+    timestamps, future timestamps, out-of-window timestamps and reads with no
+    matching prior offer are excluded and tallied into the bounded
+    :data:`DIAG_KEYS` counters instead of raising or silently vanishing.
+    Read-only against the ledger; never writes to it.
+    """
+    led = memory_root / "runtime" / "ledger"
+    diagnostics = new_diagnostics()
+    window_start = now - timedelta(days=window_days)
+
+    offered_index: dict[tuple[str, str, str], list[datetime]] = {}
+    for event in iter_ledger_events(led / "offered.jsonl", diagnostics):
+        tool = event.get("tool")
+        session_id = event.get("session_id")
+        offered_list = event.get("offered")
+        if not isinstance(offered_list, list):
+            continue
+        offer_ts = parse_ts(event.get("ts"))
+        if offer_ts is None:
+            diagnostics["invalid_ts"] += 1
+            continue
+        for item in offered_list:
+            slice_id = item.get("sl_id") if isinstance(item, dict) else item
+            if not valid_identity(tool, session_id, slice_id):
+                _classify_missing_identity(diagnostics, tool, session_id, slice_id)
+                continue
+            key = (str(tool), str(session_id), str(slice_id))
+            offered_index.setdefault(key, []).append(offer_ts)
+
+    counts: dict[str, int] = {}
+    last_read: dict[str, datetime] = {}
+    for event in iter_ledger_events(led / "memory_usage.jsonl", diagnostics):
+        if event.get("source") != "read" or event.get("kind") == "applied":
+            continue
+        tool = event.get("tool")
+        session_id = event.get("session_id")
+        slice_id = event.get("sl_id")
+        if not valid_identity(tool, session_id, slice_id):
+            _classify_missing_identity(diagnostics, tool, session_id, slice_id)
+            continue
+        read_ts = parse_ts(event.get("ts"))
+        if read_ts is None:
+            diagnostics["invalid_ts"] += 1
+            continue
+        if read_ts > now:
+            diagnostics["future_event"] += 1
+            continue
+        if read_ts < window_start:
+            diagnostics["window_older"] += 1
+            continue
+        key = (str(tool), str(session_id), str(slice_id))
+        offer_times = offered_index.get(key)
+        if not offer_times or not any(offer_ts < read_ts for offer_ts in offer_times):
+            diagnostics["read_without_offered"] += 1
+            continue
+        sid = str(slice_id)
+        counts[sid] = counts.get(sid, 0) + 1
+        if sid not in last_read or read_ts > last_read[sid]:
+            last_read[sid] = read_ts
+
+    result = {
+        sid: (count, last_read[sid].isoformat().replace("+00:00", "Z"))
+        for sid, count in counts.items()
+    }
+    return result, diagnostics

--- a/paulsha_hippo/ledger/usage.py
+++ b/paulsha_hippo/ledger/usage.py
@@ -21,6 +21,8 @@ from typing import Iterator
 # the key set itself never grows, so counters stay bounded regardless of how
 # many distinct malformed inputs are seen.
 DIAG_KEYS = (
+    "io_error",
+    "utf8_decode_error",
     "json_decode_error",
     "non_object",
     "missing_tool",
@@ -56,20 +58,27 @@ def iter_ledger_events(path: Path, diagnostics: dict[str, int]) -> "Iterator[dic
     opened for reading here, so a bad read can never mutate it, and whatever
     lines were already readable are still yielded before/around the failure.
     """
-    if not path.exists():
-        return
     try:
-        handle = path.open("r", encoding="utf-8")
+        handle = path.open("rb")
+    except FileNotFoundError:
+        return
     except OSError:
+        diagnostics["io_error"] += 1
         return
     try:
         while True:
             try:
-                line = handle.readline()
-            except (OSError, UnicodeDecodeError):
+                raw_line = handle.readline()
+            except OSError:
+                diagnostics["io_error"] += 1
                 return
-            if line == "":
+            if raw_line == b"":
                 return
+            try:
+                line = raw_line.decode("utf-8")
+            except UnicodeDecodeError:
+                diagnostics["utf8_decode_error"] += 1
+                continue
             line = line.strip()
             if not line:
                 continue
@@ -104,14 +113,12 @@ def parse_ts(value: object) -> "datetime | None":
 
 def valid_identity(tool: object, session_id: object, slice_id: object) -> bool:
     """v5 BLOCKER #3: ``(unknown)``/blank tool, session or slice id can't identify anything."""
-    tool_str = str(tool or "").strip()
-    if not tool_str or tool_str == "(unknown)":
-        return False
-    if not str(session_id or "").strip():
-        return False
-    if not str(slice_id or "").strip():
-        return False
-    return True
+    values = (
+        str(tool or "").strip(),
+        str(session_id or "").strip(),
+        str(slice_id or "").strip(),
+    )
+    return all(value and value != "(unknown)" for value in values)
 
 
 def usage_boost(read_count: int) -> float:
@@ -126,7 +133,7 @@ def _classify_missing_identity(diagnostics: dict[str, int], tool: object,
     tool_str = str(tool or "").strip()
     if not tool_str or tool_str == "(unknown)":
         diagnostics["missing_tool"] += 1
-    elif not str(session_id or "").strip():
+    elif not str(session_id or "").strip() or str(session_id).strip() == "(unknown)":
         diagnostics["missing_session"] += 1
     else:
         diagnostics["missing_sl_id"] += 1
@@ -151,7 +158,7 @@ def collect_usage_reads(
     diagnostics = new_diagnostics()
     window_start = now - timedelta(days=window_days)
 
-    offered_index: dict[tuple[str, str, str], list[datetime]] = {}
+    offered_index: dict[tuple[str, str, str], datetime] = {}
     for event in iter_ledger_events(led / "offered.jsonl", diagnostics):
         tool = event.get("tool")
         session_id = event.get("session_id")
@@ -162,13 +169,21 @@ def collect_usage_reads(
         if offer_ts is None:
             diagnostics["invalid_ts"] += 1
             continue
+        if offer_ts > now:
+            diagnostics["future_event"] += 1
+            continue
+        if offer_ts < window_start:
+            diagnostics["window_older"] += 1
+            continue
         for item in offered_list:
             slice_id = item.get("sl_id") if isinstance(item, dict) else item
             if not valid_identity(tool, session_id, slice_id):
                 _classify_missing_identity(diagnostics, tool, session_id, slice_id)
                 continue
             key = (str(tool), str(session_id), str(slice_id))
-            offered_index.setdefault(key, []).append(offer_ts)
+            prior = offered_index.get(key)
+            if prior is None or offer_ts < prior:
+                offered_index[key] = offer_ts
 
     counts: dict[str, int] = {}
     last_read: dict[str, datetime] = {}
@@ -192,8 +207,8 @@ def collect_usage_reads(
             diagnostics["window_older"] += 1
             continue
         key = (str(tool), str(session_id), str(slice_id))
-        offer_times = offered_index.get(key)
-        if not offer_times or not any(offer_ts < read_ts for offer_ts in offer_times):
+        offer_ts = offered_index.get(key)
+        if offer_ts is None or offer_ts >= read_ts:
             diagnostics["read_without_offered"] += 1
             continue
         sid = str(slice_id)

--- a/paulsha_hippo/moc/search.py
+++ b/paulsha_hippo/moc/search.py
@@ -178,8 +178,14 @@ def _tags_fts_text(tags: object) -> "str | None":
     return None
 
 
-def build_index(memory_root: Path, link_weights: dict[str, int],
-                doc_corpus: "object | None" = None) -> dict[str, object]:
+def build_index(
+    memory_root: Path,
+    link_weights: dict[str, int],
+    doc_corpus: "object | None" = None,
+    *,
+    usage_now: "datetime | None" = None,
+    usage_window_days: int = usage_ledger.USAGE_BOOST_WINDOW_DAYS,
+) -> dict[str, object]:
     """建 retrieval index（temp DB + atomic replace）並回傳 coverage 報表。
 
     回傳 dict（跨批次契約 #6）：六欄 ``scanned / invalid_frontmatter /
@@ -211,12 +217,25 @@ def build_index(memory_root: Path, link_weights: dict[str, int],
     per-invocation 唯一暫存路徑 + atomic replace——讀者（search()）永遠
     只看到完整舊版或完整新版索引。
     """
+    effective_usage_now = usage_now or datetime.now(timezone.utc)
     with _index_write_lock(memory_root):
-        return _build_index_locked(memory_root, link_weights, doc_corpus)
+        return _build_index_locked(
+            memory_root,
+            link_weights,
+            doc_corpus,
+            usage_now=effective_usage_now,
+            usage_window_days=usage_window_days,
+        )
 
 
-def _build_index_locked(memory_root: Path, link_weights: dict[str, int],
-                        doc_corpus: "object | None") -> dict[str, object]:
+def _build_index_locked(
+    memory_root: Path,
+    link_weights: dict[str, int],
+    doc_corpus: "object | None",
+    *,
+    usage_now: datetime,
+    usage_window_days: int,
+) -> dict[str, object]:
     path = index_path(memory_root)
     path.parent.mkdir(parents=True, exist_ok=True)
     # 持鎖中無其他活 writer：目錄裡任何 *.tmp 都是 crash 殘留的半成品
@@ -259,7 +278,7 @@ def _build_index_locked(memory_root: Path, link_weights: dict[str, int],
         # same identity+window-matched aggregation janitor retention uses
         # (ledger.usage.collect_usage_reads); fail-soft/bounded, read-only.
         usage_reads, _usage_diag = usage_ledger.collect_usage_reads(
-            memory_root, datetime.now(timezone.utc)
+            memory_root, usage_now, window_days=usage_window_days
         )
 
         def flush_batch(rows: list[tuple[str, str, str, str, str, str, str]]) -> None:
@@ -494,13 +513,15 @@ def search(memory_root: Path, query: str, *, project: str | None, limit: int,
     # the usage columns at all), sorting takes the original legacy fast path
     # unchanged instead of computing a boost that would always be zero.
     if not has_usage_cols or not any(_row_read_count(r) > 0 for r in rows):
-        ranked = sorted(rows, key=lambda r: (r[3] - 0.1 * (r[4] or 0), r[3], r[0]))
+        # Any result without an effective usage signal follows the original
+        # one-key stable sort exactly, including pre-v5 schema fallback.
+        ranked = sorted(rows, key=lambda r: r[3] - 0.1 * (r[4] or 0))
     else:
         def _sort_key(row: tuple) -> tuple[float, float, str]:
             bm = row[3]
             base_score = bm - 0.1 * (row[4] or 0)
             boost = usage_ledger.usage_boost(_row_read_count(row))
-            return (base_score - boost, bm, row[0])
+            return (base_score - boost, base_score, row[0])
 
         ranked = sorted(rows, key=_sort_key)
     return [{"slice_id": r[0], "project": r[1], "title": r[2], "score": r[3], "path": r[6]}

--- a/paulsha_hippo/moc/search.py
+++ b/paulsha_hippo/moc/search.py
@@ -9,6 +9,7 @@ import secrets
 import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
 
@@ -17,6 +18,7 @@ from ..atomizer.publication import committed_publication_ids
 from ..importer.config import default_projects_path, load_projects_config
 from ..ledger import lifecycle
 from ..ledger import retrieval_set
+from ..ledger import usage as usage_ledger
 from ..noise import classify_noise, pool_exclude_reason
 from . import frontmatter_io as fio
 
@@ -244,10 +246,21 @@ def _build_index_locked(memory_root: Path, link_weights: dict[str, int],
     try:
         conn.execute("CREATE VIRTUAL TABLE slices_fts USING fts5("
                      "slice_id UNINDEXED, project, title, tags, body, tokenize='unicode61')")
+        # read_count/last_read_at (v5): usage-boost aggregation for search()
+        # ranking; NOT NULL DEFAULT 0 / NULL so any row insert without usage
+        # data (the common case) is an explicit zero-boost row, and legacy
+        # readers of this table via schema introspection can still fall back.
         conn.execute("CREATE TABLE slice_meta (slice_id TEXT PRIMARY KEY, project TEXT, "
-                     "captured_at TEXT, active INTEGER, link_weight INTEGER, path TEXT)")
+                     "captured_at TEXT, active INTEGER, link_weight INTEGER, path TEXT, "
+                     "read_count INTEGER NOT NULL DEFAULT 0, last_read_at TEXT)")
         knowledge = memory_root / "knowledge"
         events = lifecycle.read_events(memory_root)
+        # v5 requirement #2/#9: read_count/last_read_at per slice, fed from the
+        # same identity+window-matched aggregation janitor retention uses
+        # (ledger.usage.collect_usage_reads); fail-soft/bounded, read-only.
+        usage_reads, _usage_diag = usage_ledger.collect_usage_reads(
+            memory_root, datetime.now(timezone.utc)
+        )
 
         def flush_batch(rows: list[tuple[str, str, str, str, str, str, str]]) -> None:
             if not rows:
@@ -265,10 +278,12 @@ def _build_index_locked(memory_root: Path, link_weights: dict[str, int],
                  for sid, project, title, tags, body, _captured_at, _path in rows],
             )
             conn.executemany(
-                "INSERT INTO slice_meta VALUES (?,?,?,?,?,?)",
+                "INSERT INTO slice_meta VALUES (?,?,?,?,?,?,?,?)",
                 [
                     (sid, project, captured_at, 1 if sid in active else 0,
-                     link_weights.get(sid, 0), fpath)
+                     link_weights.get(sid, 0), fpath,
+                     usage_reads.get(sid, (0, None))[0],
+                     usage_reads.get(sid, (0, None))[1])
                     for sid, project, _title, _tags, _body, captured_at, fpath in rows
                 ],
             )
@@ -421,6 +436,28 @@ def _build_index_locked(memory_root: Path, link_weights: dict[str, int],
     }
 
 
+def _slice_meta_has_usage_columns(conn: sqlite3.Connection) -> bool:
+    """v5 requirement #8: schema-introspection fallback for older ``slice_meta``.
+
+    A DB built before v5 has no ``read_count``/``last_read_at`` columns; rather
+    than an in-place migration, ``search()`` detects that via
+    ``PRAGMA table_info`` and falls back to the legacy (no-boost) query.
+    """
+    try:
+        columns = conn.execute("PRAGMA table_info(slice_meta)").fetchall()
+    except sqlite3.DatabaseError:
+        return False
+    names = {row[1] for row in columns if len(row) > 1}
+    return "read_count" in names and "last_read_at" in names
+
+
+def _row_read_count(row: tuple) -> int:
+    if len(row) <= 7:
+        return 0
+    value = row[7]
+    return value if isinstance(value, int) and value > 0 else 0
+
+
 def search(memory_root: Path, query: str, *, project: str | None, limit: int,
            include_decayed: bool) -> list[dict]:
     path = index_path(memory_root)
@@ -428,8 +465,10 @@ def search(memory_root: Path, query: str, *, project: str | None, limit: int,
         raise SearchIndexError("search index not built; run the dream/moc pass first")
     conn = sqlite3.connect(path)
     try:
-        sql = ("SELECT f.slice_id, m.project, f.title, bm25(slices_fts) AS bm, "
-               "m.link_weight, m.active, m.path "
+        has_usage_cols = _slice_meta_has_usage_columns(conn)
+        usage_select = ", m.read_count, m.last_read_at" if has_usage_cols else ""
+        sql = (f"SELECT f.slice_id, m.project, f.title, bm25(slices_fts) AS bm, "
+               f"m.link_weight, m.active, m.path{usage_select} "
                "FROM slices_fts f JOIN slice_meta m ON m.slice_id = f.slice_id "
                "WHERE slices_fts MATCH ?")
         params: list[object] = [query]
@@ -446,6 +485,23 @@ def search(memory_root: Path, query: str, *, project: str | None, limit: int,
     # rank: lower bm25 is better; add link_weight boost. (recency omitted for determinism in MVP test.)
     # stable key: (adjusted_score, base_score, slice_id) so usage-boost ties
     # break on base_score/slice_id instead of falling back to insertion order.
-    ranked = sorted(rows, key=lambda r: (r[3] - 0.1 * (r[4] or 0), r[3], r[0]))
+    #
+    # v5 requirement #7: with usage_boost = min(0.04, 0.01*log2(1+read_count))
+    # subtracted from the base score, a >0.04 gap between two rows' base
+    # scores can never reverse (the boost is capped at 0.04 on each side), so
+    # no extra ordering guard is needed beyond the cap itself. When no row in
+    # the result set has a positive read_count (including legacy DBs without
+    # the usage columns at all), sorting takes the original legacy fast path
+    # unchanged instead of computing a boost that would always be zero.
+    if not has_usage_cols or not any(_row_read_count(r) > 0 for r in rows):
+        ranked = sorted(rows, key=lambda r: (r[3] - 0.1 * (r[4] or 0), r[3], r[0]))
+    else:
+        def _sort_key(row: tuple) -> tuple[float, float, str]:
+            bm = row[3]
+            base_score = bm - 0.1 * (row[4] or 0)
+            boost = usage_ledger.usage_boost(_row_read_count(row))
+            return (base_score - boost, bm, row[0])
+
+        ranked = sorted(rows, key=_sort_key)
     return [{"slice_id": r[0], "project": r[1], "title": r[2], "score": r[3], "path": r[6]}
             for r in ranked[:limit]]

--- a/paulsha_hippo/moc/search.py
+++ b/paulsha_hippo/moc/search.py
@@ -444,6 +444,8 @@ def search(memory_root: Path, query: str, *, project: str | None, limit: int,
     finally:
         conn.close()
     # rank: lower bm25 is better; add link_weight boost. (recency omitted for determinism in MVP test.)
-    ranked = sorted(rows, key=lambda r: (r[3] - 0.1 * (r[4] or 0)))
+    # stable key: (adjusted_score, base_score, slice_id) so usage-boost ties
+    # break on base_score/slice_id instead of falling back to insertion order.
+    ranked = sorted(rows, key=lambda r: (r[3] - 0.1 * (r[4] or 0), r[3], r[0]))
     return [{"slice_id": r[0], "project": r[1], "title": r[2], "score": r[3], "path": r[6]}
             for r in ranked[:limit]]

--- a/tests/test_janitor_rules.py
+++ b/tests/test_janitor_rules.py
@@ -203,5 +203,65 @@ class LintFieldExtractionTests(unittest.TestCase):
         self.assertEqual(rules.plan_lint([record]), [])
 
 
+class UsageRetentionRuleTests(unittest.TestCase):
+    """v5 requirement #9: ttl_base = max(captured_at, active_since_ts, valid last_read_at)."""
+
+    def test_ttl_base_prefers_last_read_at_over_captured_at(self):
+        rec = _rec(captured="2020-01-01T00:00:00Z")
+        base_dt, source = rules._ttl_base(rec, {}, last_read_at="2026-06-01T00:00:00Z")
+        self.assertEqual(source, "last_read_at")
+        self.assertEqual(base_dt.isoformat(), "2026-06-01T00:00:00+00:00")
+
+    def test_ttl_base_ignores_stale_last_read_at(self):
+        rec = _rec(captured="2026-05-01T00:00:00Z")
+        base_dt, source = rules._ttl_base(rec, {}, last_read_at="2020-01-01T00:00:00Z")
+        self.assertEqual(source, "captured_at")
+        self.assertEqual(base_dt.isoformat(), "2026-05-01T00:00:00+00:00")
+
+    def test_recent_read_keeps_active_record_from_decaying(self):
+        # captured_at is ancient, but a read three days ago (< 90d threshold)
+        # extends the retention clock so the record must not decay.
+        events = rules.plan_scan(
+            [_rec(captured="2020-01-01T00:00:00Z")], {}, {}, CFG, NOW, HASH,
+            source_path_exists=_PATH_OK, last_read_map={"sl-1": "2026-05-28T00:00:00Z"},
+        )
+        self.assertEqual(events, [])
+
+    def test_ttl_expired_detail_records_ttl_base_and_source(self):
+        events = rules.plan_scan(
+            [_rec(captured="2020-01-01T00:00:00Z")], {}, {}, CFG, NOW, HASH,
+            source_path_exists=_PATH_OK, last_read_map={"sl-1": "2020-06-01T00:00:00Z"},
+        )
+        self.assertEqual(len(events), 1)
+        detail = events[0]["detail"]
+        self.assertEqual(detail["source"], "last_read_at")
+        self.assertEqual(detail["ttl_base"], "2020-06-01T00:00:00+00:00")
+
+    def test_read_does_not_reactivate_a_decayed_record(self):
+        # v5 requirement #9: a fresh last_read_at must never reactivate an
+        # already-decayed slice; only reimport events (_decide_reactivation)
+        # may do that. plan_scan only consults last_read_map for active
+        # records, so a decayed record stays decayed regardless of reads.
+        lc_state = {"sl-1": {"state": "decayed", "since_ts": "2026-03-01T00:00:00Z"}}
+        events = rules.plan_scan(
+            [_rec()], {}, lc_state, CFG, NOW, HASH, source_path_exists=_PATH_OK,
+            last_read_map={"sl-1": "2026-05-30T00:00:00Z"},
+        )
+        self.assertEqual(events, [])
+
+    def test_superseded_still_wins_over_fresh_last_read_at(self):
+        # Priority order (superseded > source_invalid > ttl) must not change
+        # just because the record has a recent read.
+        old = _rec(rid="sl-old", captured="2026-05-30T00:00:00Z")
+        new = _rec(rid="sl-new", supersedes=("sl-old",), captured="2026-05-30T00:00:00Z", source="claude:s2")
+        events = rules.plan_scan(
+            [old, new], {}, {}, CFG, NOW, HASH, source_path_exists=_PATH_OK,
+            last_read_map={"sl-old": "2026-05-30T00:00:00Z"},
+        )
+        decayed = [e for e in events if e["record_id"] == "sl-old"]
+        self.assertEqual(len(decayed), 1)
+        self.assertEqual(decayed[0]["reason"], "superseded")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_janitor_rules.py
+++ b/tests/test_janitor_rules.py
@@ -218,6 +218,22 @@ class UsageRetentionRuleTests(unittest.TestCase):
         self.assertEqual(source, "captured_at")
         self.assertEqual(base_dt.isoformat(), "2026-05-01T00:00:00+00:00")
 
+    def test_future_last_read_at_cannot_extend_ttl(self):
+        events = rules.plan_scan(
+            [_rec(captured="2020-01-01T00:00:00Z")],
+            {},
+            {},
+            CFG,
+            NOW,
+            HASH,
+            source_path_exists=_PATH_OK,
+            last_read_map={"sl-1": "2027-01-01T00:00:00Z"},
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["reason"], "ttl_expired")
+        self.assertEqual(events[0]["detail"]["source"], "captured_at")
+
     def test_recent_read_keeps_active_record_from_decaying(self):
         # captured_at is ancient, but a read three days ago (< 90d threshold)
         # extends the retention clock so the record must not decay.

--- a/tests/test_janitor_scanner.py
+++ b/tests/test_janitor_scanner.py
@@ -130,5 +130,53 @@ class ScannerLintTests(unittest.TestCase):
             self.assertFalse([warning for warning in result["warnings"] if warning.startswith("lint:")])
 
 
+class UsageDiagnosticsWarningTests(unittest.TestCase):
+    """v5 requirement: usage-ledger diagnostics only warn when counter > 0."""
+
+    def test_clean_ledger_emits_no_usage_diagnostics_warning(self):
+        with TemporaryDirectory() as tmp:
+            root, kroot = _setup(tmp)
+            led = root / "runtime" / "ledger"
+            led.mkdir(parents=True)
+            (led / "offered.jsonl").write_text(
+                json.dumps({"tool": "claude-code", "session_id": "s1",
+                            "ts": "2026-05-20T00:00:00Z", "offered": [{"sl_id": "sl-1"}]}) + "\n",
+                encoding="utf-8",
+            )
+            (led / "memory_usage.jsonl").write_text(
+                json.dumps({"tool": "claude-code", "session_id": "s1", "sl_id": "sl-1",
+                            "source": "read", "ts": "2026-05-21T00:00:00Z"}) + "\n",
+                encoding="utf-8",
+            )
+            cfg, cfg_hash = janitor_config.load_config(override_path=None)
+            result = scanner.run_scan(root, knowledge_root=kroot, config=cfg, config_hash=cfg_hash,
+                                      now="2026-05-31T00:00:00Z", source_path_exists=lambda r: True)
+            self.assertFalse(
+                [w for w in result["warnings"] if w.startswith("usage ledger diagnostics")]
+            )
+
+    def test_malformed_usage_ledger_emits_single_bounded_warning(self):
+        with TemporaryDirectory() as tmp:
+            root, kroot = _setup(tmp)
+            led = root / "runtime" / "ledger"
+            led.mkdir(parents=True)
+            (led / "memory_usage.jsonl").write_text(
+                "not-json\n"
+                + json.dumps({"tool": "(unknown)", "session_id": "s1", "sl_id": "sl-1",
+                              "source": "read", "ts": "2026-05-21T00:00:00Z"}) + "\n",
+                encoding="utf-8",
+            )
+            cfg, cfg_hash = janitor_config.load_config(override_path=None)
+            result = scanner.run_scan(root, knowledge_root=kroot, config=cfg, config_hash=cfg_hash,
+                                      now="2026-05-31T00:00:00Z", source_path_exists=lambda r: True)
+            usage_warnings = [w for w in result["warnings"] if w.startswith("usage ledger diagnostics")]
+            self.assertEqual(len(usage_warnings), 1)
+            self.assertIn("json_decode_error", usage_warnings[0])
+            self.assertIn("missing_tool", usage_warnings[0])
+            # ledger itself must be untouched by the scan
+            content = (led / "memory_usage.jsonl").read_text(encoding="utf-8")
+            self.assertTrue(content.startswith("not-json\n"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ledger_usage.py
+++ b/tests/test_ledger_usage.py
@@ -1,0 +1,214 @@
+# tests/test_ledger_usage.py
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from paulsha_hippo.ledger import usage as usage_ledger
+
+
+class IterLedgerEventsStreamingTests(unittest.TestCase):
+    """v5 BLOCKER #1: no ``Path.read_text().splitlines()``, no whole-file list."""
+
+    def test_never_calls_path_read_text(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ledger.jsonl"
+            path.write_text('{"a":1}\n{"b":2}\n', encoding="utf-8")
+            with mock.patch.object(
+                Path, "read_text", side_effect=AssertionError("must not call Path.read_text")
+            ):
+                diag = usage_ledger.new_diagnostics()
+                events = list(usage_ledger.iter_ledger_events(path, diag))
+            self.assertEqual(events, [{"a": 1}, {"b": 2}])
+            self.assertEqual(diag, usage_ledger.new_diagnostics())
+
+    def test_large_ledger_streams_every_line(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "large.jsonl"
+            n = 20000
+            with path.open("w", encoding="utf-8") as fh:
+                for i in range(n):
+                    fh.write(json.dumps({"i": i}) + "\n")
+            diag = usage_ledger.new_diagnostics()
+            count = 0
+            for event in usage_ledger.iter_ledger_events(path, diag):
+                self.assertEqual(event["i"], count)
+                count += 1
+            self.assertEqual(count, n)
+            self.assertEqual(diag, usage_ledger.new_diagnostics())
+
+    def test_missing_file_yields_nothing(self):
+        with TemporaryDirectory() as tmp:
+            diag = usage_ledger.new_diagnostics()
+            events = list(usage_ledger.iter_ledger_events(Path(tmp) / "absent.jsonl", diag))
+            self.assertEqual(events, [])
+            self.assertEqual(diag, usage_ledger.new_diagnostics())
+
+
+class IterLedgerEventsFailSoftTests(unittest.TestCase):
+    """v5 BLOCKER #2/#4: malformed/non-object lines and I/O errors are fail-soft
+    and bounded, and reads never mutate the ledger."""
+
+    def test_malformed_and_non_object_lines_are_bounded_and_do_not_abort(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ledger.jsonl"
+            original = '{"ok":1}\nnot-json\n[1,2,3]\n\n{"ok":2}\n'
+            path.write_text(original, encoding="utf-8")
+            diag = usage_ledger.new_diagnostics()
+            events = list(usage_ledger.iter_ledger_events(path, diag))
+            self.assertEqual(events, [{"ok": 1}, {"ok": 2}])
+            self.assertEqual(diag["json_decode_error"], 1)
+            self.assertEqual(diag["non_object"], 1)
+            self.assertEqual(set(diag.keys()), set(usage_ledger.DIAG_KEYS))
+            # read-only: ledger content is untouched
+            self.assertEqual(path.read_text(encoding="utf-8"), original)
+
+    def test_open_oserror_is_fail_soft_and_does_not_mutate_ledger(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ledger.jsonl"
+            path.write_text('{"ok":1}\n', encoding="utf-8")
+            diag = usage_ledger.new_diagnostics()
+            with mock.patch.object(Path, "open", side_effect=OSError("boom")):
+                events = list(usage_ledger.iter_ledger_events(path, diag))
+            self.assertEqual(events, [])
+            self.assertEqual(path.read_text(encoding="utf-8"), '{"ok":1}\n')
+
+    def test_invalid_utf8_mid_file_is_fail_soft(self):
+        # A UnicodeDecodeError anywhere in the file must not raise out of
+        # iter_ledger_events (fail-soft); Python's buffered text reader may
+        # need to look ahead past a valid line to find the bad bytes, so the
+        # exact partial-recovery boundary isn't guaranteed — only that the
+        # generator terminates cleanly instead of propagating the exception.
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ledger.jsonl"
+            with path.open("wb") as fh:
+                fh.write(b'{"ok":1}\n')
+                fh.write(b"\xff\xfe not valid utf-8\n")
+            diag = usage_ledger.new_diagnostics()
+            events = list(usage_ledger.iter_ledger_events(path, diag))
+            self.assertIn(events, ([], [{"ok": 1}]))
+
+
+class CollectUsageReadsTests(unittest.TestCase):
+    """v5 requirement #2/#3: identity+window matched read_count/last_read_at
+    aggregation with bounded diagnostics for every exclusion reason."""
+
+    def test_bounded_diagnostics_and_valid_attribution(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            led = root / "runtime" / "ledger"
+            led.mkdir(parents=True)
+            now = datetime(2026, 7, 27, tzinfo=timezone.utc)
+
+            offered = [
+                {"tool": "claude-code", "session_id": "s1", "ts": "2026-07-20T00:00:00Z",
+                 "offered": [{"sl_id": "sl-a"}]},
+                {"tool": "(unknown)", "session_id": "s2", "ts": "2026-07-20T00:00:00Z",
+                 "offered": [{"sl_id": "sl-b"}]},
+            ]
+            (led / "offered.jsonl").write_text(
+                "\n".join(json.dumps(e) for e in offered) + "\n", encoding="utf-8"
+            )
+            usage = [
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                 "ts": "2026-07-21T00:00:00Z"},  # valid match
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                 "ts": "2026-07-21T01:00:00Z", "kind": "applied"},  # excluded: applied
+                {"tool": "(unknown)", "session_id": "s2", "sl_id": "sl-b", "source": "read",
+                 "ts": "2026-07-21T00:00:00Z"},  # missing_tool
+                {"tool": "claude-code", "session_id": "", "sl_id": "sl-c", "source": "read",
+                 "ts": "2026-07-21T00:00:00Z"},  # missing_session
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "", "source": "read",
+                 "ts": "2026-07-21T00:00:00Z"},  # missing_sl_id
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                 "ts": "not-a-timestamp"},  # invalid_ts
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                 "ts": "2026-07-28T00:00:00Z"},  # future_event
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                 "ts": "2026-01-01T00:00:00Z"},  # window_older
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-z", "source": "read",
+                 "ts": "2026-07-21T00:00:00Z"},  # read_without_offered
+            ]
+            (led / "memory_usage.jsonl").write_text(
+                "\n".join(json.dumps(e) for e in usage) + "\n", encoding="utf-8"
+            )
+
+            result, diag = usage_ledger.collect_usage_reads(root, now)
+
+            self.assertEqual(result, {"sl-a": (1, "2026-07-21T00:00:00Z")})
+            expected_diag = usage_ledger.new_diagnostics()
+            expected_diag.update({
+                "missing_tool": 2,
+                "missing_session": 1,
+                "missing_sl_id": 1,
+                "invalid_ts": 1,
+                "future_event": 1,
+                "window_older": 1,
+                "read_without_offered": 1,
+            })
+            self.assertEqual(diag, expected_diag)
+
+    def test_does_not_mutate_ledger_files(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            led = root / "runtime" / "ledger"
+            led.mkdir(parents=True)
+            offered_content = json.dumps(
+                {"tool": "claude-code", "session_id": "s1", "ts": "2026-07-20T00:00:00Z",
+                 "offered": [{"sl_id": "sl-a"}]}
+            ) + "\n"
+            usage_content = json.dumps(
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                 "ts": "2026-07-21T00:00:00Z"}
+            ) + "\n"
+            (led / "offered.jsonl").write_text(offered_content, encoding="utf-8")
+            (led / "memory_usage.jsonl").write_text(usage_content, encoding="utf-8")
+
+            usage_ledger.collect_usage_reads(root, datetime(2026, 7, 27, tzinfo=timezone.utc))
+
+            self.assertEqual((led / "offered.jsonl").read_text(encoding="utf-8"), offered_content)
+            self.assertEqual((led / "memory_usage.jsonl").read_text(encoding="utf-8"), usage_content)
+
+    def test_multiple_reads_aggregate_count_and_latest_last_read_at(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            led = root / "runtime" / "ledger"
+            led.mkdir(parents=True)
+            (led / "offered.jsonl").write_text(
+                json.dumps({"tool": "codex", "session_id": "s1", "ts": "2026-07-01T00:00:00Z",
+                            "offered": [{"sl_id": "sl-a"}]}) + "\n",
+                encoding="utf-8",
+            )
+            reads = [
+                {"tool": "codex", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                 "ts": "2026-07-02T00:00:00Z"},
+                {"tool": "codex", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                 "ts": "2026-07-05T00:00:00Z"},
+                {"tool": "codex", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                 "ts": "2026-07-03T00:00:00Z"},
+            ]
+            (led / "memory_usage.jsonl").write_text(
+                "\n".join(json.dumps(e) for e in reads) + "\n", encoding="utf-8"
+            )
+            result, _diag = usage_ledger.collect_usage_reads(
+                root, datetime(2026, 7, 27, tzinfo=timezone.utc)
+            )
+            self.assertEqual(result["sl-a"], (3, "2026-07-05T00:00:00Z"))
+
+
+class UsageBoostFormulaTests(unittest.TestCase):
+    def test_zero_read_count_has_zero_boost(self):
+        self.assertEqual(usage_ledger.usage_boost(0), 0.0)
+
+    def test_boost_grows_with_log2_and_caps_at_0_04(self):
+        self.assertAlmostEqual(usage_ledger.usage_boost(1), 0.01)
+        self.assertLess(usage_ledger.usage_boost(1), usage_ledger.usage_boost(3))
+        self.assertEqual(usage_ledger.usage_boost(10_000_000), 0.04)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ledger_usage.py
+++ b/tests/test_ledger_usage.py
@@ -1,7 +1,9 @@
 # tests/test_ledger_usage.py
 from __future__ import annotations
 
+import gc
 import json
+import tracemalloc
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -77,20 +79,29 @@ class IterLedgerEventsFailSoftTests(unittest.TestCase):
             self.assertEqual(events, [])
             self.assertEqual(path.read_text(encoding="utf-8"), '{"ok":1}\n')
 
+    def test_exists_oserror_is_fail_soft(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ledger.jsonl"
+            diag = usage_ledger.new_diagnostics()
+            with mock.patch.object(Path, "exists", side_effect=OSError("boom")):
+                self.assertEqual(
+                    list(usage_ledger.iter_ledger_events(path, diag)),
+                    [],
+                )
+
     def test_invalid_utf8_mid_file_is_fail_soft(self):
-        # A UnicodeDecodeError anywhere in the file must not raise out of
-        # iter_ledger_events (fail-soft); Python's buffered text reader may
-        # need to look ahead past a valid line to find the bad bytes, so the
-        # exact partial-recovery boundary isn't guaranteed — only that the
-        # generator terminates cleanly instead of propagating the exception.
+        # Decode must be per physical line: one poisoned row cannot make the
+        # text buffer discard valid rows before or after it.
         with TemporaryDirectory() as tmp:
             path = Path(tmp) / "ledger.jsonl"
             with path.open("wb") as fh:
                 fh.write(b'{"ok":1}\n')
                 fh.write(b"\xff\xfe not valid utf-8\n")
+                fh.write(b'{"ok":2}\n')
             diag = usage_ledger.new_diagnostics()
             events = list(usage_ledger.iter_ledger_events(path, diag))
-            self.assertIn(events, ([], [{"ok": 1}]))
+            self.assertEqual(events, [{"ok": 1}, {"ok": 2}])
+            self.assertEqual(diag["utf8_decode_error"], 1)
 
 
 class CollectUsageReadsTests(unittest.TestCase):
@@ -151,6 +162,103 @@ class CollectUsageReadsTests(unittest.TestCase):
                 "read_without_offered": 1,
             })
             self.assertEqual(diag, expected_diag)
+
+    def test_unknown_is_rejected_for_every_identity_component(self):
+        cases = (
+            ("(unknown)", "s1", "sl-a"),
+            ("codex", "(unknown)", "sl-a"),
+            ("codex", "s1", "(unknown)"),
+        )
+        for tool, session_id, slice_id in cases:
+            with self.subTest(tool=tool, session_id=session_id, slice_id=slice_id):
+                self.assertFalse(
+                    usage_ledger.valid_identity(tool, session_id, slice_id)
+                )
+
+    def test_out_of_window_and_future_offers_never_cross_match(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            led = root / "runtime" / "ledger"
+            led.mkdir(parents=True)
+            now = datetime(2026, 7, 27, tzinfo=timezone.utc)
+            offers = [
+                {
+                    "tool": "codex",
+                    "session_id": "old",
+                    "ts": "2026-01-01T00:00:00Z",
+                    "offered": [{"sl_id": "sl-old"}],
+                },
+                {
+                    "tool": "codex",
+                    "session_id": "future",
+                    "ts": "2026-07-28T00:00:00Z",
+                    "offered": [{"sl_id": "sl-future"}],
+                },
+            ]
+            reads = [
+                {
+                    "tool": "codex",
+                    "session_id": "old",
+                    "sl_id": "sl-old",
+                    "source": "read",
+                    "ts": "2026-07-21T00:00:00Z",
+                },
+                {
+                    "tool": "codex",
+                    "session_id": "future",
+                    "sl_id": "sl-future",
+                    "source": "read",
+                    "ts": "2026-07-21T00:00:00Z",
+                },
+            ]
+            (led / "offered.jsonl").write_text(
+                "\n".join(json.dumps(event) for event in offers) + "\n",
+                encoding="utf-8",
+            )
+            (led / "memory_usage.jsonl").write_text(
+                "\n".join(json.dumps(event) for event in reads) + "\n",
+                encoding="utf-8",
+            )
+
+            result, diag = usage_ledger.collect_usage_reads(root, now)
+
+            self.assertEqual(result, {})
+            self.assertEqual(diag["window_older"], 1)
+            self.assertEqual(diag["future_event"], 1)
+            self.assertEqual(diag["read_without_offered"], 2)
+
+    def test_repeated_offers_for_one_identity_use_bounded_memory(self):
+        def peak_for(offer_count: int) -> int:
+            with TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                led = root / "runtime" / "ledger"
+                led.mkdir(parents=True)
+                event = {
+                    "tool": "codex",
+                    "session_id": "s1",
+                    "ts": "2026-07-20T00:00:00Z",
+                    "offered": [{"sl_id": "sl-a"}],
+                }
+                with (led / "offered.jsonl").open("w", encoding="utf-8") as handle:
+                    for _ in range(offer_count):
+                        handle.write(json.dumps(event) + "\n")
+                (led / "memory_usage.jsonl").write_text("", encoding="utf-8")
+                gc.collect()
+                tracemalloc.start()
+                usage_ledger.collect_usage_reads(
+                    root, datetime(2026, 7, 27, tzinfo=timezone.utc)
+                )
+                _current, peak = tracemalloc.get_traced_memory()
+                tracemalloc.stop()
+                return peak
+
+        small_peak = peak_for(100)
+        large_peak = peak_for(20_000)
+        self.assertLess(
+            large_peak,
+            small_peak + 200_000,
+            (small_peak, large_peak),
+        )
 
     def test_does_not_mutate_ledger_files(self):
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory_usage_cli.py
+++ b/tests/test_memory_usage_cli.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import argparse
 import json
+from unittest import mock
 
-from paulsha_hippo.cli import _memory_usage
+from pathlib import Path
+
+from paulsha_hippo.cli import _load_usage_rows, _memory_usage, _read_usage_jsonl
 
 
 def test_memory_usage_read_based(tmp_path, capsys):
@@ -76,3 +79,35 @@ def test_memory_usage_text_mode_renders_applied_na(tmp_path, capsys):
     assert _memory_usage(args) == 0
     out = capsys.readouterr().out
     assert "tool=codex offered=1 read=0 applied=n/a" in out
+
+
+def test_read_usage_jsonl_never_calls_path_read_text(tmp_path):
+    # v5 BLOCKER #1 at the cli.py anchor: _read_usage_jsonl must stream via
+    # ledger.usage.iter_ledger_events, never Path.read_text().splitlines().
+    path = tmp_path / "offered.jsonl"
+    path.write_text(json.dumps({"ts": "2026-06-29T01:00:00Z"}) + "\n", encoding="utf-8")
+    with mock.patch.object(Path, "read_text", side_effect=AssertionError("must not read_text")):
+        events = _read_usage_jsonl(path, since=None)
+    assert events == [{"ts": "2026-06-29T01:00:00Z"}]
+
+
+def test_read_usage_jsonl_bounds_diagnostics_for_malformed_lines(tmp_path):
+    path = tmp_path / "memory_usage.jsonl"
+    path.write_text('{"ts":"2026-06-29T01:00:00Z"}\nnot-json\n[1,2]\n', encoding="utf-8")
+    from paulsha_hippo.ledger import usage as usage_ledger
+    diagnostics = usage_ledger.new_diagnostics()
+    events = _read_usage_jsonl(path, since=None, diagnostics=diagnostics)
+    assert events == [{"ts": "2026-06-29T01:00:00Z"}]
+    assert diagnostics["json_decode_error"] == 1
+    assert diagnostics["non_object"] == 1
+
+
+def test_load_usage_rows_returns_bounded_diagnostics_without_changing_output(tmp_path):
+    led = tmp_path / "runtime" / "ledger"
+    led.mkdir(parents=True)
+    (led / "offered.jsonl").write_text("not-json\n", encoding="utf-8")
+    offered_rows, used_rows, applied_rows, diagnostics = _load_usage_rows(tmp_path, since=None)
+    assert offered_rows == []
+    assert used_rows == []
+    assert applied_rows == []
+    assert diagnostics["json_decode_error"] == 1

--- a/tests/test_memory_usage_cli.py
+++ b/tests/test_memory_usage_cli.py
@@ -88,7 +88,8 @@ def test_read_usage_jsonl_never_calls_path_read_text(tmp_path):
     path.write_text(json.dumps({"ts": "2026-06-29T01:00:00Z"}) + "\n", encoding="utf-8")
     with mock.patch.object(Path, "read_text", side_effect=AssertionError("must not read_text")):
         events = _read_usage_jsonl(path, since=None)
-    assert events == [{"ts": "2026-06-29T01:00:00Z"}]
+        assert iter(events) is events
+        assert list(events) == [{"ts": "2026-06-29T01:00:00Z"}]
 
 
 def test_read_usage_jsonl_bounds_diagnostics_for_malformed_lines(tmp_path):
@@ -97,17 +98,42 @@ def test_read_usage_jsonl_bounds_diagnostics_for_malformed_lines(tmp_path):
     from paulsha_hippo.ledger import usage as usage_ledger
     diagnostics = usage_ledger.new_diagnostics()
     events = _read_usage_jsonl(path, since=None, diagnostics=diagnostics)
-    assert events == [{"ts": "2026-06-29T01:00:00Z"}]
+    assert iter(events) is events
+    assert list(events) == [{"ts": "2026-06-29T01:00:00Z"}]
     assert diagnostics["json_decode_error"] == 1
     assert diagnostics["non_object"] == 1
 
 
-def test_load_usage_rows_returns_bounded_diagnostics_without_changing_output(tmp_path):
+def test_load_usage_rows_returns_raw_iterators_and_bounded_diagnostics(tmp_path):
     led = tmp_path / "runtime" / "ledger"
     led.mkdir(parents=True)
     (led / "offered.jsonl").write_text("not-json\n", encoding="utf-8")
-    offered_rows, used_rows, applied_rows, diagnostics = _load_usage_rows(tmp_path, since=None)
-    assert offered_rows == []
-    assert used_rows == []
-    assert applied_rows == []
+    (led / "memory_usage.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-07-10T01:05:00Z",
+                "session_id": "s1",
+                "tool": "codex",
+                "sl_id": "sl-a",
+                "source": "read",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    offered_rows, usage_rows, diagnostics = _load_usage_rows(tmp_path, since=None)
+
+    assert iter(offered_rows) is offered_rows
+    assert iter(usage_rows) is usage_rows
+    assert list(offered_rows) == []
+    assert list(usage_rows) == [
+        {
+            "ts": "2026-07-10T01:05:00Z",
+            "session_id": "s1",
+            "tool": "codex",
+            "sl_id": "sl-a",
+            "source": "read",
+        }
+    ]
     assert diagnostics["json_decode_error"] == 1

--- a/tests/test_moc_search.py
+++ b/tests/test_moc_search.py
@@ -392,7 +392,7 @@ class UsageBoostRankingTests(unittest.TestCase):
             _slice(root, "sl-1", "proj", "alpha", "alpha body")
             led = root / "runtime" / "ledger"
             led.mkdir(parents=True)
-            now = datetime.now(timezone.utc)
+            now = datetime(2026, 7, 27, tzinfo=timezone.utc)
             offer_ts = (now - timedelta(days=1)).isoformat().replace("+00:00", "Z")
             read_ts_1 = (now - timedelta(hours=12)).isoformat().replace("+00:00", "Z")
             read_ts_2 = (now - timedelta(hours=6)).isoformat().replace("+00:00", "Z")
@@ -410,7 +410,12 @@ class UsageBoostRankingTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            search.build_index(root, link_weights={})
+            search.build_index(
+                root,
+                link_weights={},
+                usage_now=now,
+                usage_window_days=30,
+            )
 
             conn = sqlite3.connect(search.index_path(root))
             try:
@@ -489,6 +494,49 @@ class UsageBoostRankingTests(unittest.TestCase):
 
             self.assertEqual([item["slice_id"] for item in hits], ["sl-better", "sl-worse"])
 
+    def test_usage_boost_exact_tie_uses_base_score_then_slice_id(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            index_path = search.index_path(root)
+            index_path.parent.mkdir(parents=True, exist_ok=True)
+            index_path.write_text("mock-db", encoding="utf-8")
+
+            # Both rows have base_score=0.10, boost=0.01 and adjusted=0.09.
+            # Raw BM25 differs, so using BM25 as the second key incorrectly
+            # puts sl-z first instead of falling through to slice_id.
+            data_rows = [
+                ("sl-a", "proj", "a", 0.20, 1, 1, "/k/a.md", 1, None),
+                ("sl-z", "proj", "z", 0.10, 0, 1, "/k/z.md", 1, None),
+            ]
+            fake_conn = self._mock_usage_search(self._USAGE_PRAGMA_ROWS, data_rows)
+
+            with mock.patch(
+                "paulsha_hippo.moc.search.sqlite3.connect", return_value=fake_conn,
+            ):
+                hits = search.search(
+                    root, "usage", project=None, limit=10, include_decayed=True
+                )
+
+            self.assertEqual([item["slice_id"] for item in hits], ["sl-a", "sl-z"])
+
+    def test_build_index_passes_injected_usage_clock_and_window(self):
+        fixed_now = datetime(2026, 7, 27, tzinfo=timezone.utc)
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with mock.patch.object(
+                search.usage_ledger,
+                "collect_usage_reads",
+                wraps=search.usage_ledger.collect_usage_reads,
+            ) as collect:
+                search.build_index(
+                    root,
+                    link_weights={},
+                    usage_now=fixed_now,
+                    usage_window_days=7,
+                )
+
+            collect.assert_called_once_with(root, fixed_now, window_days=7)
+
     def test_no_positive_read_count_takes_legacy_fast_path(self):
         # Even with usage columns present, an all-zero read_count result set
         # must produce identical ordering to the pre-v5 legacy formula.
@@ -510,6 +558,33 @@ class UsageBoostRankingTests(unittest.TestCase):
                 hits = search.search(root, "usage", project=None, limit=10, include_decayed=True)
 
             self.assertEqual([item["slice_id"] for item in hits], ["sl-low", "sl-high"])
+
+    def test_no_boost_base_score_tie_preserves_legacy_input_order(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            index_path = search.index_path(root)
+            index_path.parent.mkdir(parents=True, exist_ok=True)
+            index_path.write_text("mock-db", encoding="utf-8")
+
+            # Equal legacy base score (0.10). The legacy one-key stable sort
+            # preserves query order; raw BM25/slice-id tie-breaks change it.
+            data_rows = [
+                ("sl-first", "proj", "first", 0.20, 1, 1, "/k/first.md", 0, None),
+                ("sl-second", "proj", "second", 0.10, 0, 1, "/k/second.md", 0, None),
+            ]
+            fake_conn = self._mock_usage_search(self._USAGE_PRAGMA_ROWS, data_rows)
+
+            with mock.patch(
+                "paulsha_hippo.moc.search.sqlite3.connect", return_value=fake_conn,
+            ):
+                hits = search.search(
+                    root, "usage", project=None, limit=10, include_decayed=True
+                )
+
+            self.assertEqual(
+                [item["slice_id"] for item in hits],
+                ["sl-first", "sl-second"],
+            )
 
 
 class AtomicCoveragePublishTests(unittest.TestCase):

--- a/tests/test_moc_search.py
+++ b/tests/test_moc_search.py
@@ -33,6 +33,34 @@ class SearchTests(unittest.TestCase):
             self.assertEqual([h["slice_id"] for h in hits], ["sl-1"])
             self.assertIn("project", hits[0])
 
+    def test_search_stable_sort_uses_base_score_before_slice_id(self):
+        # v5 plan BLOCKER #7：有 usage boost 時排序鍵須為
+        # (adjusted_score, base_score, slice_id)，同分時以 base_score 決勝，
+        # 而非退回目前實作僅用 (bm - 0.1*link_weight) 單一鍵造成的插入序。
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            index_path = search.index_path(root)
+            index_path.parent.mkdir(parents=True, exist_ok=True)
+            index_path.write_text("mock-db", encoding="utf-8")
+
+            # Same adjusted score (0.0), but different base score.
+            rows = [
+                ("sl-high", "proj", "high", 0.10, 1, 1, "/k/high.md"),
+                ("sl-low", "proj", "low", 0.00, 0, 1, "/k/low.md"),
+            ]
+            cursor = mock.MagicMock()
+            cursor.fetchall.return_value = rows
+            fake_conn = mock.MagicMock()
+            fake_conn.execute.return_value = cursor
+
+            with mock.patch(
+                "paulsha_hippo.moc.search.sqlite3.connect",
+                return_value=fake_conn,
+            ):
+                hits = search.search(root, "usage", project=None, limit=10, include_decayed=True)
+
+            self.assertEqual([item["slice_id"] for item in hits], ["sl-low", "sl-high"])
+
     def test_missing_index_raises(self):
         with TemporaryDirectory() as tmp:
             with self.assertRaises(search.SearchIndexError):

--- a/tests/test_moc_search.py
+++ b/tests/test_moc_search.py
@@ -6,6 +6,7 @@ import sqlite3
 import threading
 import time
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
@@ -357,6 +358,158 @@ class SearchTests(unittest.TestCase):
                 )
             )
         return rows
+
+
+class UsageBoostRankingTests(unittest.TestCase):
+    """v5 requirement #7/#8: usage_boost ranking, 0.04 bound, legacy DB fallback."""
+
+    def test_legacy_db_without_usage_columns_falls_back(self):
+        # v5 requirement #8: a pre-v5 slice_meta (no read_count/last_read_at)
+        # must not crash search() — schema introspection detects the missing
+        # columns and falls back to the original 6-column query.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            index_path = search.index_path(root)
+            index_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(index_path)
+            conn.execute("CREATE VIRTUAL TABLE slices_fts USING fts5("
+                         "slice_id UNINDEXED, project, title, tags, body, tokenize='unicode61')")
+            conn.execute("CREATE TABLE slice_meta (slice_id TEXT PRIMARY KEY, project TEXT, "
+                         "captured_at TEXT, active INTEGER, link_weight INTEGER, path TEXT)")
+            conn.execute("INSERT INTO slices_fts VALUES (?,?,?,?,?)",
+                         ("sl-1", "proj", "alpha", "", "alpha body"))
+            conn.execute("INSERT INTO slice_meta VALUES (?,?,?,?,?,?)",
+                         ("sl-1", "proj", "2026-01-01T00:00:00Z", 1, 0, "/k/alpha.md"))
+            conn.commit()
+            conn.close()
+
+            hits = search.search(root, "alpha", project=None, limit=5, include_decayed=True)
+            self.assertEqual([h["slice_id"] for h in hits], ["sl-1"])
+
+    def test_build_index_populates_read_count_and_last_read_at(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _slice(root, "sl-1", "proj", "alpha", "alpha body")
+            led = root / "runtime" / "ledger"
+            led.mkdir(parents=True)
+            now = datetime.now(timezone.utc)
+            offer_ts = (now - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+            read_ts_1 = (now - timedelta(hours=12)).isoformat().replace("+00:00", "Z")
+            read_ts_2 = (now - timedelta(hours=6)).isoformat().replace("+00:00", "Z")
+            (led / "offered.jsonl").write_text(
+                json.dumps({"tool": "claude-code", "session_id": "s1", "ts": offer_ts,
+                            "offered": [{"sl_id": "sl-1"}]}) + "\n",
+                encoding="utf-8",
+            )
+            (led / "memory_usage.jsonl").write_text(
+                "\n".join(
+                    json.dumps({"tool": "claude-code", "session_id": "s1", "sl_id": "sl-1",
+                                "source": "read", "ts": ts})
+                    for ts in (read_ts_1, read_ts_2)
+                ) + "\n",
+                encoding="utf-8",
+            )
+
+            search.build_index(root, link_weights={})
+
+            conn = sqlite3.connect(search.index_path(root))
+            try:
+                row = conn.execute(
+                    "SELECT read_count, last_read_at FROM slice_meta WHERE slice_id = ?",
+                    ("sl-1",),
+                ).fetchone()
+            finally:
+                conn.close()
+            self.assertEqual(row[0], 2)
+            self.assertEqual(row[1], read_ts_2)
+
+    def _mock_usage_search(self, pragma_rows, data_rows):
+        def fake_execute(sql, params=None):
+            cursor = mock.MagicMock()
+            if "PRAGMA table_info" in sql:
+                cursor.fetchall.return_value = pragma_rows
+            else:
+                cursor.fetchall.return_value = data_rows
+            return cursor
+
+        fake_conn = mock.MagicMock()
+        fake_conn.execute.side_effect = fake_execute
+        return fake_conn
+
+    _USAGE_PRAGMA_ROWS = [
+        (0, "slice_id", "TEXT", 0, None, 1),
+        (1, "project", "TEXT", 0, None, 0),
+        (2, "captured_at", "TEXT", 0, None, 0),
+        (3, "active", "INTEGER", 0, None, 0),
+        (4, "link_weight", "INTEGER", 0, None, 0),
+        (5, "path", "TEXT", 0, None, 0),
+        (6, "read_count", "INTEGER", 1, "0", 0),
+        (7, "last_read_at", "TEXT", 0, None, 0),
+    ]
+
+    def test_usage_boost_orders_read_slice_ahead_of_equal_base_score(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            index_path = search.index_path(root)
+            index_path.parent.mkdir(parents=True, exist_ok=True)
+            index_path.write_text("mock-db", encoding="utf-8")
+
+            data_rows = [
+                ("sl-a", "proj", "a", 0.00, 0, 1, "/k/a.md", 0, None),
+                ("sl-b", "proj", "b", 0.00, 0, 1, "/k/b.md", 100, "2026-07-20T00:00:00Z"),
+            ]
+            fake_conn = self._mock_usage_search(self._USAGE_PRAGMA_ROWS, data_rows)
+
+            with mock.patch(
+                "paulsha_hippo.moc.search.sqlite3.connect", return_value=fake_conn,
+            ):
+                hits = search.search(root, "usage", project=None, limit=10, include_decayed=True)
+
+            self.assertEqual([item["slice_id"] for item in hits], ["sl-b", "sl-a"])
+
+    def test_usage_boost_never_reverses_gt_0_04_base_score_gap(self):
+        # v5 requirement #7: usage_boost is capped at 0.04, so a >0.04 gap
+        # between base scores can never be reversed by the boost.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            index_path = search.index_path(root)
+            index_path.parent.mkdir(parents=True, exist_ok=True)
+            index_path.write_text("mock-db", encoding="utf-8")
+
+            data_rows = [
+                ("sl-worse", "proj", "w", 0.05, 0, 1, "/k/w.md", 10_000_000, "2026-07-20T00:00:00Z"),
+                ("sl-better", "proj", "b", 0.00, 0, 1, "/k/b.md", 0, None),
+            ]
+            fake_conn = self._mock_usage_search(self._USAGE_PRAGMA_ROWS, data_rows)
+
+            with mock.patch(
+                "paulsha_hippo.moc.search.sqlite3.connect", return_value=fake_conn,
+            ):
+                hits = search.search(root, "usage", project=None, limit=10, include_decayed=True)
+
+            self.assertEqual([item["slice_id"] for item in hits], ["sl-better", "sl-worse"])
+
+    def test_no_positive_read_count_takes_legacy_fast_path(self):
+        # Even with usage columns present, an all-zero read_count result set
+        # must produce identical ordering to the pre-v5 legacy formula.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            index_path = search.index_path(root)
+            index_path.parent.mkdir(parents=True, exist_ok=True)
+            index_path.write_text("mock-db", encoding="utf-8")
+
+            data_rows = [
+                ("sl-high", "proj", "high", 0.10, 1, 1, "/k/high.md", 0, None),
+                ("sl-low", "proj", "low", 0.00, 0, 1, "/k/low.md", 0, None),
+            ]
+            fake_conn = self._mock_usage_search(self._USAGE_PRAGMA_ROWS, data_rows)
+
+            with mock.patch(
+                "paulsha_hippo.moc.search.sqlite3.connect", return_value=fake_conn,
+            ):
+                hits = search.search(root, "usage", project=None, limit=10, include_decayed=True)
+
+            self.assertEqual([item["slice_id"] for item in hits], ["sl-low", "sl-high"])
 
 
 class AtomicCoveragePublishTests(unittest.TestCase):

--- a/tests/test_moc_search.py
+++ b/tests/test_moc_search.py
@@ -44,15 +44,34 @@ class SearchTests(unittest.TestCase):
             index_path.parent.mkdir(parents=True, exist_ok=True)
             index_path.write_text("mock-db", encoding="utf-8")
 
-            # Same adjusted score (0.0), but different base score.
+            # Same adjusted score (0.0), but different base score. This must
+            # exercise the real usage-schema path rather than accidentally
+            # testing the no-boost legacy fallback.
             rows = [
-                ("sl-high", "proj", "high", 0.10, 1, 1, "/k/high.md"),
-                ("sl-low", "proj", "low", 0.00, 0, 1, "/k/low.md"),
+                ("sl-high", "proj", "high", 0.14, 1, 1, "/k/high.md", 15, None),
+                ("sl-low", "proj", "low", 0.00, 0, 1, "/k/low.md", 0, None),
             ]
-            cursor = mock.MagicMock()
-            cursor.fetchall.return_value = rows
+
+            pragma_rows = [
+                (0, "slice_id", "TEXT", 0, None, 1),
+                (1, "project", "TEXT", 0, None, 0),
+                (2, "captured_at", "TEXT", 0, None, 0),
+                (3, "active", "INTEGER", 0, None, 0),
+                (4, "link_weight", "INTEGER", 0, None, 0),
+                (5, "path", "TEXT", 0, None, 0),
+                (6, "read_count", "INTEGER", 1, "0", 0),
+                (7, "last_read_at", "TEXT", 0, None, 0),
+            ]
+
+            def fake_execute(sql, params=None):
+                cursor = mock.MagicMock()
+                cursor.fetchall.return_value = (
+                    pragma_rows if "PRAGMA table_info" in sql else rows
+                )
+                return cursor
+
             fake_conn = mock.MagicMock()
-            fake_conn.execute.return_value = cursor
+            fake_conn.execute.side_effect = fake_execute
 
             with mock.patch(
                 "paulsha_hippo.moc.search.sqlite3.connect",
@@ -547,7 +566,7 @@ class UsageBoostRankingTests(unittest.TestCase):
             index_path.write_text("mock-db", encoding="utf-8")
 
             data_rows = [
-                ("sl-high", "proj", "high", 0.10, 1, 1, "/k/high.md", 0, None),
+                ("sl-high", "proj", "high", 0.20, 1, 1, "/k/high.md", 0, None),
                 ("sl-low", "proj", "low", 0.00, 0, 1, "/k/low.md", 0, None),
             ]
             fake_conn = self._mock_usage_search(self._USAGE_PRAGMA_ROWS, data_rows)


### PR DESCRIPTION
## 摘要

- 將合法且可歸因的 `offered → read` 聚合為 per-slice `read_count`／`last_read_at`，支援可注入 UTC 時鐘與窗口。
- retrieval ranking 加入上限 0.04 的 deterministic usage boost；無有效 read 時維持 legacy stable ordering。
- janitor 以有效 `last_read_at` 延長 active slice TTL，保留 superseded/source-invalid 優先序，拒絕 future evidence。
- ledger 與 CLI 改為逐行 fail-soft iterator／compact aggregates，補齊 operator docs、OpenSpec 與 changelog。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

驗證證據：

- focused issue #41 + issue #18 funnel：`101 passed, 3 subtests passed`
- local canonical preflight：`PREFLIGHT PASS`（包含 OpenSpec strict、完整 `tests/` 與 clean-wheel installed fixture）
- `git diff --check`：通過

## 風險與回復

- 不遷移或改寫 append-only runtime ledger；舊 retrieval DB 以 schema introspection fallback。
- index 仍使用既有 temp DB、flock 與 atomic replace；可回退本 PR merge commit 並重建 index。
- `VERSION` 維持 `0.1.1`，本 PR 不觸發 release 或 live deployment。

Closes #41