### PR TITLE
fix(dream): 修復 ledger 撕裂行令 dream 永久 partial，並修 health 指標假陽性

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -14,3 +14,21 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/plans/2026-07-15-issue-34-atomization-release.md'
     excludes: []
+  issue-64-ledger-torn-line-repair:
+    title: 'issue-64-ledger-torn-line-repair'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-hippo#64'
+      - kind: openspec
+        ref: 'issue-64-ledger-torn-line-repair'
+      - kind: path
+        ref: 'openspec/changes/issue-64-ledger-torn-line-repair/proposal.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-design.md'
+      - kind: path
+        ref: 'docs/superpowers/plans/2026-07-27-issue-64-ledger-torn-line-repair.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/issue-64-ledger-torn-line-repair/todo.md'
+    excludes: []

--- a/changelog.d/64-ledger-torn-line-repair.md
+++ b/changelog.d/64-ledger-torn-line-repair.md
@@ -1,0 +1,9 @@
+### Fixed
+- ledger 撕裂行（嵌入 NUL 位元組的 JSONL 行）不再讓 janitor 每輪回報壞行、使
+  `hippo dream run` 永久停在 `partial`。新增 `hippo doctor` 的 ledger 完整性檢查與
+  `hippo ledger repair`（預設 dry-run，`--apply` 才寫入）：可救回的行原地救回（先備份、
+  同目錄 temp + fsync + 原子替換、只移除 NUL、其餘位元組逐一不變、冪等），不可救回的行
+  原樣保留並記入 `runtime/ledger/<name>.jsonl.quarantine`，janitor 的壞行計數排除已隔離行
+  （清單不可解析時 fail-closed）。
+- dream health 的 `invalid_frontmatter` 不再把生成的 MOC 索引檔當成缺欄位的 slice。改以
+  frontmatter `memory_layer: moc` 判別而非檔名慣例；該指標先前恆等於 MOC 檔數而無法歸零。

--- a/docs/superpowers/plans/2026-07-27-issue-64-ledger-torn-line-repair.md
+++ b/docs/superpowers/plans/2026-07-27-issue-64-ledger-torn-line-repair.md
@@ -1,3 +1,8 @@
+---
+status: accepted
+work_item: issue-64-ledger-torn-line-repair
+---
+
 # Ledger 撕裂行修復與 health 假陽性 Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-07-27-issue-64-ledger-torn-line-repair.md
