### PR TITLE
fix(usage): 直讀不再被丟棄，read_without_offered 不再讓 dream 永久 partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Janitor 不再把合法的 remote-form rich project ID 誤判為 `raw-remote-key`，避免已採 hashed directory key 的 atom 讓 Dream 永久降為 `partial`。
 - `moc.search.search()` 有 boost 時使用 `(adjusted_score, base_score, slice_id)` 穩定鍵，無有效 boost（含舊 schema fallback）則維持 legacy base-score one-key stable ordering。
 - usage ledger（`offered.jsonl`／`memory_usage.jsonl`）改為 binary per-line UTF-8 streaming；metadata/open/read、decode 與單行 parse 錯誤 fail-soft 且不改寫 ledger，壞行不再吞掉周邊合法行。offered/read 的未來、窗口外時間與 `(unknown)` tool/session/slice identity 一律排除並記固定鍵 bounded diagnostics。
+- 未經 offer 的「直讀」不再被 `collect_usage_reads()` 丟棄：直讀照常更新 janitor retention 的 `last_read_at`（避免實際被讀過的 slice 誤 decay），但不計入 `read_count`，故 search usage boost 與 `hippo usage funnel` read-through 主指標語意不變。`read_without_offered` 一併移出 `DIAG_KEYS`，改以獨立 bounded 的 `STAT_KEYS`（`direct_read`）計數——直讀是正常 agent 行為，不應觸發 janitor warning 而讓 `hippo dream run` 永久停在 `partial`。
 
 ### Added
 - `moc.search` 新增可注入 UTC `usage_now`／`usage_window_days` 的 usage-boost index metadata；預設窗口 30 天，`usage_boost = min(0.04, 0.01*log2(1+read_count))`，`base_score` 間距 > `0.04` 不被反轉。

--- a/changelog.d/67-direct-read-attribution.md
+++ b/changelog.d/67-direct-read-attribution.md
@@ -1,0 +1,13 @@
+### Fixed
+- 未經 offer 的「直讀」（agent 讀取一個當下沒被 shortlist 給它的 knowledge 檔）不再被
+  `collect_usage_reads()` 整批丟棄。實測真實 ledger 30 天窗內 600 筆 read 中有 550 筆屬此類，
+  這些 slice 先前在 janitor retention 的 `last_read_at` 上等同從未被讀過而可能誤 decay；
+  現在直讀照常更新 `last_read_at`（retention 覆蓋的 slice 由 31 增為 572），但**不**計入
+  `read_count`，因此 search usage boost 與 `hippo usage funnel` 的 read-through 主指標
+  語意完全不變（維持 31 slice／50 events）。
+- `read_without_offered` 移出 `DIAG_KEYS`，改以獨立且同樣 bounded 的 `STAT_KEYS`
+  （`direct_read`）計數。janitor 會把任何非零 *diagnostic* 升為 warning、進而讓
+  `hippo dream run` 整輪降為 `partial`——直讀是正常 agent 行為，不該有此效果。此為 #64
+  同型缺陷（良性狀態被當錯誤訊號釘死 dream）的第二個來源。真實 memory root 實測：
+  janitor `warnings` 由 `["usage ledger diagnostics: {'read_without_offered': 550}"]` 轉為 `[]`。
+  時間戳壞損、identity 缺漏、未來與窗口外事件仍屬 diagnostics，照常 warning。