+++ b/docs/superpowers/plans/2026-07-27-issue-64-ledger-torn-line-repair.md
@@ -1,0 +1,1076 @@
+# Ledger 撕裂行修復與 health 假陽性 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓 append-only ledger 的撕裂行可被偵測、可救回、可隔離，使 `hippo dream run` 不再因一行 60 天前的壞資料永久停在 `partial`，並修正 health `invalid_frontmatter` 因生成的 MOC 索引檔而恆不歸零的假陽性。
+
+**Architecture:** 新增 `paulsha_hippo/ledger/integrity.py` 作為單一責任模組，負責「行分類 / 原子修復 / quarantine 讀寫」三件事，不知道 janitor 與 doctor 的存在。消費端各自接上：`import_log.read_import_records_tolerant` 讀 quarantine 以排除已知壞行、`ops.run_doctor` 印出掃描結果、`cli` 註冊 `ledger repair` 子命令。`ledger/dream.py` 的 health 掃描獨立修一個 MOC 排除條件。
+
+**Tech Stack:** Python 3.12、標準庫（`json` / `hashlib` / `os` / `pathlib`）、pytest、argparse。無新增外部相依。
+
+## Global Constraints
+
+- 語言：PR 標題、內文、commit message、changelog 碎片一律 zh-tw（repo 屬 `github.com/hamanpaul/*`）。
+- `VERSION` 維持 `0.1.1`，本 PR 非 release PR，不得變動。
+- 必須新增 `changelog.d/64-ledger-torn-line-repair.md` 碎片（R-09）。
+- 分支已建立為 `feature/64-ledger-torn-line-repair`；不得直接 commit 到 `main`。
+- PR body 必須含 `Closes #64`（R-17）。
+- 不得變更 `paulsha_hippo/dream/orchestrator.py` 的 warning → partial 判定語意。
+- 所有寫入 ledger 的路徑必須：先備份 → 同目錄 temp → `fsync` → `os.replace`。
+- 行雜湊的正規定義（寫入端與讀取端必須一致）：`sha256(line.encode("utf-8"))`，其中 `line` 是 `content.splitlines()` 的元素，**不含結尾換行、不做 strip**。
+
+---
+
+### Task 1: ledger 行分類核心
+
+**Files:**
+- Create: `paulsha_hippo/ledger/integrity.py`
+- Test: `tests/test_ledger_integrity.py`
+
+**Interfaces:**
+- Consumes: 無（本 plan 的第一個任務）
+- Produces:
+  - `line_sha256(line: str) -> str`
+  - `classify_line(line: str) -> tuple[str, str]` — 回傳 `(classification, reason)`，classification 為 `"ok"` / `"recoverable"` / `"unrecoverable"`
+  - `NUL: str`、`QUARANTINE_SUFFIX: str`
+
+**設計要點：** `read_import_records_tolerant` 目前把**空白行也計為 bad line**。若分類把空白行當 `ok`，「修完後 janitor 計數歸零」這個不變量就不成立。因此空白行歸類為 `unrecoverable`、reason `blank`，走 quarantine 讓 janitor 停止回報，而不是假裝它正常。
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_ledger_integrity.py
+import json
+
+from paulsha_hippo.ledger import integrity
+
+
+def test_classify_ok_line():
+    line = json.dumps({"status": "written"}, sort_keys=True)
+    assert integrity.classify_line(line) == ("ok", "")
+
+
+def test_classify_nul_torn_line_is_recoverable():
+    payload = json.dumps({"status": "written", "id": "abc"}, sort_keys=True)
+    torn = payload[:10] + "\x00" * 577 + payload[10:]
+    assert integrity.classify_line(torn) == ("recoverable", "nul-torn")
+
+
+def test_classify_blank_line_is_unrecoverable_blank():
+    assert integrity.classify_line("") == ("unrecoverable", "blank")
+    assert integrity.classify_line("   ") == ("unrecoverable", "blank")
+
+
+def test_classify_truncated_json_is_unrecoverable():
+    assert integrity.classify_line('{"status": "writ') == ("unrecoverable", "unparseable")
+
+
+def test_classify_all_nul_line_is_unrecoverable():
+    assert integrity.classify_line("\x00" * 32) == ("unrecoverable", "blank")
+
+
+def test_line_sha256_is_over_raw_line_without_strip():
+    import hashlib
+
+    line = '  {"a": 1}  '
+    assert integrity.line_sha256(line) == hashlib.sha256(line.encode("utf-8")).hexdigest()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'paulsha_hippo.ledger.integrity'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# paulsha_hippo/ledger/integrity.py
+"""Append-only ledger 的位元組層完好性：撕裂行分類、原子修復、quarantine。
+
+本模組只認識 JSONL 檔案與行，不知道 janitor / doctor / dream 的存在。
+消費端自行接上（issue #64）。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+NUL = "\x00"
+QUARANTINE_SUFFIX = ".quarantine"
+
+
+def line_sha256(line: str) -> str:
+    """行的正規雜湊：不含結尾換行、不做 strip，寫入端與讀取端共用同一定義。"""
+    return hashlib.sha256(line.encode("utf-8")).hexdigest()
+
+
+def classify_line(line: str) -> tuple[str, str]:
+    """回傳 (classification, reason)。
+
+    classification 為 "ok" / "recoverable" / "unrecoverable"。空白行歸為
+    unrecoverable：既有 reader 也把空白行計為 bad line，若視為 ok 則
+    「修復後壞行計數歸零」的不變量不成立。
+    """
+    stripped = line.strip().replace(NUL, "").strip()
+    if not stripped:
+        return ("unrecoverable", "blank")
+
+    candidate = line.strip()
+    try:
+        json.loads(candidate)
+    except json.JSONDecodeError:
+        pass
+    else:
+        return ("ok", "")
+
+    try:
+        json.loads(stripped)
+    except json.JSONDecodeError:
+        return ("unrecoverable", "unparseable")
+    return ("recoverable", "nul-torn")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -v`
+Expected: PASS（6 passed）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paulsha_hippo/ledger/integrity.py tests/test_ledger_integrity.py
+git commit -m "feat(ledger): 撕裂行分類核心
+
+Refs #64"
+```
+
+---
+
+### Task 2: 檔案與目錄掃描（唯讀）
+
+**Files:**
+- Modify: `paulsha_hippo/ledger/integrity.py`
+- Test: `tests/test_ledger_integrity.py`
+
+**Interfaces:**
+- Consumes: `classify_line`、`line_sha256`（Task 1）
+- Produces:
+  - `LineFinding` dataclass，欄位 `line_no: int`（1-indexed）、`sha256: str`、`classification: str`、`reason: str`
+  - `scan_file(path: Path) -> list[LineFinding]` — 只回傳非 `ok` 的行
+  - `scan_ledger_dir(memory_root: Path) -> dict[str, list[LineFinding]]` — key 為檔名（非完整路徑），只含有壞行的檔
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# 追加到 tests/test_ledger_integrity.py
+import hashlib
+from pathlib import Path
+
+
+def _write_ledger(tmp_path: Path, name: str, lines: list[str]) -> Path:
+    path = tmp_path / "runtime" / "ledger" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_scan_file_reports_line_numbers_and_classification(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:4] + "\x00" * 8 + good[4:]
+    path = _write_ledger(tmp_path, "import.jsonl", [good, torn, '{"n": '])
+
+    findings = integrity.scan_file(path)
+
+    assert [f.line_no for f in findings] == [2, 3]
+    assert findings[0].classification == "recoverable"
+    assert findings[0].reason == "nul-torn"
+    assert findings[0].sha256 == integrity.line_sha256(torn)
+    assert findings[1].classification == "unrecoverable"
+    assert findings[1].reason == "unparseable"
+
+
+def test_scan_file_on_clean_ledger_returns_empty(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", [json.dumps({"n": 1})])
+    assert integrity.scan_file(path) == []
+
+
+def test_scan_file_does_not_modify_the_file(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good, good[:3] + "\x00" + good[3:]])
+    before = hashlib.sha256(path.read_bytes()).hexdigest()
+
+    integrity.scan_file(path)
+
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == before
+
+
+def test_scan_ledger_dir_skips_clean_files_and_missing_dir(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    _write_ledger(tmp_path, "clean.jsonl", [good])
+    _write_ledger(tmp_path, "import.jsonl", [good[:3] + "\x00" + good[3:]])
+
+    result = integrity.scan_ledger_dir(tmp_path)
+
+    assert set(result) == {"import.jsonl"}
+    assert integrity.scan_ledger_dir(tmp_path / "nope") == {}
+
+
+def test_scan_ledger_dir_ignores_quarantine_sidecars(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    _write_ledger(tmp_path, "import.jsonl", [good])
+    _write_ledger(tmp_path, "import.jsonl.quarantine", ["not json at all"])
+
+    assert integrity.scan_ledger_dir(tmp_path) == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -v`
+Expected: FAIL with `AttributeError: module 'paulsha_hippo.ledger.integrity' has no attribute 'scan_file'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# 追加到 paulsha_hippo/ledger/integrity.py（import 區補 dataclass / Path）
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class LineFinding:
+    line_no: int
+    sha256: str
+    classification: str
+    reason: str
+
+
+def _read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8", errors="surrogateescape").splitlines()
+
+
+def scan_file(path: Path) -> list[LineFinding]:
+    """唯讀掃描單一 JSONL，只回傳非 ok 的行。行號為 1-indexed。"""
+    if not path.is_file():
+        return []
+    findings: list[LineFinding] = []
+    for index, line in enumerate(_read_lines(path), start=1):
+        classification, reason = classify_line(line)
+        if classification == "ok":
+            continue
+        findings.append(
+            LineFinding(
+                line_no=index,
+                sha256=line_sha256(line),
+                classification=classification,
+                reason=reason,
+            )
+        )
+    return findings
+
+
+def ledger_dir(memory_root: Path) -> Path:
+    return memory_root / "runtime" / "ledger"
+
+
+def scan_ledger_dir(memory_root: Path) -> dict[str, list[LineFinding]]:
+    """掃描 runtime/ledger/*.jsonl，只回傳有壞行的檔（key 為檔名）。"""
+    directory = ledger_dir(memory_root)
+    if not directory.is_dir():
+        return {}
+    result: dict[str, list[LineFinding]] = {}
+    for path in sorted(directory.glob("*.jsonl")):
+        findings = scan_file(path)
+        if findings:
+            result[path.name] = findings
+    return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -v`
+Expected: PASS（11 passed）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paulsha_hippo/ledger/integrity.py tests/test_ledger_integrity.py
+git commit -m "feat(ledger): 撕裂行檔案與目錄掃描
+
+Refs #64"
+```
+
+---
+
+### Task 3: quarantine 清單讀寫（fail-closed）
+
+**Files:**
+- Modify: `paulsha_hippo/ledger/integrity.py`
+- Test: `tests/test_ledger_integrity.py`
+
+**Interfaces:**
+- Consumes: `LineFinding`、`line_sha256`、`QUARANTINE_SUFFIX`（Task 1–2）
+- Produces:
+  - `quarantine_path(ledger_path: Path) -> Path`
+  - `read_quarantine(ledger_path: Path) -> frozenset[str] | None` — 回傳已隔離行的 sha256 集合；清單不存在回傳空集合；**清單存在但不可解析回傳 `None`**（fail-closed 訊號）
+  - `append_quarantine(ledger_path: Path, findings: list[LineFinding], *, now: str) -> int`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# 追加到 tests/test_ledger_integrity.py
+def test_read_quarantine_missing_returns_empty(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", [json.dumps({"n": 1})])
+    assert integrity.read_quarantine(path) == frozenset()
+
+
+def test_append_then_read_quarantine_roundtrip(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", ['{"n": '])
+    findings = integrity.scan_file(path)
+
+    written = integrity.append_quarantine(path, findings, now="2026-07-27T00:00:00Z")
+
+    assert written == 1
+    assert integrity.read_quarantine(path) == frozenset({findings[0].sha256})
+    record = json.loads(integrity.quarantine_path(path).read_text().splitlines()[0])
+    assert record["line_no"] == 1
+    assert record["sha256"] == findings[0].sha256
+    assert record["reason"] == "unparseable"
+    assert record["quarantined_at"] == "2026-07-27T00:00:00Z"
+
+
+def test_append_quarantine_is_idempotent(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", ['{"n": '])
+    findings = integrity.scan_file(path)
+    integrity.append_quarantine(path, findings, now="2026-07-27T00:00:00Z")
+
+    written = integrity.append_quarantine(path, findings, now="2026-07-27T01:00:00Z")
+
+    assert written == 0
+    assert len(integrity.quarantine_path(path).read_text().splitlines()) == 1
+
+
+def test_read_quarantine_corrupt_returns_none_fail_closed(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", ['{"n": '])
+    integrity.quarantine_path(path).write_text("這不是 JSON\n", encoding="utf-8")
+
+    assert integrity.read_quarantine(path) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'read_quarantine'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# 追加到 paulsha_hippo/ledger/integrity.py
+def quarantine_path(ledger_path: Path) -> Path:
+    return ledger_path.with_name(ledger_path.name + QUARANTINE_SUFFIX)
+
+
+def read_quarantine(ledger_path: Path) -> frozenset[str] | None:
+    """已隔離行的 sha256 集合。
+
+    清單不存在 → 空集合。清單存在但任一行不可解析 → None，呼叫端必須
+    fail-closed（壞行一律照計），不得因清單不可讀而放行。
+    """
+    path = quarantine_path(ledger_path)
+    if not path.is_file():
+        return frozenset()
+    hashes: set[str] = set()
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in content.splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        digest = record.get("sha256")
+        if not isinstance(digest, str) or not digest:
+            return None
+        hashes.add(digest)
+    return frozenset(hashes)
+
+
+def append_quarantine(ledger_path: Path, findings: list[LineFinding], *, now: str) -> int:
+    """把不可救回行記入 quarantine 清單，回傳實際新增筆數（已存在者不重複記）。"""
+    existing = read_quarantine(ledger_path)
+    if existing is None:
+        raise ValueError(f"quarantine 清單不可解析：{quarantine_path(ledger_path)}")
+    rows = [f for f in findings if f.classification == "unrecoverable" and f.sha256 not in existing]
+    if not rows:
+        return 0
+    path = quarantine_path(ledger_path)
+    with path.open("a", encoding="utf-8") as handle:
+        for finding in rows:
+            handle.write(
+                json.dumps(
+                    {
+                        "line_no": finding.line_no,
+                        "sha256": finding.sha256,
+                        "reason": finding.reason,
+                        "quarantined_at": now,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+        handle.flush()
+        os.fsync(handle.fileno())
+    return len(rows)
+```
+
+在 import 區補上 `import os`。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -v`
+Expected: PASS（15 passed）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paulsha_hippo/ledger/integrity.py tests/test_ledger_integrity.py
+git commit -m "feat(ledger): quarantine 清單讀寫，清單損毀時 fail-closed
+
+Refs #64"
+```
+
+---
+
+### Task 4: 原子修復（備份 → temp → fsync → replace）
+
+**Files:**
+- Modify: `paulsha_hippo/ledger/integrity.py`
+- Test: `tests/test_ledger_integrity.py`
+
+**Interfaces:**
+- Consumes: `scan_file`、`append_quarantine`、`NUL`（Task 1–3）
+- Produces: `repair_file(path: Path, *, apply: bool, now: str) -> dict` — 回傳 `{"file": str, "recoverable": int, "unrecoverable": int, "quarantined": int, "backup": str | None, "applied": bool}`
+
+**設計要點：** 不可救回行**原樣保留**在檔中，只有可救回行被改寫。無任何可救回行時不寫檔、不備份（冪等）。
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# 追加到 tests/test_ledger_integrity.py
+def test_dry_run_does_not_touch_file(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" * 5 + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [good, torn])
+    before = hashlib.sha256(path.read_bytes()).hexdigest()
+
+    result = integrity.repair_file(path, apply=False, now="2026-07-27T00:00:00Z")
+
+    assert result["recoverable"] == 1
+    assert result["applied"] is False
+    assert result["backup"] is None
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == before
+    assert not integrity.quarantine_path(path).exists()
+
+
+def test_apply_removes_only_nul_and_preserves_every_other_byte(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    other = json.dumps({"n": 2}, sort_keys=True)
+    torn = good[:3] + "\x00" * 577 + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [other, torn, other])
+
+    result = integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert result["applied"] is True
+    assert json.loads(lines[1]) == {"n": 1}
+    assert lines[0] == other and lines[2] == other
+    assert "\x00" not in path.read_text(encoding="utf-8")
+
+
+def test_apply_writes_backup_identical_to_original(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [torn])
+    original = path.read_bytes()
+
+    result = integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    backup = Path(result["backup"])
+    assert backup.exists()
+    assert backup.read_bytes() == original
+
+
+def test_apply_is_idempotent(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [torn])
+    integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+    after_first = path.read_bytes()
+    backups_before = sorted(p.name for p in path.parent.glob("import.jsonl.bak-repair-*"))
+
+    result = integrity.repair_file(path, apply=True, now="2026-07-27T02:00:00Z")
+
+    assert result["recoverable"] == 0
+    assert result["backup"] is None
+    assert path.read_bytes() == after_first
+    assert sorted(p.name for p in path.parent.glob("import.jsonl.bak-repair-*")) == backups_before
+
+
+def test_apply_keeps_unrecoverable_line_in_place_and_quarantines_it(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    broken = '{"n": '
+    path = _write_ledger(tmp_path, "import.jsonl", [torn, broken])
+
+    result = integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[1] == broken
+    assert result["quarantined"] == 1
+    assert integrity.read_quarantine(path) == frozenset({integrity.line_sha256(broken)})
+
+
+def test_replace_failure_leaves_original_intact(tmp_path, monkeypatch):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [torn])
+    original = path.read_bytes()
+
+    def boom(_src, _dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(integrity.os, "replace", boom)
+
+    with pytest.raises(OSError):
+        integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    assert path.read_bytes() == original
+    backups = list(path.parent.glob("import.jsonl.bak-repair-*"))
+    assert len(backups) == 1 and backups[0].read_bytes() == original
+
+
+def test_backup_failure_aborts_before_touching_original(tmp_path, monkeypatch):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [torn])
+    original = path.read_bytes()
+
+    real_write_bytes = Path.write_bytes
+
+    def boom(self, data):
+        if ".bak-repair-" in self.name:
+            raise OSError("backup failed")
+        return real_write_bytes(self, data)
+
+    monkeypatch.setattr(Path, "write_bytes", boom)
+
+    with pytest.raises(OSError):
+        integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    assert path.read_bytes() == original
+```
+
+測試檔頂端需 `import pytest`。備份失敗與替換失敗都讓例外往外拋——這是維護窗口的單次操作，
+半修復狀態靜默通過遠比大聲失敗危險。替換失敗時備份保留供人工處置。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'repair_file'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# 追加到 paulsha_hippo/ledger/integrity.py
+def _backup_name(path: Path, now: str) -> str:
+    stamp = now.replace(":", "").replace("-", "")
+    return f"{path.name}.bak-repair-{stamp}"
+
+
+def repair_file(path: Path, *, apply: bool, now: str) -> dict:
+    findings = scan_file(path)
+    recoverable = [f for f in findings if f.classification == "recoverable"]
+    unrecoverable = [f for f in findings if f.classification == "unrecoverable"]
+    result: dict = {
+        "file": str(path),
+        "recoverable": len(recoverable),
+        "unrecoverable": len(unrecoverable),
+        "quarantined": 0,
+        "backup": None,
+        "applied": False,
+    }
+    if not apply:
+        return result
+
+    if unrecoverable:
+        result["quarantined"] = append_quarantine(path, unrecoverable, now=now)
+
+    if not recoverable:
+        # 冪等：沒有可救回行就不寫檔、不備份。
+        return result
+
+    targets = {f.line_no for f in recoverable}
+    lines = _read_lines(path)
+    rebuilt = [
+        line.replace(NUL, "") if index in targets else line
+        for index, line in enumerate(lines, start=1)
+    ]
+
+    backup = path.with_name(_backup_name(path, now))
+    backup.write_bytes(path.read_bytes())
+
+    tmp = path.with_name(f".{path.name}.repair.tmp")
+    with tmp.open("w", encoding="utf-8", errors="surrogateescape") as handle:
+        handle.write("\n".join(rebuilt) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+    result["backup"] = str(backup)
+    result["applied"] = True
+    return result
+
+
+def repair_ledger_dir(memory_root: Path, *, apply: bool, now: str) -> list[dict]:
+    directory = ledger_dir(memory_root)
+    if not directory.is_dir():
+        return []
+    results = []
+    for path in sorted(directory.glob("*.jsonl")):
+        outcome = repair_file(path, apply=apply, now=now)
+        if outcome["recoverable"] or outcome["unrecoverable"]:
+            results.append(outcome)
+    return results
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -v`
+Expected: PASS（20 passed）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paulsha_hippo/ledger/integrity.py tests/test_ledger_integrity.py
+git commit -m "feat(ledger): 撕裂行原子修復，可救回行救回、不可救回行原地隔離
+
+Refs #64"
+```
+
+---
+
+### Task 5: janitor 讀取端排除已隔離行
+
+**Files:**
+- Modify: `paulsha_hippo/ledger/import_log.py:65-96`（`read_import_records_tolerant`）
+- Test: `tests/test_ledger_integrity.py`
+
+**Interfaces:**
+- Consumes: `integrity.read_quarantine`、`integrity.line_sha256`（Task 1、3）
+- Produces: `read_import_records_tolerant` 行為變更——已隔離行不計入 `bad_line_count`
+
+**設計要點：** 這是「雙邊隔離」的讀取端。少了這一半，不可救回行仍會讓 janitor 每輪 warn、dream 永久 partial，問題原封不動。
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# 追加到 tests/test_ledger_integrity.py
+from paulsha_hippo.ledger import import_log
+
+
+def test_quarantined_bad_line_is_not_counted(tmp_path):
+    good = json.dumps({"idempotency_key": "k", "status": "written"}, sort_keys=True)
+    broken = '{"n": '
+    path = _write_ledger(tmp_path, "import.jsonl", [good, broken])
+    integrity.append_quarantine(path, integrity.scan_file(path), now="2026-07-27T00:00:00Z")
+
+    records, bad = import_log.read_import_records_tolerant(path)
+
+    assert bad == 0
+    assert len(records) == 1
+
+
+def test_unquarantined_bad_line_is_still_counted(tmp_path):
+    good = json.dumps({"idempotency_key": "k", "status": "written"}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good, '{"n": '])
+
+    _records, bad = import_log.read_import_records_tolerant(path)
+
+    assert bad == 1
+
+
+def test_corrupt_quarantine_list_fails_closed(tmp_path):
+    good = json.dumps({"idempotency_key": "k", "status": "written"}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good, '{"n": '])
+    integrity.quarantine_path(path).write_text("這不是 JSON\n", encoding="utf-8")
+
+    _records, bad = import_log.read_import_records_tolerant(path)
+
+    assert bad == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -k quarantin -v`
+Expected: FAIL — `test_quarantined_bad_line_is_not_counted` 得到 `bad == 1`（尚未接上讀取端）
+
+- [ ] **Step 3: Write minimal implementation**
+
+把 `paulsha_hippo/ledger/import_log.py` 的 `read_import_records_tolerant` 迴圈改為：
+
+```python
+def read_import_records_tolerant(import_log_path: Path) -> tuple[list[dict], int]:
+    """Read import records while skipping empty or malformed JSONL rows.
+
+    已進入 quarantine 清單的壞行不計入 bad_line_count（issue #64 雙邊隔離的
+    讀取端）。清單存在但不可解析時 fail-closed：壞行一律照計。
+    """
+    if not import_log_path.exists():
+        return [], 0
+
+    try:
+        content = import_log_path.read_text()
+    except FileNotFoundError:
+        return [], 0
+
+    if not content.strip():
+        return [], 0
+
+    from . import integrity
+
+    quarantined = integrity.read_quarantine(import_log_path)
+    if quarantined is None:
+        quarantined = frozenset()
+
+    records: list[dict] = []
+    bad_line_count = 0
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if integrity.line_sha256(raw_line) not in quarantined:
+                bad_line_count += 1
+            continue
+
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            if integrity.line_sha256(raw_line) not in quarantined:
+                bad_line_count += 1
+            continue
+
+        records.append(record)
+
+    return records, bad_line_count
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py tests/ -k "quarantin or import" -v`
+Expected: PASS，且既有 janitor 測試不退步
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paulsha_hippo/ledger/import_log.py tests/test_ledger_integrity.py
+git commit -m "fix(janitor): bad-line 計數排除已隔離行，清單損毀時 fail-closed
+
+Refs #64"
+```
+
+---
+
+### Task 6: health 掃描排除生成的 MOC 索引檔
+
+**Files:**
+- Modify: `paulsha_hippo/ledger/dream.py:176-189`
+- Test: `tests/test_ledger_integrity.py`
+
+**Interfaces:**
+- Consumes: 無新介面
+- Produces: health 的 `invalid_frontmatter` / `generic_title` / `unknown_project` 不再計入 `memory_layer: moc` 的檔案
+
+**設計要點：** 用 frontmatter 欄位而非 `*-moc.md` 檔名判別。`moc/moc_builder.py:_write_moc` 寫入 `memory_layer: moc`，knowledge slice 為 `memory_layer: knowledge`。
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# 追加到 tests/test_ledger_integrity.py
+from paulsha_hippo.ledger import dream as dream_ledger
+
+
+def _write_slice(root, name, body="內容", **fm):
+    fields = {
+        "slice_id": "sl-1",
+        "project": "p",
+        "checksum": "deadbeef",
+        "memory_layer": "knowledge",
+    }
+    fields.update(fm)
+    lines = ["---"] + [f"{k}: {v}" for k, v in fields.items()] + ["---", body]
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def test_generated_moc_is_not_counted_as_invalid_frontmatter(tmp_path):
+    knowledge = tmp_path / "knowledge"
+    knowledge.mkdir(parents=True)
+    (knowledge / "wiki-moc.md").write_text(
+        "---\nmemory_layer: moc\nmoc_kind: wiki\n---\n# Wiki MOC\n", encoding="utf-8"
+    )
+
+    health = dream_ledger.backlog_census(tmp_path, now="2026-07-27T00:00:00Z")
+
+    assert health["invalid_frontmatter"] == 0
+
+
+def test_genuinely_broken_slice_is_still_counted(tmp_path):
+    knowledge = tmp_path / "knowledge"
+    knowledge.mkdir(parents=True)
+    (knowledge / "broken.md").write_text(
+        "---\nmemory_layer: knowledge\n---\n內容\n", encoding="utf-8"
+    )
+
+    health = dream_ledger.backlog_census(tmp_path, now="2026-07-27T00:00:00Z")
+
+    assert health["invalid_frontmatter"] == 1
+```
+
+包住 knowledge 掃描迴圈的函式是 `backlog_census(memory_root, *, now=None)`（`paulsha_hippo/ledger/dream.py:110`）。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -k moc -v`
+Expected: FAIL — `test_generated_moc_is_not_counted_as_invalid_frontmatter` 得到 `1`
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `paulsha_hippo/ledger/dream.py` 的 knowledge 掃描迴圈中，讀完 frontmatter 後、`required` 檢查之前插入：
+
+```python
+            # 生成的 MOC 索引檔依設計不帶 slice frontmatter，計入會讓這些指標
+            # 永遠無法歸零而失去診斷價值（issue #64）。以欄位而非檔名判別。
+            if str(frontmatter.get("memory_layer") or "") == "moc":
+                continue
+            required = ("slice_id", "project", "checksum", "memory_layer")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -k moc -v`
+Expected: PASS（2 passed）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paulsha_hippo/ledger/dream.py tests/test_ledger_integrity.py
+git commit -m "fix(dream): health 計數排除帶 memory_layer moc 的生成索引檔
+
+Refs #64"
+```
+
+---
+
+### Task 7: `hippo ledger repair` 子命令與 doctor 輸出
+
+**Files:**
+- Modify: `paulsha_hippo/cli.py`（子命令註冊區約 423-431 行的 `locks` 之後；handler 放在 `_locks_cleanup_legacy` 附近）
+- Modify: `paulsha_hippo/ops.py:1303` 附近（doctor 輸出 dream lock 那行之後）
+- Test: `tests/test_ledger_integrity.py`
+
+**Interfaces:**
+- Consumes: `integrity.repair_ledger_dir`、`integrity.scan_ledger_dir`（Task 2、4）
+- Produces: CLI `hippo ledger repair --memory-root <path> [--apply] [--now <iso>]`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# 追加到 tests/test_ledger_integrity.py
+from paulsha_hippo import cli
+
+
+def test_cli_ledger_repair_dry_run_leaves_file_untouched(tmp_path, capsys):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good[:3] + "\x00" + good[3:]])
+    before = hashlib.sha256(path.read_bytes()).hexdigest()
+
+    code = cli.main(["ledger", "repair", "--memory-root", str(tmp_path)])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload[0]["recoverable"] == 1
+    assert payload[0]["applied"] is False
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == before
+
+
+def test_cli_ledger_repair_apply_fixes_line(tmp_path, capsys):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good[:3] + "\x00" + good[3:]])
+
+    code = cli.main([
+        "ledger", "repair", "--memory-root", str(tmp_path),
+        "--apply", "--now", "2026-07-27T00:00:00Z",
+    ])
+
+    capsys.readouterr()
+    assert code == 0
+    assert json.loads(path.read_text(encoding="utf-8").splitlines()[0]) == {"n": 1}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -k cli_ledger -v`
+Expected: FAIL — argparse 以 `invalid choice: 'ledger'` 結束
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `paulsha_hippo/cli.py` 的 `locks` 子命令註冊之後加入：
+
+```python
+    ledger_p = memory_subparsers.add_parser("ledger", help="append-only ledger 維運")
+    ledger_sub = ledger_p.add_subparsers(dest="ledger_command", required=True)
+    ledger_repair = ledger_sub.add_parser(
+        "repair",
+        help="修復 ledger 撕裂行（僅維護窗口；預設 dry-run）",
+    )
+    ledger_repair.add_argument("--memory-root", required=True)
+    ledger_repair.add_argument("--apply", action="store_true")
+    ledger_repair.add_argument("--now", default=None,
+                               help="ISO8601 時間戳；未給時取當下 UTC")
+    ledger_repair.set_defaults(func=_ledger_repair)
+```
+
+handler（放在 `_locks_cleanup_legacy` 之後）：
+
+```python
+def _ledger_repair(args: argparse.Namespace) -> int:
+    from datetime import datetime, timezone
+
+    from paulsha_hippo.ledger import integrity
+
+    now = args.now or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    results = integrity.repair_ledger_dir(
+        Path(args.memory_root), apply=args.apply, now=now
+    )
+    print(json.dumps(results, ensure_ascii=False, sort_keys=True))
+    return 0
+```
+
+doctor 輸出：在 `paulsha_hippo/ops.py` 印出 dream lock 那行（約 1303 行）之後加入：
+
+```python
+    from .ledger import integrity
+
+    ledger_findings = integrity.scan_ledger_dir(memory_root)
+    if not ledger_findings:
+        print("- ledger 完整性：✓ 無撕裂行")
+    else:
+        for name, findings in ledger_findings.items():
+            recoverable = [f for f in findings if f.classification == "recoverable"]
+            unrecoverable = [f for f in findings if f.classification == "unrecoverable"]
+            lines = ", ".join(str(f.line_no) for f in findings[:10])
+            suffix = " …" if len(findings) > 10 else ""
+            print(
+                f"- ledger 完整性：✗ {name} 可救回 {len(recoverable)}／"
+                f"不可救回 {len(unrecoverable)}（行 {lines}{suffix}）"
+                "——`hippo ledger repair --memory-root <root> --apply`"
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_ledger_integrity.py -v`
+Expected: PASS（全數通過）
+
+手動驗證 doctor 對真實 memory root 的輸出與耗時：
+
+Run: `time python3 -m paulsha_hippo doctor 2>&1 | grep "ledger 完整性"`
+Expected: 指出 `import.jsonl` 有 1 個可救回行（行 230）；若 doctor 總耗時因此顯著增加，改為先以
+`b"\x00" in path.read_bytes()` 快篩、只有命中的檔才逐行解析。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add paulsha_hippo/cli.py paulsha_hippo/ops.py tests/test_ledger_integrity.py
+git commit -m "feat(cli): 新增 hippo ledger repair 與 doctor ledger 完整性檢查
+
+Refs #64"
+```
+
+---
+
+### Task 8: 交付治理
+
+**Files:**
+- Create: `changelog.d/64-ledger-torn-line-repair.md`
+- Modify: `openspec/changes/issue-64-ledger-torn-line-repair/tasks.md`（勾選已完成項）
+
+**Interfaces:**
+- Consumes: Task 1–7 的全部產出
+- Produces: 可合併的 PR
+
+- [ ] **Step 1: 寫 changelog 碎片**
+
+```markdown
+### Fixed
+- ledger 撕裂行（嵌入 NUL 位元組的 JSONL 行）不再讓 janitor 每輪回報壞行、使
+  `hippo dream run` 永久停在 `partial`。新增 `hippo doctor` 的 ledger 完整性檢查與
+  `hippo ledger repair`（預設 dry-run，`--apply` 才寫入）：可救回的行原地救回、
+  不可救回的行原樣保留並記入 quarantine 清單，janitor 的壞行計數排除已隔離行。
+- dream health 的 `invalid_frontmatter` 不再把生成的 MOC 索引檔當成缺欄位的 slice，
+  該指標先前恆等於 MOC 檔數而無法歸零。
+```
+
+- [ ] **Step 2: 跑全套測試**
+
+Run: `python3 -m pytest -q`
+Expected: 全數通過，無退步
+
+- [ ] **Step 3: 跑 policy 與 openspec 驗證**
+
+Run: `python3 -m policy_check --repo . && openspec validate issue-64-ledger-torn-line-repair --strict`
+Expected: policy 無 failure（既有 R-22 warn 可留）；openspec valid
+
+- [ ] **Step 4: 確認 VERSION 未變**
+
+Run: `git diff main --stat -- VERSION`
+Expected: 無輸出
+
+- [ ] **Step 5: Commit 並開 PR**
+
+```bash
+git add changelog.d/64-ledger-torn-line-repair.md openspec/changes/issue-64-ledger-torn-line-repair/tasks.md
+git commit -m "chore(issue-64): changelog 碎片與 tasks 進度
+
+Refs #64"
+git push -u origin feature/64-ledger-torn-line-repair
+```
+
+PR body 必須包含 `Closes #64`，並勾滿 `.github/pull_request_template.md` 的 checklist。
+
+---
+
+## 合併後的 runtime 修復（不在 PR diff 內）
+
+PR 合併並重裝部署副本後執行：
+
+```bash
+cp ~/.agents/memory/runtime/ledger/import.jsonl \
+   ~/.agents/memory/runtime/ledger/import.jsonl.manual-bak-2026-07-27
+hippo ledger repair --memory-root ~/.agents/memory              # dry-run，確認只有 line 230
+hippo ledger repair --memory-root ~/.agents/memory --apply
+hippo requeue claude-code:3c0a8d08-7925-4694-89f1-85a2838bc586 --memory-root ~/.agents/memory
+hippo requeue claude-code:66f5eed9-214b-4595-b4bf-835a87496e81 --memory-root ~/.agents/memory
+hippo dream run --memory-root ~/.agents/memory
+```
+
+驗收：`dream run` 的 `status` 為 `"ok"`、`health.invalid_frontmatter` 為 `0`、inbox 的 119 個
+滯留 fragment 被消化。
+
+**注意：** `requeue` 的 session key 格式為 `<tool>:<session_id>`，執行前先以
+`hippo doctor` 或 ledger fold 確認兩個 key 的實際字面值。

--- a/docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-design.md
+++ b/docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-design.md
@@ -1,0 +1,106 @@
+# Ledger 撕裂行修復與 health 指標假陽性（issue #64）設計
+
+- 日期：2026-07-27
+- Issue：[#64](https://github.com/hamanpaul/paulsha-hippo/issues/64)
+- 狀態：已核可，待實作
+
+## 背景
+
+`hippo dream run` 長期回報 `status: "partial"`，從未全綠。實測定位到單一根因與一項指標失真。
+
+### 根因一：`import.jsonl` 撕裂寫入令 dream 永久 partial
+
+`runtime/ledger/import.jsonl` line 230 是一筆 2026-06-24 的撕裂寫入——577 個 `\x00` 插在一筆 `copilot-cli:799ae7d0-1925-4545-b32b-0e3e146d74b5` 記錄中間。該行共 1272 bytes，移除 NUL 後剩 695 bytes 的完整 JSON，`recorded_at` 與前後鄰居時間戳吻合。
+
+判定鏈：
+
+1. `janitor/scanner.py:171` — `import.jsonl` 解析失敗行數 > 0 時附加 warning `skipped N bad line(s)`。
+2. `dream/orchestrator.py:_run_pass` — pass 回傳的 `warnings` 為非空 list 即回傳 `False`。
+3. `dream/orchestrator.py:130` — `status = "ok" if (atomize_clean and janitor_clean and moc_clean) else "partial"`。
+
+`import.jsonl` 是 append-only，這行不會自己消失，因此一行 60 天前的壞資料讓 dream 永遠不可能全綠。
+
+### 根因二：`invalid_frontmatter: 16` 是假陽性
+
+`ledger/dream.py:176` 用 `knowledge.rglob("*.md")` 掃全樹計算 health，把生成的 MOC 索引檔也當成 slice 檢查。這些檔案依設計沒有 `slice_id` / `checksum`。數字恆等於 MOC 檔數（16）。
+
+## 設計決策
+
+### 決策一：可救回的行原地救回，不可救回的隔離（A + B fallback）
+
+移除 NUL 後可解析的行**原地救回**：那 695 bytes 的 JSON 內容完好，NUL 是檔案系統層的垃圾、從來不是任何 append 真正寫入的內容，因此這是復原歷史而非改寫歷史。不可救回的行則保留原樣、改以 quarantine 清單隔離，原檔位元組不動。
+
+被否決的替代方案：
+
+- **純附加隔離（只做 B）**：完全不碰 append-only 契約，但壞行永遠留在檔裡，未來新寫的 reader 仍會踩到，且該筆記錄的內容等同放棄。
+- **只偵測不修（只做 C）**：PR 最小，但每次復發都得人工處理，與「這個瑕疵潛伏 60 天沒人發現」的教訓相悖。
+
+### 決策二：用 frontmatter 欄位而非檔名辨識 MOC
+
+`moc/moc_builder.py:_write_moc` 寫入 `memory_layer: moc`，knowledge slice 則是 `memory_layer: knowledge`。用欄位判別比比對 `*-moc.md` 檔名穩固，未來改命名也不會失效。
+
+## 元件
+
+### 1. 偵測：`hippo doctor` 的 ledger 完整性檢查
+
+唯讀掃描 `runtime/ledger/*.jsonl`，每行分三類：
+
+| 分類 | 判準 |
+|------|------|
+| ok | 直接 `json.loads` 成功 |
+| recoverable | 移除 `\x00` 後 `json.loads` 成功 |
+| unrecoverable | 移除 `\x00` 後仍失敗 |
+
+輸出每檔的壞行數與行號。目的是讓這類瑕疵不再只能從一句 opaque 的 `partial` 反推。
+
+### 2. 修復：`hippo ledger repair`
+
+沿用 `locks cleanup-legacy` 既有慣例：`--memory-root` 必填、預設 dry-run、`--apply` 才寫入。
+
+`--apply` 執行順序：
+
+1. 備份 `<name>.jsonl.bak-repair-<ts>`。
+2. 逐行重建：可救回行移除 NUL；**不可救回行原樣保留在檔中，不刪除**。
+3. 同目錄 temp file + fsync + `os.replace` 原子替換。
+4. 無任何可救回行時不寫入、不備份（冪等）。
+
+### 3. Quarantine 清單
+
+不可救回行若只是留在檔裡，janitor 會繼續 warn，dream 仍然 partial。因此隔離必須是雙邊的：
+
+- 寫入端：`runtime/ledger/<name>.jsonl.quarantine`（JSONL，每筆 `{line_no, sha256, reason, quarantined_at}`）。
+- 讀取端：`janitor/scanner.py` 的 bad-line 計數排除已隔離的行。
+
+以內容 sha256 為主鍵、行號為輔助。append-only 只在尾端加行，既有行號穩定；repair 不刪行，行數也不變，因此行號可安全作為輔助鍵。
+
+### 4. health 掃描排除 MOC
+
+`ledger/dream.py` 讀完 frontmatter 後，`memory_layer == "moc"` 即 skip，不計入 `invalid_frontmatter`、`generic_title`、`unknown_project`。
+
+## 錯誤處理
+
+- ledger 目錄不存在或無 `*.jsonl`：視為無事可做，回報 0 筆，不報錯。
+- 備份寫入失敗：中止且不觸碰原檔。
+- temp 寫入或 `os.replace` 失敗：原檔維持原狀，備份保留供人工處置。
+- quarantine 檔本身損毀：fail-closed，該檔的 bad line 一律照計，不因清單不可讀而誤放行。
+
+## 測試
+
+- 撕裂行被判為 recoverable；`--apply` 後可解析、**其餘位元組逐一不變**、備份存在。
+- 不可救回行進 quarantine、原檔該行不變、janitor 不再計為 bad line。
+- 冪等：repair 第二次執行為 no-op，不再產生備份。
+- dry-run 前後全檔 sha256 不變。
+- health 掃描：MOC 檔不計入 `invalid_frontmatter`；真正損壞的 slice 仍計入。
+
+## 不在範圍
+
+- `dream/orchestrator.py` 的 warning → partial 語意不變更。dream status 是對外契約，#20 / #34 都引用過該語意。修掉壞資料後 janitor warning 自然消失，dream 即可轉綠，不需要改判定。
+- `invalid_checksum: 18`（尾端換行造成的 checksum 漂移，2026-07-24 備份中即已存在）另案處理。
+- `runtime/queue` fire-and-forget 無 sweeper（2 筆 payload 滯留 18 天）另案處理。
+
+## 合併後的 runtime 待辦
+
+1. 備份 `import.jsonl`。
+2. `hippo ledger repair --memory-root ~/.agents/memory --apply` 修復 line 230。
+3. `hippo requeue` 兩個卡住的 parked session：`claude-code__3c0a8d08…`（68 frags）、`claude-code__66f5eed9…`（51 frags），合計 119 個 fragment 滯留 inbox。
+4. `hippo dream run` 確認 `status: "ok"`。

--- a/docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-design.md
+++ b/docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-design.md
@@ -1,3 +1,8 @@
+---
+status: accepted
+work_item: issue-64-ledger-torn-line-repair
+---
+
 # Ledger 撕裂行修復與 health 指標假陽性（issue #64）設計
 
 - 日期：2026-07-27
@@ -24,7 +29,7 @@
 
 `ledger/dream.py:176` 用 `knowledge.rglob("*.md")` 掃全樹計算 health，把生成的 MOC 索引檔也當成 slice 檢查。這些檔案依設計沒有 `slice_id` / `checksum`。數字恆等於 MOC 檔數（16）。
 
-## 設計決策
+## Decisions
 
 ### 決策一：可救回的行原地救回，不可救回的隔離（A + B fallback）
 

--- a/docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-spec.md
+++ b/docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-spec.md
@@ -1,0 +1,56 @@
+---
+status: accepted
+work_item: issue-64-ledger-torn-line-repair
+---
+
+# Ledger 撕裂行修復與 health 指標假陽性（issue #64）規格
+
+## Problem and Outcome
+
+`runtime/ledger/import.jsonl` line 230 是一筆 2026-06-24 的撕裂寫入——577 個 `\x00` 插在一筆完好的 JSON 記錄中間。janitor 每輪因此回報 `skipped 1 bad line(s)`，而 `_run_pass` 只要 warnings 非空即判 pass 不 clean，使 `hippo dream run` 永久停在 `status: "partial"`。ledger 為 append-only，該行不會自行消失，且目前沒有任何檢查會指名它——這個瑕疵潛伏 60 天，只能從一句 opaque 的 `partial` 反推。
+
+同時 health 的 `invalid_frontmatter` 恆為 16，等於生成的 MOC 索引檔數；該指標永遠無法歸零，失去診斷價值。
+
+預期結果：撕裂行可被指名、可救回、可隔離；修復後 dream 轉為 `ok`；`invalid_frontmatter` 能反映真實的 slice 損壞數。
+
+## Goals
+
+- 診斷可指名每個撕裂行的檔名、行號與可救回性。
+- 可救回的行救回其內容；不可救回的行讓消費端停止無限重複 warn。
+- 修復操作原子、冪等、可回滾。
+- health 計數只涵蓋 knowledge slice，不含生成的衍生產物。
+
+## Requirements
+
+### 撕裂行偵測與分類
+
+診斷 SHALL 唯讀掃描 `runtime/ledger/*.jsonl`，將每行分類為正常、可救回（移除 `\x00` 後可解析）或不可救回，並 SHALL 指名檔名與行號。診斷 MUST NOT 修改任何 ledger 檔案。
+
+空白行歸類為不可救回：既有 reader 也把空白行計為 bad line，若視為正常則「修復後壞行計數歸零」的不變量不成立。
+
+### 可救回行的原子救回
+
+修復 SHALL 預設 dry-run，僅在明確指定套用旗標時寫入。套用時 SHALL 先建立含時間戳的備份，僅自可救回行移除 `\x00`、其餘所有位元組逐一保持不變，並 SHALL 以同目錄暫存檔加 fsync 後原子替換。備份或替換失敗時 SHALL 中止且原檔維持原狀。無可救回行時 SHALL 為 no-op、不寫入、不備份。
+
+### 不可救回行的雙邊隔離
+
+不可救回行 SHALL 原樣保留於原檔中，不得刪除，並 SHALL 記入 quarantine 清單（行號、內容 SHA-256、原因、隔離時間）。消費端 SHALL 將已隔離行排除在壞行計數之外。quarantine 清單不可解析時 SHALL fail-closed，該檔壞行一律照計。
+
+隔離必須雙邊生效：只寫清單而消費端不讀，dream 仍會永久 partial，問題原封不動。
+
+### health 計數排除生成的 MOC 索引檔
+
+health 的 `invalid_frontmatter`、`generic_title`、`unknown_project` SHALL 排除帶 `memory_layer: moc` 的生成索引檔。以 frontmatter 欄位而非檔名慣例判別。
+
+## Non-Goals
+
+- 不變更 `dream/orchestrator.py` 的 warning → partial 判定語意。dream status 是對外契約，#20 / #34 均引用該語意；修掉壞資料後 warning 自然消失即可轉綠。
+- 不處理 `invalid_checksum: 18`（尾端換行造成的 checksum 漂移，2026-07-24 備份中即已存在）。
+- 不處理 `runtime/queue` 缺 sweeper（2 筆 payload 滯留 18 天）。
+
+## Acceptance
+
+- `hippo doctor` 對現行 memory root 指出 `import.jsonl` line 230 為可救回。
+- `hippo ledger repair --apply` 後該行可解析，檔案其餘位元組逐一不變，備份存在。
+- 修復後 `hippo dream run` 回報 `status: "ok"`、`health.invalid_frontmatter` 為 `0`。
+- 全套 pytest 通過；`policy_check` 無 failure；`openspec validate issue-64-ledger-torn-line-repair --strict` 通過。

--- a/docs/superpowers/workstreams/issue-64-ledger-torn-line-repair/todo.md
+++ b/docs/superpowers/workstreams/issue-64-ledger-torn-line-repair/todo.md
@@ -1,0 +1,31 @@
+---
+status: accepted
+work_item: issue-64-ledger-torn-line-repair
+---
+
+# issue-64-ledger-torn-line-repair / todo
+
+規劃三件套：
+
+- spec — `docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-spec.md`
+- design — `docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-design.md`
+- plan — `docs/superpowers/plans/2026-07-27-issue-64-ledger-torn-line-repair.md`
+
+## Tasks
+
+- [ ] ledger 行分類核心（`classify_line` / `line_sha256`，空白行歸不可救回）
+- [ ] 檔案與目錄唯讀掃描（`scan_file` / `scan_ledger_dir`，回報行號）
+- [ ] quarantine 清單讀寫，清單損毀時 fail-closed
+- [ ] 原子修復（備份 → 逐行重建 → temp + fsync + `os.replace`），冪等
+- [ ] janitor 讀取端排除已隔離行（`read_import_records_tolerant`）
+- [ ] health 掃描排除帶 `memory_layer: moc` 的生成索引檔
+- [ ] `hippo ledger repair` 子命令與 `hippo doctor` ledger 完整性輸出
+- [ ] changelog.d 碎片、全套 pytest、policy_check、openspec strict validate
+
+## Blockers
+
+- [ ] 無
+
+## 合併後 runtime 修復（不在 PR diff 內）
+
+- [ ] 修復 `import.jsonl` line 230，requeue 兩個 parked session，確認 dream `status: "ok"`

--- a/docs/superpowers/workstreams/issue-64-ledger-torn-line-repair/todo.md
+++ b/docs/superpowers/workstreams/issue-64-ledger-torn-line-repair/todo.md
@@ -13,14 +13,14 @@ work_item: issue-64-ledger-torn-line-repair
 
 ## Tasks
 
-- [ ] ledger 行分類核心（`classify_line` / `line_sha256`，空白行歸不可救回）
-- [ ] 檔案與目錄唯讀掃描（`scan_file` / `scan_ledger_dir`，回報行號）
-- [ ] quarantine 清單讀寫，清單損毀時 fail-closed
-- [ ] 原子修復（備份 → 逐行重建 → temp + fsync + `os.replace`），冪等
-- [ ] janitor 讀取端排除已隔離行（`read_import_records_tolerant`）
-- [ ] health 掃描排除帶 `memory_layer: moc` 的生成索引檔
-- [ ] `hippo ledger repair` 子命令與 `hippo doctor` ledger 完整性輸出
-- [ ] changelog.d 碎片、全套 pytest、policy_check、openspec strict validate
+- [x] ledger 行分類核心（`classify_line` / `line_sha256`，空白行歸不可救回）
+- [x] 檔案與目錄唯讀掃描（`scan_file` / `scan_ledger_dir`，回報行號）
+- [x] quarantine 清單讀寫，清單損毀時 fail-closed
+- [x] 原子修復（備份 → 逐行重建 → temp + fsync + `os.replace`），冪等
+- [x] janitor 讀取端排除已隔離行（`read_import_records_tolerant`）
+- [x] health 掃描排除帶 `memory_layer: moc` 的生成索引檔
+- [x] `hippo ledger repair` 子命令與 `hippo doctor` ledger 完整性輸出
+- [x] changelog.d 碎片、全套 pytest、policy_check、openspec strict validate
 
 ## Blockers
 

--- a/openspec/changes/issue-64-ledger-torn-line-repair/.openspec.yaml
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/issue-64-ledger-torn-line-repair/design.md
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/design.md
@@ -1,3 +1,8 @@
+---
+status: accepted
+work_item: issue-64-ledger-torn-line-repair
+---
+
 ## Context
 
 `runtime/ledger/import.jsonl` line 230 含 577 個 `\x00`，插在一筆 `copilot-cli:799ae7d0-1925-4545-b32b-0e3e146d74b5` 記錄中間。全行 1272 bytes，移除 NUL 後剩 695 bytes 的完整 JSON，`recorded_at` 與前後鄰居時間戳吻合。

--- a/openspec/changes/issue-64-ledger-torn-line-repair/design.md
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/design.md
@@ -1,0 +1,73 @@
+## Context
+
+`runtime/ledger/import.jsonl` line 230 含 577 個 `\x00`，插在一筆 `copilot-cli:799ae7d0-1925-4545-b32b-0e3e146d74b5` 記錄中間。全行 1272 bytes，移除 NUL 後剩 695 bytes 的完整 JSON，`recorded_at` 與前後鄰居時間戳吻合。
+
+判定鏈：`janitor/scanner.py:171` 對解析失敗行附加 warning `skipped N bad line(s)` → `dream/orchestrator.py:_run_pass` 見 warnings 非空即回傳 `False` → `dream/orchestrator.py:130` 判 `status = "partial"`。
+
+約束：ledger 是 append-only 契約；`import.jsonl` 已 24,139 行 / 16MB；health 掃描每輪 dream 都跑，成本敏感。
+
+完整背景見 `docs/superpowers/specs/2026-07-27-issue-64-ledger-torn-line-repair-design.md`。
+
+## Goals / Non-Goals
+
+Goals：
+
+- 讓撕裂行可被偵測、可被指名（檔名 + 行號），不再只能從 opaque 的 `partial` 反推。
+- 可救回的行救回內容；不可救回的行讓 janitor 停止無限重複 warn。
+- 修復操作原子、冪等、可回滾。
+- 修正 `invalid_frontmatter` 因 MOC 索引檔而恆不歸零的假陽性。
+
+Non-Goals：
+
+- 不變更 `dream/orchestrator.py` 的 warning → partial 判定語意。
+- 不處理 `invalid_checksum: 18`（尾端換行造成的 checksum 漂移）。
+- 不處理 `runtime/queue` 缺 sweeper。
+
+## Decisions
+
+### 決策一：可救回的行原地救回，不可救回的雙邊隔離
+
+移除 NUL 後可解析的行原地救回。理由：該 695 bytes 的 JSON 內容完好，NUL 是檔案系統層的垃圾、從來不是任何 append 真正寫入的內容，因此屬於復原歷史而非改寫歷史。
+
+替代方案：
+
+- 純附加隔離（完全不碰原檔）：不牴觸 append-only 契約，但壞行永遠留存，未來新寫的 reader 仍會踩到，且該筆記錄的內容等同放棄。
+- 只偵測不修：PR 最小，但每次復發都需人工處置，與「瑕疵潛伏 60 天無人發現」的教訓相悖。
+
+### 決策二：隔離必須雙邊生效
+
+quarantine 若只是寫一份清單而 janitor 不讀，不可救回行仍會讓 dream 永久 partial——問題原封不動。因此寫入端（`<name>.jsonl.quarantine`）與讀取端（janitor bad-line 計數排除已隔離行）必須成對交付。
+
+以內容 sha256 為主鍵、行號為輔助鍵：append-only 只在尾端加行，既有行號穩定；repair 不刪行，行數也不變。
+
+### 決策三：用 frontmatter 欄位而非檔名辨識 MOC
+
+`moc/moc_builder.py:_write_moc` 寫入 `memory_layer: moc`，knowledge slice 為 `memory_layer: knowledge`。用欄位判別比比對 `*-moc.md` 檔名穩固，未來改命名不會失效。
+
+替代方案：比對檔名後綴——實作更短，但把命名慣例變成隱性契約。
+
+### 決策四：沿用既有維護命令形狀
+
+`hippo ledger repair` 照 `locks cleanup-legacy` 的既有慣例：`--memory-root` 必填、預設 dry-run、`--apply` 才寫入。維持同類破壞性維護操作的一致心智模型。
+
+## Risks / Trade-offs
+
+- **改寫 append-only 檔案的先例** → 只移除 NUL、其餘位元組逐一不變，並以測試逐位元組驗證；`--apply` 前強制備份；dry-run 為預設。
+- **備份寫入成功但替換失敗，留下孤兒備份** → 備份採含時間戳的固定命名，doctor 可指認；替換失敗時原檔維持原狀，不進入半修復狀態。
+- **quarantine 清單本身損毀導致壞行被誤放行** → fail-closed：清單不可讀時該檔的 bad line 一律照計。
+- **行號作為輔助鍵在未來若引入 ledger compaction 會失效** → 主鍵為內容 sha256，行號僅為輔助；compaction 若實作需一併重寫清單，於 spec 標明。
+- **health 掃描排除 MOC 後，真正損壞的 MOC 檔不再被計入** → MOC 為每輪 dream 重新生成的衍生物，其正確性由 moc pass 自身保證，不屬 slice health 範疇。
+
+## Migration Plan
+
+1. 合併後備份 `import.jsonl`。
+2. `hippo ledger repair --memory-root ~/.agents/memory`（dry-run）確認只有 line 230 被列為可救回。
+3. `--apply` 執行修復。
+4. `hippo requeue` 兩個卡住的 parked session（`claude-code__3c0a8d08…` 68 frags、`claude-code__66f5eed9…` 51 frags）。
+5. `hippo dream run` 確認 `status: "ok"` 且 `invalid_frontmatter: 0`。
+
+回滾：還原 `.bak-repair-<ts>` 備份即可，quarantine 清單為附加檔可直接刪除。
+
+## Open Questions
+
+無。設計決策已於 2026-07-27 與維護者確認定案。

--- a/openspec/changes/issue-64-ledger-torn-line-repair/proposal.md
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/proposal.md
@@ -1,3 +1,8 @@
+---
+status: accepted
+work_item: issue-64-ledger-torn-line-repair
+---
+
 ## Why
 
 `runtime/ledger/import.jsonl` line 230 是一筆 2026-06-24 的撕裂寫入（577 個 `\x00` 插在一筆完好的 JSON 記錄中間），使 janitor 每輪回報 `skipped 1 bad line(s)`，經 `_run_pass` 的「warnings 非空即不 clean」判定，讓 `hippo dream run` 永久停在 `status: "partial"`、從未全綠。ledger 是 append-only，這行不會自己消失，而目前沒有任何檢查會指出它——這個瑕疵潛伏了 60 天，只能從一句 opaque 的 `partial` 反推。

--- a/openspec/changes/issue-64-ledger-torn-line-repair/proposal.md
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`runtime/ledger/import.jsonl` line 230 是一筆 2026-06-24 的撕裂寫入（577 個 `\x00` 插在一筆完好的 JSON 記錄中間），使 janitor 每輪回報 `skipped 1 bad line(s)`，經 `_run_pass` 的「warnings 非空即不 clean」判定，讓 `hippo dream run` 永久停在 `status: "partial"`、從未全綠。ledger 是 append-only，這行不會自己消失，而目前沒有任何檢查會指出它——這個瑕疵潛伏了 60 天，只能從一句 opaque 的 `partial` 反推。
+
+既有需求「Complete backlog and health semantics」已規定 malformed **inbox artifact** 必須進入 durable quarantine，避免後續週期無限重複同一個 warning；但該原則未涵蓋 **ledger 行**，這正是本次踩到的缺口。
+
+## What Changes
+
+- 新增 `hippo doctor` 的 ledger 完整性檢查：唯讀掃描 `runtime/ledger/*.jsonl`，將每行分類為正常／可救回（移除 NUL 後可解析）／不可救回，並回報檔名與行號。
+- 新增 `hippo ledger repair` 子命令：`--memory-root` 必填、預設 dry-run、`--apply` 才寫入。可救回行原地救回（備份 → 同目錄 temp + fsync + `os.replace`），不可救回行原樣保留不刪除。
+- 新增 quarantine 清單 `runtime/ledger/<name>.jsonl.quarantine`，並讓 janitor 的 bad-line 計數排除已隔離的行——隔離必須雙邊生效，否則不可救回行仍會讓 dream 永久 partial。
+- 修正 health 指標假陽性：health 掃描依 frontmatter `memory_layer: moc` 排除生成的 MOC 索引檔，不再把它們當成缺欄位的 slice 計入 `invalid_frontmatter`（目前恆為 16，等於 MOC 檔數）。
+
+## Capabilities
+
+### New Capabilities
+- `ledger-integrity`: append-only ledger 的位元組層完好性——撕裂行的偵測分類、可救回行的原地救回、不可救回行的雙邊隔離，以及這些操作的原子性與冪等性保證。
+
+### Modified Capabilities
+- `atomization-release-integrity`: 「Complete backlog and health semantics」的 health 計數需排除生成的 MOC 索引檔。MOC 檔依設計不帶 slice frontmatter，將其計入 `invalid_frontmatter` 使該指標永遠無法歸零、失去指示價值。
+
+## Impact
+
+- `paulsha_hippo/cli.py`：新增 `ledger repair` 子命令與 `doctor` 的 ledger 檢查輸出。
+- `paulsha_hippo/janitor/scanner.py`：bad-line 計數排除已隔離行。
+- `paulsha_hippo/ledger/dream.py`：health 掃描排除 `memory_layer: moc`。
+- 新增檔案契約 `runtime/ledger/<name>.jsonl.quarantine`（JSONL）。
+- 不變更 `dream/orchestrator.py` 的 warning → partial 判定語意；dream status 是對外契約，#20 / #34 均引用該語意，修掉壞資料後 warning 自然消失即可轉綠。

--- a/openspec/changes/issue-64-ledger-torn-line-repair/specs/atomization-release-integrity/spec.md
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/specs/atomization-release-integrity/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Complete backlog and health semantics
+
+Machine-readable status SHALL report raw, split, retrying, parked, quarantined, and promoted session counts; oldest backlog age; notes created; generic-title, `_unknown`, invalid checksum/frontmatter counts; eligible/indexed coverage; backend/config/build identity; and a run correlation ID. Repeated malformed inbox artifacts SHALL enter a durable quarantine state with hash/reason/source evidence so subsequent dream cycles do not emit the same warning indefinitely. Health MUST distinguish process success from pipeline `ok`, degraded/partial, failed, and skipped outcomes.
+
+Health counts SHALL be derived from knowledge slices only. Generated MOC index artifacts, identified by their `memory_layer: moc` frontmatter field rather than by filename convention, SHALL be excluded from the generic-title, `_unknown`, invalid checksum and invalid frontmatter counts. Counting generated artifacts that by design carry no slice frontmatter makes those counts unable to reach zero and destroys their diagnostic value.
+
+#### Scenario: Split backlog is visible
+- **WHEN** raw inbox is small but sessions remain in split/parked states
+- **THEN** status SHALL report those states and SHALL NOT represent raw inbox depth as total backlog
+
+#### Scenario: Malformed inbox is quarantined once
+- **WHEN** an inbox artifact lacks required source metadata or cannot be parsed
+- **THEN** it SHALL be preserved in quarantine with evidence and subsequent dream cycles SHALL not repeatedly warn about the same source artifact
+
+#### Scenario: Generated MOC artifacts are not counted as broken slices
+- **WHEN** the knowledge tree contains generated MOC index files carrying `memory_layer: moc`
+- **THEN** health SHALL exclude them from the invalid frontmatter count, and a knowledge tree whose every slice is well-formed SHALL report an invalid frontmatter count of zero
+
+#### Scenario: Genuinely broken slices are still counted
+- **WHEN** the knowledge tree contains a slice that is missing required frontmatter fields and is not a generated MOC artifact
+- **THEN** health SHALL count it in the invalid frontmatter count

--- a/openspec/changes/issue-64-ledger-torn-line-repair/specs/ledger-integrity/spec.md
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/specs/ledger-integrity/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Ledger 撕裂行偵測與分類
+
+診斷輸出 SHALL 唯讀掃描 `runtime/ledger/` 下的每個 `*.jsonl`，將每一行分類為正常、可救回（移除所有 `\x00` 後可解析為 JSON）或不可救回（移除 `\x00` 後仍不可解析），並 SHALL 指名每個受影響檔案與其壞行行號。診斷 MUST NOT 修改任何 ledger 檔案。
+
+#### Scenario: 撕裂行被指名
+- **WHEN** 某 ledger 檔案含一行嵌有 NUL 位元組、但移除後可解析為 JSON 的記錄
+- **THEN** 診斷 SHALL 將該行歸類為可救回，並輸出檔名與行號
+
+#### Scenario: 不可救回行被區分
+- **WHEN** 某 ledger 檔案含一行移除 NUL 後仍不可解析的記錄
+- **THEN** 診斷 SHALL 將該行歸類為不可救回，與可救回行分別計數
+
+#### Scenario: 診斷不觸碰檔案
+- **WHEN** 對含壞行的 ledger 執行診斷
+- **THEN** 所有 ledger 檔案的位元組內容 SHALL 維持不變
+
+### Requirement: 可救回行的原子救回
+
+修復命令 SHALL 預設為 dry-run，僅在明確指定套用旗標時寫入。套用時 SHALL 先建立含時間戳的備份，逐行重建內容時僅自可救回行移除 `\x00`、其餘所有位元組逐一保持不變，並 SHALL 以同目錄暫存檔加 fsync 後原子替換目標檔。備份建立失敗或替換失敗時 SHALL 中止且原檔維持原狀。
+
+#### Scenario: 預設為 dry-run
+- **WHEN** 未指定套用旗標執行修復命令
+- **THEN** 命令 SHALL 報告將被修復的行，且所有 ledger 檔案的 SHA-256 SHALL 維持不變
+
+#### Scenario: 救回只移除 NUL
+- **WHEN** 對含可救回行的 ledger 套用修復
+- **THEN** 該行 SHALL 可解析為 JSON，且檔案其餘所有位元組 SHALL 與修復前逐一相同
+
+#### Scenario: 修復前先備份
+- **WHEN** 套用修復並成功寫入
+- **THEN** SHALL 存在含時間戳的備份檔，其內容 SHALL 與修復前的原檔逐位元組相同
+
+#### Scenario: 冪等
+- **WHEN** 對已修復完成的 ledger 再次套用修復
+- **THEN** 命令 SHALL 為 no-op，SHALL NOT 寫入目標檔，且 SHALL NOT 產生新備份
+
+### Requirement: 不可救回行的雙邊隔離
+
+不可救回行 SHALL 原樣保留於原檔中，不得刪除。修復 SHALL 將其記入同目錄的 quarantine 清單，每筆包含行號、內容 SHA-256、原因與隔離時間。消費該 ledger 的掃描端 SHALL 將已隔離的行排除在壞行計數之外，使後續週期不再重複回報同一個 warning。quarantine 清單不可讀時 SHALL fail-closed，該檔壞行一律照計。
+
+#### Scenario: 不可救回行被隔離而非刪除
+- **WHEN** 對含不可救回行的 ledger 套用修復
+- **THEN** 該行 SHALL 仍存在於原檔且內容不變，並 SHALL 於 quarantine 清單中留下行號、SHA-256、原因與隔離時間
+
+#### Scenario: 已隔離行不再觸發 warning
+- **WHEN** 掃描端處理一個所有壞行皆已隔離的 ledger
+- **THEN** 壞行計數 SHALL 為零，且 SHALL NOT 產生壞行 warning
+
+#### Scenario: quarantine 清單損毀時 fail-closed
+- **WHEN** quarantine 清單存在但無法解析
+- **THEN** 掃描端 SHALL 將該 ledger 的壞行全數計入，SHALL NOT 因清單不可讀而放行

--- a/openspec/changes/issue-64-ledger-torn-line-repair/tasks.md
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/tasks.md
@@ -1,0 +1,62 @@
+---
+status: proposed
+work_item: issue-64-ledger-torn-line-repair
+---
+
+# Issue #64 ledger 撕裂行修復 tasks
+
+依 TDD：每個實作任務前先落紅燈測試。測試置於 `tests/test_ledger_integrity.py`（新增）與既有 janitor / dream health 測試檔。
+
+## 1. 撕裂行分類（偵測核心）
+
+- [ ] 1.1 紅燈：三分類測試——正常行、可救回行（嵌入 `\x00`、移除後可解析）、不可救回行（移除 `\x00` 後仍不可解析），驗證分類結果與行號正確
+- [ ] 1.2 實作分類函式：唯讀掃描單一 `*.jsonl`，回傳每行分類與行號
+- [ ] 1.3 紅燈：掃描不得修改檔案——掃描前後所有 ledger 檔的 SHA-256 不變
+- [ ] 1.4 實作 `runtime/ledger/` 全目錄掃描聚合
+
+## 2. `hippo doctor` ledger 完整性輸出
+
+- [ ] 2.1 紅燈：doctor 對含壞行的 memory root 輸出受影響檔名、行號與可救／不可救分類計數
+- [ ] 2.2 接上 doctor 輸出；確認 ledger 目錄不存在或無 `*.jsonl` 時回報 0 筆且不報錯
+- [ ] 2.3 量測 doctor 在真實規模（`import.jsonl` 24k 行 / 16MB、共 32 個 ledger 檔）的耗時；若顯著拖慢互動式 doctor，改為先以位元組層快篩再逐行解析
+
+## 3. `hippo ledger repair` 命令
+
+- [ ] 3.1 紅燈：預設 dry-run——未帶 `--apply` 時報告待修復行，且所有 ledger 檔 SHA-256 不變
+- [ ] 3.2 紅燈：救回只移除 NUL——`--apply` 後該行可解析，且檔案其餘位元組與修復前逐一相同
+- [ ] 3.3 紅燈：備份存在且與修復前原檔逐位元組相同
+- [ ] 3.4 紅燈：冪等——對已修復檔再次 `--apply` 為 no-op、不寫入、不產生新備份
+- [ ] 3.5 實作命令：`--memory-root` 必填、預設 dry-run、`--apply` 才寫入（沿用 `locks cleanup-legacy` 形狀）
+- [ ] 3.6 實作寫入路徑：備份 → 逐行重建 → 同目錄 temp + fsync + `os.replace`
+- [ ] 3.7 紅燈 + 實作：備份失敗或替換失敗時中止，原檔維持原狀，不進入半修復狀態
+
+## 4. Quarantine 雙邊隔離
+
+- [ ] 4.1 紅燈：不可救回行 `--apply` 後仍原樣存在於原檔，且 quarantine 清單留下行號、SHA-256、原因、隔離時間
+- [ ] 4.2 實作 quarantine 寫入端 `runtime/ledger/<name>.jsonl.quarantine`（JSONL）
+- [ ] 4.3 紅燈：janitor 對「所有壞行皆已隔離」的 ledger 壞行計數為 0 且不產生 warning
+- [ ] 4.4 實作 janitor 讀取端：`_build_import_index` 的壞行計數排除已隔離行，以內容 SHA-256 為主鍵、行號為輔助
+- [ ] 4.5 紅燈 + 實作：quarantine 清單存在但不可解析時 fail-closed，該檔壞行全數照計
+
+## 5. health 指標假陽性
+
+- [ ] 5.1 紅燈：knowledge 樹含生成的 MOC 索引檔（`memory_layer: moc`）時，`invalid_frontmatter` 為 0
+- [ ] 5.2 紅燈：真正缺必要欄位且非 MOC 的 slice 仍計入 `invalid_frontmatter`
+- [ ] 5.3 實作：`ledger/dream.py` health 掃描依 `memory_layer == "moc"` skip，同時排除於 `generic_title` 與 `unknown_project` 計數
+
+## 6. 交付治理
+
+- [ ] 6.1 新增 `changelog.d/64-ledger-torn-line-repair.md` 碎片（zh-tw）
+- [ ] 6.2 `VERSION` 維持 `0.1.1` 不動（非 release PR）
+- [ ] 6.3 全套 `pytest` 通過
+- [ ] 6.4 `python3 -m policy_check --repo .` 無 failure
+- [ ] 6.5 `openspec validate issue-64-ledger-torn-line-repair --strict` 通過
+- [ ] 6.6 PR body 帶 `Closes #64`，checklist 全勾
+
+## 7. 合併後 runtime 修復（不在 PR diff 內）
+
+- [ ] 7.1 備份 `~/.agents/memory/runtime/ledger/import.jsonl`
+- [ ] 7.2 dry-run 確認僅 line 230 列為可救回
+- [ ] 7.3 `--apply` 修復 line 230
+- [ ] 7.4 `hippo requeue` 兩個 parked session（`claude-code__3c0a8d08…` 68 frags、`claude-code__66f5eed9…` 51 frags）
+- [ ] 7.5 `hippo dream run` 確認 `status: "ok"` 且 `invalid_frontmatter: 0`

--- a/openspec/changes/issue-64-ledger-torn-line-repair/tasks.md
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/tasks.md
@@ -9,49 +9,49 @@ work_item: issue-64-ledger-torn-line-repair
 
 ## 1. 撕裂行分類（偵測核心）
 
-- [ ] 1.1 紅燈：三分類測試——正常行、可救回行（嵌入 `\x00`、移除後可解析）、不可救回行（移除 `\x00` 後仍不可解析），驗證分類結果與行號正確
-- [ ] 1.2 實作分類函式：唯讀掃描單一 `*.jsonl`，回傳每行分類與行號
-- [ ] 1.3 紅燈：掃描不得修改檔案——掃描前後所有 ledger 檔的 SHA-256 不變
-- [ ] 1.4 實作 `runtime/ledger/` 全目錄掃描聚合
+- [x] 1.1 紅燈：三分類測試——正常行、可救回行（嵌入 `\x00`、移除後可解析）、不可救回行（移除 `\x00` 後仍不可解析），驗證分類結果與行號正確
+- [x] 1.2 實作分類函式：唯讀掃描單一 `*.jsonl`，回傳每行分類與行號
+- [x] 1.3 紅燈：掃描不得修改檔案——掃描前後所有 ledger 檔的 SHA-256 不變
+- [x] 1.4 實作 `runtime/ledger/` 全目錄掃描聚合
 
 ## 2. `hippo doctor` ledger 完整性輸出
 
-- [ ] 2.1 紅燈：doctor 對含壞行的 memory root 輸出受影響檔名、行號與可救／不可救分類計數
-- [ ] 2.2 接上 doctor 輸出；確認 ledger 目錄不存在或無 `*.jsonl` 時回報 0 筆且不報錯
-- [ ] 2.3 量測 doctor 在真實規模（`import.jsonl` 24k 行 / 16MB、共 32 個 ledger 檔）的耗時；若顯著拖慢互動式 doctor，改為先以位元組層快篩再逐行解析
+- [x] 2.1 紅燈：doctor 對含壞行的 memory root 輸出受影響檔名、行號與可救／不可救分類計數
+- [x] 2.2 接上 doctor 輸出；確認 ledger 目錄不存在或無 `*.jsonl` 時回報 0 筆且不報錯
+- [x] 2.3 量測 doctor 在真實規模（`import.jsonl` 24k 行 / 16MB、共 32 個 ledger 檔）的耗時；若顯著拖慢互動式 doctor，改為先以位元組層快篩再逐行解析
 
 ## 3. `hippo ledger repair` 命令
 
-- [ ] 3.1 紅燈：預設 dry-run——未帶 `--apply` 時報告待修復行，且所有 ledger 檔 SHA-256 不變
-- [ ] 3.2 紅燈：救回只移除 NUL——`--apply` 後該行可解析，且檔案其餘位元組與修復前逐一相同
-- [ ] 3.3 紅燈：備份存在且與修復前原檔逐位元組相同
-- [ ] 3.4 紅燈：冪等——對已修復檔再次 `--apply` 為 no-op、不寫入、不產生新備份
-- [ ] 3.5 實作命令：`--memory-root` 必填、預設 dry-run、`--apply` 才寫入（沿用 `locks cleanup-legacy` 形狀）
-- [ ] 3.6 實作寫入路徑：備份 → 逐行重建 → 同目錄 temp + fsync + `os.replace`
-- [ ] 3.7 紅燈 + 實作：備份失敗或替換失敗時中止，原檔維持原狀，不進入半修復狀態
+- [x] 3.1 紅燈：預設 dry-run——未帶 `--apply` 時報告待修復行，且所有 ledger 檔 SHA-256 不變
+- [x] 3.2 紅燈：救回只移除 NUL——`--apply` 後該行可解析，且檔案其餘位元組與修復前逐一相同
+- [x] 3.3 紅燈：備份存在且與修復前原檔逐位元組相同
+- [x] 3.4 紅燈：冪等——對已修復檔再次 `--apply` 為 no-op、不寫入、不產生新備份
+- [x] 3.5 實作命令：`--memory-root` 必填、預設 dry-run、`--apply` 才寫入（沿用 `locks cleanup-legacy` 形狀）
+- [x] 3.6 實作寫入路徑：備份 → 逐行重建 → 同目錄 temp + fsync + `os.replace`
+- [x] 3.7 紅燈 + 實作：備份失敗或替換失敗時中止，原檔維持原狀，不進入半修復狀態
 
 ## 4. Quarantine 雙邊隔離
 
-- [ ] 4.1 紅燈：不可救回行 `--apply` 後仍原樣存在於原檔，且 quarantine 清單留下行號、SHA-256、原因、隔離時間
-- [ ] 4.2 實作 quarantine 寫入端 `runtime/ledger/<name>.jsonl.quarantine`（JSONL）
-- [ ] 4.3 紅燈：janitor 對「所有壞行皆已隔離」的 ledger 壞行計數為 0 且不產生 warning
-- [ ] 4.4 實作 janitor 讀取端：`_build_import_index` 的壞行計數排除已隔離行，以內容 SHA-256 為主鍵、行號為輔助
-- [ ] 4.5 紅燈 + 實作：quarantine 清單存在但不可解析時 fail-closed，該檔壞行全數照計
+- [x] 4.1 紅燈：不可救回行 `--apply` 後仍原樣存在於原檔，且 quarantine 清單留下行號、SHA-256、原因、隔離時間
+- [x] 4.2 實作 quarantine 寫入端 `runtime/ledger/<name>.jsonl.quarantine`（JSONL）
+- [x] 4.3 紅燈：janitor 對「所有壞行皆已隔離」的 ledger 壞行計數為 0 且不產生 warning
+- [x] 4.4 實作 janitor 讀取端：`_build_import_index` 的壞行計數排除已隔離行，以內容 SHA-256 為主鍵、行號為輔助
+- [x] 4.5 紅燈 + 實作：quarantine 清單存在但不可解析時 fail-closed，該檔壞行全數照計
 
 ## 5. health 指標假陽性
 
-- [ ] 5.1 紅燈：knowledge 樹含生成的 MOC 索引檔（`memory_layer: moc`）時，`invalid_frontmatter` 為 0
-- [ ] 5.2 紅燈：真正缺必要欄位且非 MOC 的 slice 仍計入 `invalid_frontmatter`
-- [ ] 5.3 實作：`ledger/dream.py` health 掃描依 `memory_layer == "moc"` skip，同時排除於 `generic_title` 與 `unknown_project` 計數
+- [x] 5.1 紅燈：knowledge 樹含生成的 MOC 索引檔（`memory_layer: moc`）時，`invalid_frontmatter` 為 0
+- [x] 5.2 紅燈：真正缺必要欄位且非 MOC 的 slice 仍計入 `invalid_frontmatter`
+- [x] 5.3 實作：`ledger/dream.py` health 掃描依 `memory_layer == "moc"` skip，同時排除於 `generic_title` 與 `unknown_project` 計數
 
 ## 6. 交付治理
 
-- [ ] 6.1 新增 `changelog.d/64-ledger-torn-line-repair.md` 碎片（zh-tw）
-- [ ] 6.2 `VERSION` 維持 `0.1.1` 不動（非 release PR）
-- [ ] 6.3 全套 `pytest` 通過
-- [ ] 6.4 `python3 -m policy_check --repo .` 無 failure
-- [ ] 6.5 `openspec validate issue-64-ledger-torn-line-repair --strict` 通過
-- [ ] 6.6 PR body 帶 `Closes #64`，checklist 全勾
+- [x] 6.1 新增 `changelog.d/64-ledger-torn-line-repair.md` 碎片（zh-tw）
+- [x] 6.2 `VERSION` 維持 `0.1.1` 不動（非 release PR）
+- [x] 6.3 全套 `pytest` 通過
+- [x] 6.4 `python3 -m policy_check --repo .` 無 failure
+- [x] 6.5 `openspec validate issue-64-ledger-torn-line-repair --strict` 通過
+- [x] 6.6 PR body 帶 `Closes #64`，checklist 全勾
 
 ## 7. 合併後 runtime 修復（不在 PR diff 內）
 

--- a/openspec/changes/issue-64-ledger-torn-line-repair/tasks.md
+++ b/openspec/changes/issue-64-ledger-torn-line-repair/tasks.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 work_item: issue-64-ledger-torn-line-repair
 ---
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/paulsha_hippo/cli.py
+++ b/paulsha_hippo/cli.py
@@ -429,6 +429,18 @@ def _build_parser() -> argparse.ArgumentParser:
     locks_cleanup.add_argument("--apply", action="store_true")
     locks_cleanup.set_defaults(func=_locks_cleanup_legacy)
 
+    ledger_p = memory_subparsers.add_parser("ledger", help="append-only ledger 維運")
+    ledger_sub = ledger_p.add_subparsers(dest="ledger_command", required=True)
+    ledger_repair = ledger_sub.add_parser(
+        "repair",
+        help="修復 ledger 撕裂行（僅維護窗口；預設 dry-run）",
+    )
+    ledger_repair.add_argument("--memory-root", required=True)
+    ledger_repair.add_argument("--apply", action="store_true")
+    ledger_repair.add_argument("--now", default=None,
+                               help="ISO8601 時間戳；未給時取當下 UTC")
+    ledger_repair.set_defaults(func=_ledger_repair)
+
     requeue_p = memory_subparsers.add_parser(
         "requeue", help="把 parked session 送回 split 重走 promote（#15 恢復路徑）"
     )
@@ -1891,6 +1903,19 @@ def _locks_cleanup_legacy(args: argparse.Namespace) -> int:
     if (result.get("blocked") or result.get("busy")
             or result.get("unknown") or result.get("unsafe_locks_dir")):
         return 1
+    return 0
+
+
+def _ledger_repair(args: argparse.Namespace) -> int:
+    from datetime import datetime, timezone
+
+    from paulsha_hippo.ledger import integrity
+
+    now = args.now or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    results = integrity.repair_ledger_dir(
+        Path(args.memory_root), apply=args.apply, now=now
+    )
+    print(json.dumps(results, ensure_ascii=False, sort_keys=True))
     return 0
 
 

--- a/paulsha_hippo/ledger/dream.py
+++ b/paulsha_hippo/ledger/dream.py
@@ -179,6 +179,10 @@ def backlog_census(memory_root: Path, *, now: str | None = None) -> dict[str, An
             except (OSError, UnicodeError):
                 invalid_frontmatter += 1
                 continue
+            # 生成的 MOC 索引檔依設計不帶 slice frontmatter，計入會讓這些指標
+            # 永遠無法歸零而失去診斷價值（issue #64）。以欄位而非檔名判別。
+            if str(frontmatter.get("memory_layer") or "") == "moc":
+                continue
             required = ("slice_id", "project", "checksum", "memory_layer")
             if not frontmatter or any(field not in frontmatter for field in required):
                 invalid_frontmatter += 1

--- a/paulsha_hippo/ledger/import_log.py
+++ b/paulsha_hippo/ledger/import_log.py
@@ -63,7 +63,11 @@ def read_import_records(import_log_path: Path) -> list[dict]:
 
 
 def read_import_records_tolerant(import_log_path: Path) -> tuple[list[dict], int]:
-    """Read import records while skipping empty or malformed JSONL rows."""
+    """Read import records while skipping empty or malformed JSONL rows.
+
+    已進入 quarantine 清單的壞行不計入 bad_line_count（issue #64 雙邊隔離的
+    讀取端）。清單存在但不可解析時 fail-closed：壞行一律照計。
+    """
     if not import_log_path.exists():
         return [], 0
 
@@ -75,18 +79,26 @@ def read_import_records_tolerant(import_log_path: Path) -> tuple[list[dict], int
     if not content.strip():
         return [], 0
 
+    from . import integrity
+
+    quarantined = integrity.read_quarantine(import_log_path)
+    if quarantined is None:
+        quarantined = frozenset()
+
     records: list[dict] = []
     bad_line_count = 0
-    for line in content.splitlines():
-        line = line.strip()
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
         if not line:
-            bad_line_count += 1
+            if integrity.line_sha256(raw_line) not in quarantined:
+                bad_line_count += 1
             continue
 
         try:
             record = json.loads(line)
         except json.JSONDecodeError:
-            bad_line_count += 1
+            if integrity.line_sha256(raw_line) not in quarantined:
+                bad_line_count += 1
             continue
 
         records.append(record)

--- a/paulsha_hippo/ledger/integrity.py
+++ b/paulsha_hippo/ledger/integrity.py
@@ -156,3 +156,64 @@ def append_quarantine(ledger_path: Path, findings: list[LineFinding], *, now: st
         handle.flush()
         os.fsync(handle.fileno())
     return len(rows)
+
+
+def _backup_name(path: Path, now: str) -> str:
+    stamp = now.replace(":", "").replace("-", "")
+    return f"{path.name}.bak-repair-{stamp}"
+
+
+def repair_file(path: Path, *, apply: bool, now: str) -> dict:
+    findings = scan_file(path)
+    recoverable = [f for f in findings if f.classification == "recoverable"]
+    unrecoverable = [f for f in findings if f.classification == "unrecoverable"]
+    result: dict = {
+        "file": str(path),
+        "recoverable": len(recoverable),
+        "unrecoverable": len(unrecoverable),
+        "quarantined": 0,
+        "backup": None,
+        "applied": False,
+    }
+    if not apply:
+        return result
+
+    if unrecoverable:
+        result["quarantined"] = append_quarantine(path, unrecoverable, now=now)
+
+    if not recoverable:
+        # 冪等：沒有可救回行就不寫檔、不備份。
+        return result
+
+    targets = {f.line_no for f in recoverable}
+    lines = _read_lines(path)
+    rebuilt = [
+        line.replace(NUL, "") if index in targets else line
+        for index, line in enumerate(lines, start=1)
+    ]
+
+    backup = path.with_name(_backup_name(path, now))
+    backup.write_bytes(path.read_bytes())
+
+    tmp = path.with_name(f".{path.name}.repair.tmp")
+    with tmp.open("w", encoding="utf-8", errors="surrogateescape") as handle:
+        handle.write("\n".join(rebuilt) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+    result["backup"] = str(backup)
+    result["applied"] = True
+    return result
+
+
+def repair_ledger_dir(memory_root: Path, *, apply: bool, now: str) -> list[dict]:
+    directory = ledger_dir(memory_root)
+    if not directory.is_dir():
+        return []
+    results = []
+    for path in sorted(directory.glob("*.jsonl")):
+        outcome = repair_file(path, apply=apply, now=now)
+        if outcome["recoverable"] or outcome["unrecoverable"]:
+            results.append(outcome)
+    return results

--- a/paulsha_hippo/ledger/integrity.py
+++ b/paulsha_hippo/ledger/integrity.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -94,3 +95,64 @@ def scan_ledger_dir(memory_root: Path) -> dict[str, list[LineFinding]]:
         if findings:
             result[path.name] = findings
     return result
+
+
+def quarantine_path(ledger_path: Path) -> Path:
+    return ledger_path.with_name(ledger_path.name + QUARANTINE_SUFFIX)
+
+
+def read_quarantine(ledger_path: Path) -> frozenset[str] | None:
+    """已隔離行的 sha256 集合。
+
+    清單不存在 → 空集合。清單存在但任一行不可解析 → None，呼叫端必須
+    fail-closed（壞行一律照計），不得因清單不可讀而放行。
+    """
+    path = quarantine_path(ledger_path)
+    if not path.is_file():
+        return frozenset()
+    hashes: set[str] = set()
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in content.splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        digest = record.get("sha256")
+        if not isinstance(digest, str) or not digest:
+            return None
+        hashes.add(digest)
+    return frozenset(hashes)
+
+
+def append_quarantine(ledger_path: Path, findings: list[LineFinding], *, now: str) -> int:
+    """把不可救回行記入 quarantine 清單，回傳實際新增筆數（已存在者不重複記）。"""
+    existing = read_quarantine(ledger_path)
+    if existing is None:
+        raise ValueError(f"quarantine 清單不可解析：{quarantine_path(ledger_path)}")
+    rows = [f for f in findings if f.classification == "unrecoverable" and f.sha256 not in existing]
+    if not rows:
+        return 0
+    path = quarantine_path(ledger_path)
+    with path.open("a", encoding="utf-8") as handle:
+        for finding in rows:
+            handle.write(
+                json.dumps(
+                    {
+                        "line_no": finding.line_no,
+                        "sha256": finding.sha256,
+                        "reason": finding.reason,
+                        "quarantined_at": now,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+        handle.flush()
+        os.fsync(handle.fileno())
+    return len(rows)

--- a/paulsha_hippo/ledger/integrity.py
+++ b/paulsha_hippo/ledger/integrity.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass
+from pathlib import Path
 
 NUL = "\x00"
 QUARANTINE_SUFFIX = ".quarantine"
@@ -43,3 +45,52 @@ def classify_line(line: str) -> tuple[str, str]:
     except json.JSONDecodeError:
         return ("unrecoverable", "unparseable")
     return ("recoverable", "nul-torn")
+
+
+@dataclass(frozen=True)
+class LineFinding:
+    line_no: int
+    sha256: str
+    classification: str
+    reason: str
+
+
+def _read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8", errors="surrogateescape").splitlines()
+
+
+def scan_file(path: Path) -> list[LineFinding]:
+    """唯讀掃描單一 JSONL，只回傳非 ok 的行。行號為 1-indexed。"""
+    if not path.is_file():
+        return []
+    findings: list[LineFinding] = []
+    for index, line in enumerate(_read_lines(path), start=1):
+        classification, reason = classify_line(line)
+        if classification == "ok":
+            continue
+        findings.append(
+            LineFinding(
+                line_no=index,
+                sha256=line_sha256(line),
+                classification=classification,
+                reason=reason,
+            )
+        )
+    return findings
+
+
+def ledger_dir(memory_root: Path) -> Path:
+    return memory_root / "runtime" / "ledger"
+
+
+def scan_ledger_dir(memory_root: Path) -> dict[str, list[LineFinding]]:
+    """掃描 runtime/ledger/*.jsonl，只回傳有壞行的檔（key 為檔名）。"""
+    directory = ledger_dir(memory_root)
+    if not directory.is_dir():
+        return {}
+    result: dict[str, list[LineFinding]] = {}
+    for path in sorted(directory.glob("*.jsonl")):
+        findings = scan_file(path)
+        if findings:
+            result[path.name] = findings
+    return result

--- a/paulsha_hippo/ledger/integrity.py
+++ b/paulsha_hippo/ledger/integrity.py
@@ -1,0 +1,45 @@
+# paulsha_hippo/ledger/integrity.py
+"""Append-only ledger 的位元組層完好性：撕裂行分類、原子修復、quarantine。
+
+本模組只認識 JSONL 檔案與行，不知道 janitor / doctor / dream 的存在。
+消費端自行接上（issue #64）。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+NUL = "\x00"
+QUARANTINE_SUFFIX = ".quarantine"
+
+
+def line_sha256(line: str) -> str:
+    """行的正規雜湊：不含結尾換行、不做 strip，寫入端與讀取端共用同一定義。"""
+    return hashlib.sha256(line.encode("utf-8")).hexdigest()
+
+
+def classify_line(line: str) -> tuple[str, str]:
+    """回傳 (classification, reason)。
+
+    classification 為 "ok" / "recoverable" / "unrecoverable"。空白行歸為
+    unrecoverable：既有 reader 也把空白行計為 bad line，若視為 ok 則
+    「修復後壞行計數歸零」的不變量不成立。
+    """
+    stripped = line.strip().replace(NUL, "").strip()
+    if not stripped:
+        return ("unrecoverable", "blank")
+
+    candidate = line.strip()
+    try:
+        json.loads(candidate)
+    except json.JSONDecodeError:
+        pass
+    else:
+        return ("ok", "")
+
+    try:
+        json.loads(stripped)
+    except json.JSONDecodeError:
+        return ("unrecoverable", "unparseable")
+    return ("recoverable", "nul-torn")

--- a/paulsha_hippo/ops.py
+++ b/paulsha_hippo/ops.py
@@ -1301,6 +1301,23 @@ def _print_runtime_health(memory_root: Path, *,
                           proc_root: str | Path = "/proc") -> None:
     """doctor 的 runtime 健康報告段落（#19）：只報告，不自動 kill、不影響 exit code。"""
     print(f"- dream lock（runtime/locks/dream.lock）：{dream_lock_status(memory_root)}")
+
+    from .ledger import integrity
+
+    ledger_findings = integrity.scan_ledger_dir(memory_root)
+    if not ledger_findings:
+        print("- ledger 完整性：✓ 無撕裂行")
+    else:
+        for name, findings in ledger_findings.items():
+            recoverable = [f for f in findings if f.classification == "recoverable"]
+            unrecoverable = [f for f in findings if f.classification == "unrecoverable"]
+            lines = ", ".join(str(f.line_no) for f in findings[:10])
+            suffix = " …" if len(findings) > 10 else ""
+            print(
+                f"- ledger 完整性：✗ {name} 可救回 {len(recoverable)}／"
+                f"不可救回 {len(unrecoverable)}（行 {lines}{suffix}）"
+                "——`hippo ledger repair --memory-root <root> --apply`"
+            )
     reports = dream_process_report(proc_root=proc_root)
     if not reports:
         print("- dream/supervise 進程：無")

--- a/tests/test_ledger_integrity.py
+++ b/tests/test_ledger_integrity.py
@@ -91,3 +91,41 @@ def test_scan_ledger_dir_ignores_quarantine_sidecars(tmp_path):
     _write_ledger(tmp_path, "import.jsonl.quarantine", ["not json at all"])
 
     assert integrity.scan_ledger_dir(tmp_path) == {}
+
+
+def test_read_quarantine_missing_returns_empty(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", [json.dumps({"n": 1})])
+    assert integrity.read_quarantine(path) == frozenset()
+
+
+def test_append_then_read_quarantine_roundtrip(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", ['{"n": '])
+    findings = integrity.scan_file(path)
+
+    written = integrity.append_quarantine(path, findings, now="2026-07-27T00:00:00Z")
+
+    assert written == 1
+    assert integrity.read_quarantine(path) == frozenset({findings[0].sha256})
+    record = json.loads(integrity.quarantine_path(path).read_text().splitlines()[0])
+    assert record["line_no"] == 1
+    assert record["sha256"] == findings[0].sha256
+    assert record["reason"] == "unparseable"
+    assert record["quarantined_at"] == "2026-07-27T00:00:00Z"
+
+
+def test_append_quarantine_is_idempotent(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", ['{"n": '])
+    findings = integrity.scan_file(path)
+    integrity.append_quarantine(path, findings, now="2026-07-27T00:00:00Z")
+
+    written = integrity.append_quarantine(path, findings, now="2026-07-27T01:00:00Z")
+
+    assert written == 0
+    assert len(integrity.quarantine_path(path).read_text().splitlines()) == 1
+
+
+def test_read_quarantine_corrupt_returns_none_fail_closed(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", ['{"n": '])
+    integrity.quarantine_path(path).write_text("這不是 JSON\n", encoding="utf-8")
+
+    assert integrity.read_quarantine(path) is None

--- a/tests/test_ledger_integrity.py
+++ b/tests/test_ledger_integrity.py
@@ -277,3 +277,45 @@ def test_corrupt_quarantine_list_fails_closed(tmp_path):
     _records, bad = import_log.read_import_records_tolerant(path)
 
     assert bad == 1
+
+# ── Task 6：health 掃描排除生成的 MOC 索引檔 ──────────────────────────────────
+from paulsha_hippo.ledger import dream as dream_ledger
+
+
+def _write_slice(root, name, body="內容", **fm):
+    fields = {
+        "slice_id": "sl-1",
+        "project": "p",
+        "checksum": "deadbeef",
+        "memory_layer": "knowledge",
+    }
+    fields.update(fm)
+    lines = ["---"] + [f"{k}: {v}" for k, v in fields.items()] + ["---", body]
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def test_generated_moc_is_not_counted_as_invalid_frontmatter(tmp_path):
+    knowledge = tmp_path / "knowledge"
+    knowledge.mkdir(parents=True)
+    (knowledge / "wiki-moc.md").write_text(
+        "---\nmemory_layer: moc\nmoc_kind: wiki\n---\n# Wiki MOC\n", encoding="utf-8"
+    )
+
+    health = dream_ledger.backlog_census(tmp_path, now="2026-07-27T00:00:00Z")
+
+    assert health["invalid_frontmatter"] == 0
+
+
+def test_genuinely_broken_slice_is_still_counted(tmp_path):
+    knowledge = tmp_path / "knowledge"
+    knowledge.mkdir(parents=True)
+    (knowledge / "broken.md").write_text(
+        "---\nmemory_layer: knowledge\n---\n內容\n", encoding="utf-8"
+    )
+
+    health = dream_ledger.backlog_census(tmp_path, now="2026-07-27T00:00:00Z")
+
+    assert health["invalid_frontmatter"] == 1

--- a/tests/test_ledger_integrity.py
+++ b/tests/test_ledger_integrity.py
@@ -319,3 +319,34 @@ def test_genuinely_broken_slice_is_still_counted(tmp_path):
     health = dream_ledger.backlog_census(tmp_path, now="2026-07-27T00:00:00Z")
 
     assert health["invalid_frontmatter"] == 1
+
+# ── Task 7：hippo ledger repair 子命令 ────────────────────────────────────────
+from paulsha_hippo import cli
+
+
+def test_cli_ledger_repair_dry_run_leaves_file_untouched(tmp_path, capsys):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good[:3] + "\x00" + good[3:]])
+    before = hashlib.sha256(path.read_bytes()).hexdigest()
+
+    code = cli.main(["ledger", "repair", "--memory-root", str(tmp_path)])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload[0]["recoverable"] == 1
+    assert payload[0]["applied"] is False
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == before
+
+
+def test_cli_ledger_repair_apply_fixes_line(tmp_path, capsys):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good[:3] + "\x00" + good[3:]])
+
+    code = cli.main([
+        "ledger", "repair", "--memory-root", str(tmp_path),
+        "--apply", "--now", "2026-07-27T00:00:00Z",
+    ])
+
+    capsys.readouterr()
+    assert code == 0
+    assert json.loads(path.read_text(encoding="utf-8").splitlines()[0]) == {"n": 1}

--- a/tests/test_ledger_integrity.py
+++ b/tests/test_ledger_integrity.py
@@ -243,3 +243,37 @@ def test_backup_failure_aborts_before_touching_original(tmp_path, monkeypatch):
         integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
 
     assert path.read_bytes() == original
+
+# ── Task 5：janitor 讀取端排除已隔離行 ────────────────────────────────────────
+from paulsha_hippo.ledger import import_log
+
+
+def test_quarantined_bad_line_is_not_counted(tmp_path):
+    good = json.dumps({"idempotency_key": "k", "status": "written"}, sort_keys=True)
+    broken = '{"n": '
+    path = _write_ledger(tmp_path, "import.jsonl", [good, broken])
+    integrity.append_quarantine(path, integrity.scan_file(path), now="2026-07-27T00:00:00Z")
+
+    records, bad = import_log.read_import_records_tolerant(path)
+
+    assert bad == 0
+    assert len(records) == 1
+
+
+def test_unquarantined_bad_line_is_still_counted(tmp_path):
+    good = json.dumps({"idempotency_key": "k", "status": "written"}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good, '{"n": '])
+
+    _records, bad = import_log.read_import_records_tolerant(path)
+
+    assert bad == 1
+
+
+def test_corrupt_quarantine_list_fails_closed(tmp_path):
+    good = json.dumps({"idempotency_key": "k", "status": "written"}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good, '{"n": '])
+    integrity.quarantine_path(path).write_text("這不是 JSON\n", encoding="utf-8")
+
+    _records, bad = import_log.read_import_records_tolerant(path)
+
+    assert bad == 1

--- a/tests/test_ledger_integrity.py
+++ b/tests/test_ledger_integrity.py
@@ -1,0 +1,35 @@
+# tests/test_ledger_integrity.py
+import json
+
+from paulsha_hippo.ledger import integrity
+
+
+def test_classify_ok_line():
+    line = json.dumps({"status": "written"}, sort_keys=True)
+    assert integrity.classify_line(line) == ("ok", "")
+
+
+def test_classify_nul_torn_line_is_recoverable():
+    payload = json.dumps({"status": "written", "id": "abc"}, sort_keys=True)
+    torn = payload[:10] + "\x00" * 577 + payload[10:]
+    assert integrity.classify_line(torn) == ("recoverable", "nul-torn")
+
+
+def test_classify_blank_line_is_unrecoverable_blank():
+    assert integrity.classify_line("") == ("unrecoverable", "blank")
+    assert integrity.classify_line("   ") == ("unrecoverable", "blank")
+
+
+def test_classify_truncated_json_is_unrecoverable():
+    assert integrity.classify_line('{"status": "writ') == ("unrecoverable", "unparseable")
+
+
+def test_classify_all_nul_line_is_unrecoverable():
+    assert integrity.classify_line("\x00" * 32) == ("unrecoverable", "blank")
+
+
+def test_line_sha256_is_over_raw_line_without_strip():
+    import hashlib
+
+    line = '  {"a": 1}  '
+    assert integrity.line_sha256(line) == hashlib.sha256(line.encode("utf-8")).hexdigest()

--- a/tests/test_ledger_integrity.py
+++ b/tests/test_ledger_integrity.py
@@ -1,5 +1,7 @@
 # tests/test_ledger_integrity.py
 import json
+import hashlib
+from pathlib import Path
 
 from paulsha_hippo.ledger import integrity
 
@@ -33,3 +35,59 @@ def test_line_sha256_is_over_raw_line_without_strip():
 
     line = '  {"a": 1}  '
     assert integrity.line_sha256(line) == hashlib.sha256(line.encode("utf-8")).hexdigest()
+
+
+def _write_ledger(tmp_path: Path, name: str, lines: list[str]) -> Path:
+    path = tmp_path / "runtime" / "ledger" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_scan_file_reports_line_numbers_and_classification(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:4] + "\x00" * 8 + good[4:]
+    path = _write_ledger(tmp_path, "import.jsonl", [good, torn, '{"n": '])
+
+    findings = integrity.scan_file(path)
+
+    assert [f.line_no for f in findings] == [2, 3]
+    assert findings[0].classification == "recoverable"
+    assert findings[0].reason == "nul-torn"
+    assert findings[0].sha256 == integrity.line_sha256(torn)
+    assert findings[1].classification == "unrecoverable"
+    assert findings[1].reason == "unparseable"
+
+
+def test_scan_file_on_clean_ledger_returns_empty(tmp_path):
+    path = _write_ledger(tmp_path, "import.jsonl", [json.dumps({"n": 1})])
+    assert integrity.scan_file(path) == []
+
+
+def test_scan_file_does_not_modify_the_file(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    path = _write_ledger(tmp_path, "import.jsonl", [good, good[:3] + "\x00" + good[3:]])
+    before = hashlib.sha256(path.read_bytes()).hexdigest()
+
+    integrity.scan_file(path)
+
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == before
+
+
+def test_scan_ledger_dir_skips_clean_files_and_missing_dir(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    _write_ledger(tmp_path, "clean.jsonl", [good])
+    _write_ledger(tmp_path, "import.jsonl", [good[:3] + "\x00" + good[3:]])
+
+    result = integrity.scan_ledger_dir(tmp_path)
+
+    assert set(result) == {"import.jsonl"}
+    assert integrity.scan_ledger_dir(tmp_path / "nope") == {}
+
+
+def test_scan_ledger_dir_ignores_quarantine_sidecars(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    _write_ledger(tmp_path, "import.jsonl", [good])
+    _write_ledger(tmp_path, "import.jsonl.quarantine", ["not json at all"])
+
+    assert integrity.scan_ledger_dir(tmp_path) == {}

--- a/tests/test_ledger_integrity.py
+++ b/tests/test_ledger_integrity.py
@@ -1,6 +1,7 @@
 # tests/test_ledger_integrity.py
 import json
 import hashlib
+import pytest
 from pathlib import Path
 
 from paulsha_hippo.ledger import integrity
@@ -129,3 +130,116 @@ def test_read_quarantine_corrupt_returns_none_fail_closed(tmp_path):
     integrity.quarantine_path(path).write_text("這不是 JSON\n", encoding="utf-8")
 
     assert integrity.read_quarantine(path) is None
+
+
+def test_dry_run_does_not_touch_file(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" * 5 + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [good, torn])
+    before = hashlib.sha256(path.read_bytes()).hexdigest()
+
+    result = integrity.repair_file(path, apply=False, now="2026-07-27T00:00:00Z")
+
+    assert result["recoverable"] == 1
+    assert result["applied"] is False
+    assert result["backup"] is None
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == before
+    assert not integrity.quarantine_path(path).exists()
+
+
+def test_apply_removes_only_nul_and_preserves_every_other_byte(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    other = json.dumps({"n": 2}, sort_keys=True)
+    torn = good[:3] + "\x00" * 577 + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [other, torn, other])
+
+    result = integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert result["applied"] is True
+    assert json.loads(lines[1]) == {"n": 1}
+    assert lines[0] == other and lines[2] == other
+    assert "\x00" not in path.read_text(encoding="utf-8")
+
+
+def test_apply_writes_backup_identical_to_original(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [torn])
+    original = path.read_bytes()
+
+    result = integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    backup = Path(result["backup"])
+    assert backup.exists()
+    assert backup.read_bytes() == original
+
+
+def test_apply_is_idempotent(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [torn])
+    integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+    after_first = path.read_bytes()
+    backups_before = sorted(p.name for p in path.parent.glob("import.jsonl.bak-repair-*"))
+
+    result = integrity.repair_file(path, apply=True, now="2026-07-27T02:00:00Z")
+
+    assert result["recoverable"] == 0
+    assert result["backup"] is None
+    assert path.read_bytes() == after_first
+    assert sorted(p.name for p in path.parent.glob("import.jsonl.bak-repair-*")) == backups_before
+
+
+def test_apply_keeps_unrecoverable_line_in_place_and_quarantines_it(tmp_path):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    broken = '{"n": '
+    path = _write_ledger(tmp_path, "import.jsonl", [torn, broken])
+
+    result = integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[1] == broken
+    assert result["quarantined"] == 1
+    assert integrity.read_quarantine(path) == frozenset({integrity.line_sha256(broken)})
+
+
+def test_replace_failure_leaves_original_intact(tmp_path, monkeypatch):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [torn])
+    original = path.read_bytes()
+
+    def boom(_src, _dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(integrity.os, "replace", boom)
+
+    with pytest.raises(OSError):
+        integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    assert path.read_bytes() == original
+    backups = list(path.parent.glob("import.jsonl.bak-repair-*"))
+    assert len(backups) == 1 and backups[0].read_bytes() == original
+
+
+def test_backup_failure_aborts_before_touching_original(tmp_path, monkeypatch):
+    good = json.dumps({"n": 1}, sort_keys=True)
+    torn = good[:3] + "\x00" + good[3:]
+    path = _write_ledger(tmp_path, "import.jsonl", [torn])
+    original = path.read_bytes()
+
+    real_write_bytes = Path.write_bytes
+
+    def boom(self, data):
+        if ".bak-repair-" in self.name:
+            raise OSError("backup failed")
+        return real_write_bytes(self, data)
+
+    monkeypatch.setattr(Path, "write_bytes", boom)
+
+    with pytest.raises(OSError):
+        integrity.repair_file(path, apply=True, now="2026-07-27T00:00:00Z")
+
+    assert path.read_bytes() == original


### PR DESCRIPTION
## 摘要

修復 `hippo dream run` 長期停在 `status: "partial"` 的**單一根因**，並修正一項讓 health 指標永遠無法歸零的假陽性。

根因是 `runtime/ledger/import.jsonl` **line 230**——一筆 2026-06-24 的撕裂寫入，577 個 `\x00` 插在一筆完好的 JSON 記錄中間。判定鏈：`janitor/scanner.py:171` 回報 `skipped 1 bad line(s)` → `dream/orchestrator.py:_run_pass` 見 warnings 非空即判不 clean → `orchestrator.py:130` 判 `partial`。ledger 是 append-only，這行不會自己消失，而先前沒有任何檢查會指出它，只能從一句 opaque 的 `partial` 反推——這個瑕疵因此潛伏了 60 天。

本 PR 交付：

- **偵測**：`hippo doctor` 新增 ledger 完整性檢查，唯讀掃描 `runtime/ledger/*.jsonl`，把每行分為正常／可救回（移除 NUL 後可解析）／不可救回，並指名檔名與行號。
- **修復**：`hippo ledger repair`，沿用 `locks cleanup-legacy` 慣例（`--memory-root` 必填、預設 dry-run、`--apply` 才寫入）。可救回行原地救回：先備份 → 逐行重建（只移除 NUL）→ 同目錄 temp + fsync + `os.replace` 原子替換；無可救回行時 no-op、不備份。
- **雙邊隔離**：不可救回行原樣保留不刪，記入 `runtime/ledger/<name>.jsonl.quarantine`（行號／SHA-256／原因／時間），且 janitor 的壞行計數排除已隔離行。隔離若只寫清單而讀取端不認，dream 仍會永久 partial，因此兩端成對交付；清單不可解析時 fail-closed。
- **health 假陽性**：`invalid_frontmatter` 先前恆等於生成的 MOC 索引檔數（16）而無法歸零。改以 frontmatter `memory_layer: moc` 判別（非檔名慣例）排除。

設計決策與被否決的替代方案見 `openspec/changes/issue-64-ledger-torn-line-repair/design.md`。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

實測數據：

- 全套 `pytest`：**1577 passed, 4 skipped, 0 failed**（151 subtests）；新增 29 個 `tests/test_ledger_integrity.py`。
- `policy_check`：25 pass / 0 fail / 1 warn（R-22 為既有陳年 doc 懸空，非本 PR 引入）。
- `openspec validate issue-64-ledger-torn-line-repair --strict`：valid。
- `VERSION` 維持 `0.1.1`（非 release PR）。

**對真實 production 資料的端對端驗證**（唯讀／於副本上操作，未變更正式 ledger）：

- 全檔 24,140 行掃描結果：恰好 1 個壞行，line 230，判定 `('recoverable', 'nul-torn')`——獨立重現原始診斷。
- 於真實 ledger 副本執行 `--apply`：備份與原檔**逐位元組相同**；移除位元組數**恰為 577**；`orig.replace(b"\x00", b"") == new` 成立，即**非 NUL 位元組一個都沒動**；line 230 修復後可解析；二次 `--apply` 為 no-op 且不產生新備份。
- dry-run 對真實 ledger：回報 `recoverable: 1`、`applied: false`，檔案 SHA-256 不變。
- 真實 knowledge 樹的 `backlog_census`：`invalid_frontmatter` **16 → 0**（`invalid_checksum: 18` 屬明確排除的另案）。
- `hippo doctor` 實際輸出 `- ledger 完整性：✗ import.jsonl 可救回 1／不可救回 0（行 230）——…`，全程耗時 1.02 秒，故未加位元組層快篩。

## 風險與回復

- 本 PR **不變更** `dream/orchestrator.py` 的 warning → partial 判定語意。dream status 是對外契約，#20 / #34 均引用；修掉壞資料後 warning 自然消失即可轉綠，不需改判定。
- 修復會改寫 append-only ledger 檔。立場是：那 695 bytes 的 JSON 內容完好，NUL 屬檔案系統層垃圾、從來不是任何 append 真正寫入的內容，因此屬**復原**而非改寫歷史。防護為預設 dry-run、強制備份、原子替換、以及「非 NUL 位元組逐一不變」的測試。
- 回復：還原 `.bak-repair-<ts>` 備份即可；quarantine 清單為附加檔，可直接刪除。
- **尚未完成的 acceptance**（合併後於維護窗口執行，見 `tasks.md` 第 7 節）：實際修復 `import.jsonl` line 230、`hippo requeue` 兩個 parked session（`claude-code__3c0a8d08…` 68 frags、`claude-code__66f5eed9…` 51 frags，合計 119 個 fragment 滯留 inbox）、並確認 `hippo dream run` 回報 `status: "ok"`。
- 不在範圍：`invalid_checksum: 18`（尾端換行造成的 checksum 漂移，2026-07-24 備份中即已存在）、`runtime/queue` 缺 sweeper（2 筆 payload 滯留 18 天）。兩者另案處理。

Closes #64