--- a/paulsha_hippo/janitor/scanner.py
+++ b/paulsha_hippo/janitor/scanner.py
@@ -179,7 +179,9 @@ def run_scan(
     # ledger; a nonzero diagnostic is surfaced as a single warning (v5
     # requirement: no zero-value warning noise).
     now_dt = usage_ledger.parse_ts(now) or datetime.now(timezone.utc)
-    last_read_map_raw, usage_diag = usage_ledger.collect_usage_reads(memory_root, now_dt)
+    last_read_map_raw, usage_diag, _usage_stats = usage_ledger.collect_usage_reads(
+        memory_root, now_dt
+    )
     last_read_map = {sid: last_read for sid, (_count, last_read) in last_read_map_raw.items()}
     nonzero_usage_diag = {key: count for key, count in usage_diag.items() if count > 0}
     if nonzero_usage_diag:

--- a/paulsha_hippo/ledger/usage.py
+++ b/paulsha_hippo/ledger/usage.py
@@ -31,7 +31,15 @@ DIAG_KEYS = (
     "invalid_ts",
     "future_event",
     "window_older",
-    "read_without_offered",
+)
+
+# Fixed, bounded statistic key set (issue #67) — normal outcomes that are
+# neither defects nor offer-attributed matches. Kept apart from DIAG_KEYS
+# because janitor surfaces every non-zero *diagnostic* as a warning, which
+# downgrades the whole dream run to ``partial``; a direct read is ordinary
+# agent behaviour and must never do that.
+STAT_KEYS = (
+    "direct_read",
 )
 
 # Usage-boost read_count/last_read_at aggregation only considers reads within
@@ -46,6 +54,11 @@ USAGE_BOOST_COEFFICIENT = 0.01
 def new_diagnostics() -> dict[str, int]:
     """A fresh all-zero counter dict over the fixed :data:`DIAG_KEYS` set."""
     return {key: 0 for key in DIAG_KEYS}
+
+
+def new_stats() -> dict[str, int]:
+    """A fresh all-zero counter dict over the fixed :data:`STAT_KEYS` set."""
+    return {key: 0 for key in STAT_KEYS}
 
 
 def iter_ledger_events(path: Path, diagnostics: dict[str, int]) -> "Iterator[dict]":
@@ -141,21 +154,32 @@ def _classify_missing_identity(diagnostics: dict[str, int], tool: object,
 
 def collect_usage_reads(
     memory_root: Path, now: datetime, window_days: int = USAGE_BOOST_WINDOW_DAYS,
-) -> "tuple[dict[str, tuple[int, str]], dict[str, int]]":
+) -> "tuple[dict[str, tuple[int, str]], dict[str, int], dict[str, int]]":
     """Aggregate per-slice ``(read_count, last_read_at)`` for ranking/retention.
 
-    v5 requirement #2: a read only counts when the same
-    ``(tool, session_id, slice_id)`` triple has a prior ``offered`` event, the
-    usage event has ``source == "read"`` and ``kind != "applied"``, and the
-    read timestamp is both later than the offer and within
-    ``[now - window_days, now]``. Missing/``(unknown)`` identity, unparsable
-    timestamps, future timestamps, out-of-window timestamps and reads with no
-    matching prior offer are excluded and tallied into the bounded
-    :data:`DIAG_KEYS` counters instead of raising or silently vanishing.
+    v5 requirement #2: ``read_count`` only counts a read when the same
+    ``(tool, session_id, slice_id)`` triple has a *strictly prior* ``offered``
+    event, the usage event has ``source == "read"`` and ``kind != "applied"``,
+    and the read timestamp is within ``[now - window_days, now]``. That keeps
+    the search usage boost aligned with the funnel's read-through
+    conversion-rate semantics.
+
+    Issue #67: a valid in-window read with no such prior offer — the agent read
+    a knowledge file that was never shortlisted to it — is a *direct* read. It
+    is normal behaviour, not a defect, so it is counted in the :data:`STAT_KEYS`
+    statistics and still updates ``last_read_at`` (a read is evidence the slice
+    is alive, which janitor retention must see), but it never contributes to
+    ``read_count``. A slice with direct reads only therefore surfaces as
+    ``(0, <ts>)``: zero boost, live retention.
+
+    Missing/``(unknown)`` identity, unparsable timestamps, future timestamps and
+    out-of-window timestamps remain genuine defects and are tallied into the
+    bounded :data:`DIAG_KEYS` counters instead of raising or silently vanishing.
     Read-only against the ledger; never writes to it.
     """
     led = memory_root / "runtime" / "ledger"
     diagnostics = new_diagnostics()
+    stats = new_stats()
     window_start = now - timedelta(days=window_days)
 
     offered_index: dict[tuple[str, str, str], datetime] = {}
@@ -208,16 +232,18 @@ def collect_usage_reads(
             continue
         key = (str(tool), str(session_id), str(slice_id))
         offer_ts = offered_index.get(key)
-        if offer_ts is None or offer_ts >= read_ts:
-            diagnostics["read_without_offered"] += 1
-            continue
         sid = str(slice_id)
-        counts[sid] = counts.get(sid, 0) + 1
+        if offer_ts is None or offer_ts >= read_ts:
+            stats["direct_read"] += 1
+        else:
+            counts[sid] = counts.get(sid, 0) + 1
         if sid not in last_read or read_ts > last_read[sid]:
             last_read[sid] = read_ts
 
+    # Keyed off last_read, not counts: a direct-read-only slice has no
+    # offer-attributed count but must still expose its last_read_at.
     result = {
-        sid: (count, last_read[sid].isoformat().replace("+00:00", "Z"))
-        for sid, count in counts.items()
+        sid: (counts.get(sid, 0), read_ts.isoformat().replace("+00:00", "Z"))
+        for sid, read_ts in last_read.items()
     }
-    return result, diagnostics
+    return result, diagnostics, stats

--- a/paulsha_hippo/moc/search.py
+++ b/paulsha_hippo/moc/search.py
@@ -277,7 +277,7 @@ def _build_index_locked(
         # v5 requirement #2/#9: read_count/last_read_at per slice, fed from the
         # same identity+window-matched aggregation janitor retention uses
         # (ledger.usage.collect_usage_reads); fail-soft/bounded, read-only.
-        usage_reads, _usage_diag = usage_ledger.collect_usage_reads(
+        usage_reads, _usage_diag, _usage_stats = usage_ledger.collect_usage_reads(
             memory_root, usage_now, window_days=usage_window_days
         )
 

--- a/tests/test_janitor_ledger_tolerance.py
+++ b/tests/test_janitor_ledger_tolerance.py
@@ -86,5 +86,61 @@ class JanitorLedgerToleranceTests(unittest.TestCase):
             )
 
 
+class JanitorDirectReadWarningTests(unittest.TestCase):
+    """Issue #67: un-offered reads must not pin ``hippo dream run`` at ``partial``.
+
+    ``run_scan`` surfaces any non-zero usage diagnostic as a warning, and dream
+    downgrades a run to ``partial`` whenever ``warnings_total > 0``. A direct
+    read is normal agent behaviour, so it must not reach that warning at all —
+    only genuine ledger defects may.
+    """
+
+    def _scan_with_reads(self, reads: list[dict], offers: list[dict] | None = None) -> dict:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            knowledge_root = root / "knowledge"
+            knowledge_root.mkdir(parents=True)
+            _write_record(knowledge_root / "sl-a.md", "sl-a", "sess-a")
+            led = root / "runtime" / "ledger"
+            led.mkdir(parents=True, exist_ok=True)
+            (led / "offered.jsonl").write_text(
+                "".join(json.dumps(e) + "\n" for e in (offers or [])), encoding="utf-8"
+            )
+            (led / "memory_usage.jsonl").write_text(
+                "".join(json.dumps(e) + "\n" for e in reads), encoding="utf-8"
+            )
+            cfg, cfg_hash = janitor_config.load_config(override_path=None)
+            return scanner.run_scan(
+                root,
+                now="2026-07-27T00:00:00Z",
+                knowledge_root=knowledge_root,
+                config=cfg,
+                config_hash=cfg_hash,
+                source_path_exists=lambda record: True,
+            )
+
+    def test_direct_reads_emit_no_usage_diagnostics_warning(self):
+        result = self._scan_with_reads([
+            {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a",
+             "source": "read", "ts": "2026-07-26T00:00:00Z"},
+        ])
+
+        self.assertEqual(
+            [w for w in result["warnings"] if "usage ledger diagnostics" in w], []
+        )
+
+    def test_genuine_ledger_defects_still_warn(self):
+        result = self._scan_with_reads([
+            {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a",
+             "source": "read", "ts": "not-a-timestamp"},
+        ])
+
+        self.assertTrue(
+            any("usage ledger diagnostics" in w and "invalid_ts" in w
+                for w in result["warnings"]),
+            result["warnings"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ledger_usage.py
+++ b/tests/test_ledger_usage.py
@@ -148,9 +148,14 @@ class CollectUsageReadsTests(unittest.TestCase):
                 "\n".join(json.dumps(e) for e in usage) + "\n", encoding="utf-8"
             )
 
-            result, diag = usage_ledger.collect_usage_reads(root, now)
+            result, diag, stats = usage_ledger.collect_usage_reads(root, now)
 
-            self.assertEqual(result, {"sl-a": (1, "2026-07-21T00:00:00Z")})
+            # sl-z was read but never offered: issue #67 direct read -> count 0,
+            # last_read_at present so janitor retention still sees it.
+            self.assertEqual(result, {
+                "sl-a": (1, "2026-07-21T00:00:00Z"),
+                "sl-z": (0, "2026-07-21T00:00:00Z"),
+            })
             expected_diag = usage_ledger.new_diagnostics()
             expected_diag.update({
                 "missing_tool": 2,
@@ -159,9 +164,9 @@ class CollectUsageReadsTests(unittest.TestCase):
                 "invalid_ts": 1,
                 "future_event": 1,
                 "window_older": 1,
-                "read_without_offered": 1,
             })
             self.assertEqual(diag, expected_diag)
+            self.assertEqual(stats, {"direct_read": 1})
 
     def test_unknown_is_rejected_for_every_identity_component(self):
         cases = (
@@ -220,12 +225,19 @@ class CollectUsageReadsTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            result, diag = usage_ledger.collect_usage_reads(root, now)
+            result, diag, stats = usage_ledger.collect_usage_reads(root, now)
 
-            self.assertEqual(result, {})
+            # The out-of-window / future offers must not attribute either read:
+            # read_count stays 0 on both. Issue #67: the reads themselves are
+            # valid and in-window, so they land as direct reads rather than
+            # vanishing.
+            self.assertEqual(result, {
+                "sl-old": (0, "2026-07-21T00:00:00Z"),
+                "sl-future": (0, "2026-07-21T00:00:00Z"),
+            })
             self.assertEqual(diag["window_older"], 1)
             self.assertEqual(diag["future_event"], 1)
-            self.assertEqual(diag["read_without_offered"], 2)
+            self.assertEqual(stats["direct_read"], 2)
 
     def test_repeated_offers_for_one_identity_use_bounded_memory(self):
         def peak_for(offer_count: int) -> int:
@@ -302,10 +314,112 @@ class CollectUsageReadsTests(unittest.TestCase):
             (led / "memory_usage.jsonl").write_text(
                 "\n".join(json.dumps(e) for e in reads) + "\n", encoding="utf-8"
             )
-            result, _diag = usage_ledger.collect_usage_reads(
+            result, _diag, _stats = usage_ledger.collect_usage_reads(
                 root, datetime(2026, 7, 27, tzinfo=timezone.utc)
             )
             self.assertEqual(result["sl-a"], (3, "2026-07-05T00:00:00Z"))
+
+
+class DirectReadAttributionTests(unittest.TestCase):
+    """Issue #67: an un-offered ("direct") read is a normal category, not a diagnostic.
+
+    It must feed the janitor retention base (``last_read_at``) — a read is
+    evidence the slice is alive — while leaving the search usage boost
+    (``read_count``) to offer-attributed reads only, so the funnel's
+    conversion-rate semantics stay intact.
+    """
+
+    @staticmethod
+    def _write(root: Path, offers: list[dict], reads: list[dict]) -> None:
+        led = root / "runtime" / "ledger"
+        led.mkdir(parents=True, exist_ok=True)
+        (led / "offered.jsonl").write_text(
+            "".join(json.dumps(e) + "\n" for e in offers), encoding="utf-8"
+        )
+        (led / "memory_usage.jsonl").write_text(
+            "".join(json.dumps(e) + "\n" for e in reads), encoding="utf-8"
+        )
+
+    def test_read_without_offered_is_not_a_diagnostic_key(self):
+        self.assertNotIn("read_without_offered", usage_ledger.DIAG_KEYS)
+        self.assertNotIn("read_without_offered", usage_ledger.new_diagnostics())
+
+    def test_direct_read_yields_last_read_with_zero_read_count(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = datetime(2026, 7, 27, tzinfo=timezone.utc)
+            self._write(root, [], [
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-direct",
+                 "source": "read", "ts": "2026-07-21T00:00:00Z"},
+            ])
+
+            result, diag, stats = usage_ledger.collect_usage_reads(root, now)
+
+            # read_count 0 -> zero boost; last_read_at present -> retention sees it.
+            self.assertEqual(result, {"sl-direct": (0, "2026-07-21T00:00:00Z")})
+            self.assertEqual(usage_ledger.usage_boost(result["sl-direct"][0]), 0.0)
+            self.assertEqual(diag, usage_ledger.new_diagnostics())
+            self.assertEqual(stats["direct_read"], 1)
+
+    def test_direct_reads_never_inflate_the_offer_attributed_read_count(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = datetime(2026, 7, 27, tzinfo=timezone.utc)
+            self._write(
+                root,
+                [{"tool": "claude-code", "session_id": "s1", "ts": "2026-07-20T00:00:00Z",
+                  "offered": [{"sl_id": "sl-a"}]}],
+                [
+                    {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a",
+                     "source": "read", "ts": "2026-07-21T00:00:00Z"},
+                    # same slice, different session, never offered there -> direct
+                    {"tool": "claude-code", "session_id": "s2", "sl_id": "sl-a",
+                     "source": "read", "ts": "2026-07-22T00:00:00Z"},
+                ],
+            )
+
+            result, _diag, stats = usage_ledger.collect_usage_reads(root, now)
+
+            # count stays 1 (offer-attributed only) but last_read advances to the
+            # later direct read, so retention uses the freshest evidence.
+            self.assertEqual(result, {"sl-a": (1, "2026-07-22T00:00:00Z")})
+            self.assertEqual(stats["direct_read"], 1)
+
+    def test_offer_not_strictly_before_read_counts_as_direct(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = datetime(2026, 7, 27, tzinfo=timezone.utc)
+            self._write(
+                root,
+                [{"tool": "codex", "session_id": "s1", "ts": "2026-07-21T00:00:00Z",
+                  "offered": [{"sl_id": "sl-a"}]}],
+                [{"tool": "codex", "session_id": "s1", "sl_id": "sl-a", "source": "read",
+                  "ts": "2026-07-21T00:00:00Z"}],
+            )
+
+            result, diag, stats = usage_ledger.collect_usage_reads(root, now)
+
+            self.assertEqual(result, {"sl-a": (0, "2026-07-21T00:00:00Z")})
+            self.assertEqual(diag, usage_ledger.new_diagnostics())
+            self.assertEqual(stats["direct_read"], 1)
+
+    def test_malformed_and_out_of_window_reads_are_still_diagnostics_not_direct(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            now = datetime(2026, 7, 27, tzinfo=timezone.utc)
+            self._write(root, [], [
+                {"tool": "claude-code", "session_id": "s1", "sl_id": "sl-a",
+                 "source": "read", "ts": "2026-01-01T00:00:00Z"},   # window_older
+                {"tool": "(unknown)", "session_id": "s1", "sl_id": "sl-a",
+                 "source": "read", "ts": "2026-07-21T00:00:00Z"},   # missing_tool
+            ])
+
+            result, diag, stats = usage_ledger.collect_usage_reads(root, now)
+
+            self.assertEqual(result, {})
+            self.assertEqual(diag["window_older"], 1)
+            self.assertEqual(diag["missing_tool"], 1)
+            self.assertEqual(stats["direct_read"], 0)
 
 
 class UsageBoostFormulaTests(unittest.TestCase):


### PR DESCRIPTION
## 摘要

Closes #67

未經 offer 的「直讀」（agent 讀取一個當下沒被 shortlist 給它的 knowledge 檔）先前在
`collect_usage_reads()` 被 `continue` 整批丟棄，並且被計入 `DIAG_KEYS` 的
`read_without_offered`。後者讓 janitor 每輪發 warning，令 `hippo dream run` 永久停在
`partial`——與 #64 同型（良性狀態被當錯誤訊號釘死 dream），只是換了來源（#41 v5 的 bounded
diagnostics）。

### 診斷

把 hook 寫入事件的 `offered` 布林值與 `collect_usage_reads()` 對 `offered.jsonl` 的 join
判定，在真實 ledger 30 天窗內逐筆交叉比對：

| join 判定 | hook `offered` | 事件數 |
|---|---|---|
| `join:OK` | `True` | 50 |
| `join:no-offer` | `False` | 546 |
| `join:offer-not-before` | `False` | 4 |

**600/600 完全一致，零分歧——歸因的 join 沒有算錯。** 那 550 筆是真的直讀，且
`openspec/specs/stage2-memory-read-attribution/spec.md:14-16` 早已明訂這是要記錄的正常事件
（`offered:false`）。真正的缺陷在下游：這 550 筆被完全丟棄，導致 541 個實際被讀過的 slice
在 janitor retention 的 `last_read_at` 上等同從未被讀過，可能誤 decay。

### 變更

- **retention 納入直讀**：直讀照常更新 `last_read_at`。retention 覆蓋的 slice 由 **31 增為 572**。
- **boost 不納入直讀**：直讀不計入 `read_count`，因此 search usage boost 與
  `hippo usage funnel` 的 read-through 主指標語意**完全不變**（維持 31 slice／50 events）。
  實測 553/572 個 slice 只被讀過一次，全部計入只會讓 541 個 slice 各得 `0.01` 的近乎均勻
  加成、稀釋排序。決策記於 #67 comment。
- **`read_without_offered` 移出 `DIAG_KEYS`**，改以獨立且同樣 bounded 的 `STAT_KEYS`
  （`direct_read`）計數——不是靜默丟棄，是改記到正確的類別。時間戳壞損、identity 缺漏、
  未來與窗口外事件仍屬 diagnostics，照常 warning。

`collect_usage_reads()` 回傳值由 2-tuple 改為 `(result, diagnostics, stats)`；兩個 production
呼叫端（`janitor/scanner.py`、`moc/search.py`）同步更新。`search()` 只用 `read_count` 排序、
不使用 `last_read_at`，故直讀 slice 以 `(0, <ts>)` 進 `slice_meta` 對排序零影響，legacy
fast path（無任何 `read_count>0` 時走原一鍵排序）亦保持不變。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

證據：

- **全套測試**：`python3 -m pytest -q` → `1620 passed, 4 skipped, 154 subtests passed`。
  先寫 RED（6 failed）再實作，非 focused 子集。
- **policy_check**：R-01～R-26 全 pass，唯 R-22 為 **warn**（陳年 doc 懸空引用，先前即存在，
  非本 PR 造成，不擋 merge）。R-09 為 diff-aware，本機無 PR context，由 CI 覆核。
- **OpenSpec**：`openspec validate --all --strict` → `13 passed, 0 failed`。
- **真實 memory root 實測**（`~/.agents/memory`，read-only）：
  - `janitor scan --dry-run` 的 `warnings` 由
    `["usage ledger diagnostics: {'read_without_offered': 550}"]` → `[]`（`scanned: 1119` 不變）
  - `diagnostics` 全零；`stats == {'direct_read': 550}`
  - 有 `last_read_at` 的 slice：31 → 572；有 `read_count>0` 的 slice：31（不變）
- **文件/CLI**：無 CLI 介面或旗標變動，`hippo usage funnel` 輸出契約不變，故 README／
  `docs/cross-cli-capability-matrix.md` 無需同步。本變更是把消費端對齊既有的
  `stage2-memory-read-attribution` spec，spec 本身不需修改。
- **VERSION**：維持 `0.1.1`，本 PR 非 release。

## 風險與回復

- 無資料遷移、無 ledger 寫入路徑變更；`collect_usage_reads()` 全程 read-only。
- 行為風險集中在 janitor retention：572（而非 31）個 slice 的 TTL base 現在會採計
  `last_read_at`，**方向是延長保留**，不會造成非預期刪除。`superseded` / `source_invalid`
  優先序與「read 不 reactivation」等 #41 v5 既有邊界未動，並由既有測試覆蓋。
- `collect_usage_reads()` 為 internal API（非 CLI 契約），呼叫端僅兩處且已同步。
- 回復方式：revert 本 commit 即可，無殘留狀態。
- 尚未完成的 acceptance：本 PR 合併並重新部署後，需觀察下一輪排程 dream 實際回到
  `status: ok`（目前僅以 `janitor scan --dry-run` 在同一份 live 資料上證明 warning 已消失）。
