### PR TITLE
fix(dream): janitor usage 診斷改以實際讀檔時間為基準，不再誤判併發寫入為 future_event

### DIFF
--- a/changelog.d/70-janitor-usage-now.md
+++ b/changelog.d/70-janitor-usage-now.md
@@ -1,0 +1,18 @@
+### Fixed
+- dream 執行期間、其他 agent 對同一 memory root 的併發 ledger 寫入不再被 janitor
+  誤判為 `future_event`、令整輪降為 `partial`。`dream/orchestrator.py` 以單一 `now`
+  釘住整輪並先跑 atomize（已知的 rglob 效能問題可讓單輪耗時 10+ 分鐘），janitor 隨後
+  沿用同一個 run-start 的 `now` 判斷 usage ledger 事件是否「來自未來」；任何在 run 起點
+  之後、janitor 實際讀檔之前寫入的 offered/read 事件（例如 prompt-time hook 每次送出
+  提示都會寫一筆 offered）因此被誤記為時鐘偏移。實測一輪 `now=07:03:27Z`、atomize 跑
+  13 分鐘的 run 中，`offered.jsonl` 於 07:05–07:16 間新增 4 筆同期 session 事件，其中
+  2 筆落入 janitor 讀檔前即造成 `usage ledger diagnostics: {'future_event': 2}` warning，
+  使該輪整體降為 `partial`。
+- `janitor.scanner.run_scan` 新增 keyword-only 參數 `usage_now: str | None = None`：
+  usage ledger（offered/read）診斷改以此為時間基準，預設為 janitor 實際執行當下的
+  牆鐘時間（而非 run 起點的 `now`）；`now` 既有的 TTL/decay/reactivation 判定與
+  lifecycle 事件 ts 記錄完全不受影響。dream CLI／`hippo janitor scan` 呼叫端不需改動
+  即得到修復——併發寫入的 ts 只要不晚於 janitor 實際讀檔時刻即不再算 `future_event`；
+  真正的時鐘偏移（ts 晚於 janitor 實際讀檔時刻）仍照常記診斷、照常 warning。
+  此為「良性狀態被當錯誤訊號釘死 dream」反模式的第三個實例（前兩例：#64 ledger 撕裂行、
+  #67 `read_without_offered` 直讀）。

--- a/paulsha_hippo/janitor/scanner.py
+++ b/paulsha_hippo/janitor/scanner.py
@@ -133,20 +133,38 @@ def run_scan(
     config_hash: str,
     now: str,
     dry_run: bool = False,
-    source_path_exists: Callable[[record_source.KnowledgeRecord], bool | None] | None = None
+    source_path_exists: Callable[[record_source.KnowledgeRecord], bool | None] | None = None,
+    *,
+    usage_now: str | None = None,
 ) -> dict[str, Any]:
     """
     Run janitor scan: evaluate records and persist lifecycle events.
-    
+
     Args:
         memory_root: Memory root directory
         knowledge_root: Knowledge layer root directory
         config: Janitor configuration
         config_hash: Hash of janitor config
-        now: Current timestamp (ISO format)
+        now: Current timestamp (ISO format). Drives TTL/decay/reactivation
+            judgments and the ts recorded on persisted lifecycle events.
         dry_run: If True, compute plan but don't persist events
         source_path_exists: Optional callable to check source path existence
-    
+        usage_now: Optional ISO timestamp used as the clock basis for usage
+            ledger (offered/read) diagnostics only — everything else keeps
+            using `now`. Defaults to real wall-clock time (the janitor's own
+            read time), not `now`. #70: a dream run freezes a single `now` at
+            run-start and hands it unchanged to a janitor pass that may run
+            many minutes later (atomize can take 10+ minutes due to a known
+            rglob perf issue); any offered/read event written by another
+            concurrent agent in that gap has a ts *after* the frozen `now`
+            but *before* the janitor pass actually reads the ledger. Judging
+            such events against `now` misclassifies them as `future_event` —
+            a real diagnostic reserved for genuine clock skew — which
+            escalates to a warning and pins the whole dream run at `partial`.
+            Defaulting the usage clock to the actual read time fixes that
+            false positive while leaving genuine clock skew (ts beyond the
+            real read time) diagnosed exactly as before.
+
     Returns:
         Dict with keys:
             - summary: Dict with scanned/decayed/reactivated/unchanged/skipped counts
@@ -178,9 +196,17 @@ def run_scan(
     # an already-decayed one. Fail-soft/bounded and read-only against the
     # ledger; a nonzero diagnostic is surfaced as a single warning (v5
     # requirement: no zero-value warning noise).
-    now_dt = usage_ledger.parse_ts(now) or datetime.now(timezone.utc)
+    #
+    # #70: the usage-ledger clock basis is intentionally decoupled from `now`
+    # here — it defaults to real wall-clock time (when this scan is actually
+    # reading the ledger), not the run's frozen `now`. See run_scan's
+    # docstring for the concurrent-write false-positive this avoids.
+    if usage_now is not None:
+        usage_now_dt = usage_ledger.parse_ts(usage_now) or datetime.now(timezone.utc)
+    else:
+        usage_now_dt = datetime.now(timezone.utc)
     last_read_map_raw, usage_diag, _usage_stats = usage_ledger.collect_usage_reads(
-        memory_root, now_dt
+        memory_root, usage_now_dt
     )
     last_read_map = {sid: last_read for sid, (_count, last_read) in last_read_map_raw.items()}
     nonzero_usage_diag = {key: count for key, count in usage_diag.items() if count > 0}

--- a/tests/test_janitor_ledger_tolerance.py
+++ b/tests/test_janitor_ledger_tolerance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -110,6 +111,14 @@ class JanitorDirectReadWarningTests(unittest.TestCase):
                 "".join(json.dumps(e) + "\n" for e in reads), encoding="utf-8"
             )
             cfg, cfg_hash = janitor_config.load_config(override_path=None)
+            # #70: usage diagnostics are windowed off the *janitor's own read
+            # time* (usage_now), not the run's frozen `now`. These tests assert
+            # fixed event timestamps against a fixed clock, so usage_now is
+            # pinned explicitly here — otherwise, once the scanner's usage
+            # clock default becomes real wall-clock time, these hard-coded
+            # 2026-07-26 event timestamps would silently drift out of the
+            # 30-day window (become `window_older`) as real time passes,
+            # turning this into a time bomb rather than a deterministic test.
             return scanner.run_scan(
                 root,
                 now="2026-07-27T00:00:00Z",
@@ -117,6 +126,7 @@ class JanitorDirectReadWarningTests(unittest.TestCase):
                 config=cfg,
                 config_hash=cfg_hash,
                 source_path_exists=lambda record: True,
+                usage_now="2026-07-27T00:00:00Z",
             )
 
     def test_direct_reads_emit_no_usage_diagnostics_warning(self):
@@ -139,6 +149,102 @@ class JanitorDirectReadWarningTests(unittest.TestCase):
             any("usage ledger diagnostics" in w and "invalid_ts" in w
                 for w in result["warnings"]),
             result["warnings"],
+        )
+
+
+class JanitorUsageNowConcurrencyTests(unittest.TestCase):
+    """Issue #70: a dream run freezes a single `now` at run-start and hands it
+    to both the (slow) atomize pass and the janitor pass that runs after it.
+    Any ledger event written concurrently — e.g. by another agent's prompt-time
+    hook — while atomize is still running lands *after* that frozen `now`, but
+    strictly *before* the janitor pass actually reads the ledger. Judging it
+    against the frozen `now` misclassifies ordinary concurrent activity as
+    `future_event`, which janitor escalates to a warning and which pins the
+    whole dream run at `partial` (same anti-pattern as #64 / #67).
+
+    `usage_now` decouples the usage-ledger clock from the run's frozen `now`:
+    it defaults to the janitor's actual wall-clock read time, so concurrent
+    writes are judged against *when they were actually read*, not against a
+    timestamp fixed possibly 10+ minutes earlier at run-start.
+    """
+
+    def _scan(
+        self, reads: list[dict], *, now: str, usage_now: str | None,
+        pass_usage_now: bool = True,
+    ) -> dict:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            knowledge_root = root / "knowledge"
+            knowledge_root.mkdir(parents=True)
+            _write_record(knowledge_root / "sl-a.md", "sl-a", "sess-a")
+            led = root / "runtime" / "ledger"
+            led.mkdir(parents=True, exist_ok=True)
+            (led / "offered.jsonl").write_text("", encoding="utf-8")
+            (led / "memory_usage.jsonl").write_text(
+                "".join(json.dumps(e) + "\n" for e in reads), encoding="utf-8"
+            )
+            cfg, cfg_hash = janitor_config.load_config(override_path=None)
+            kwargs: dict = dict(
+                knowledge_root=knowledge_root,
+                config=cfg,
+                config_hash=cfg_hash,
+                now=now,
+                source_path_exists=lambda record: True,
+            )
+            if pass_usage_now:
+                kwargs["usage_now"] = usage_now
+            return scanner.run_scan(root, **kwargs)
+
+    def test_concurrent_write_after_frozen_now_but_before_usage_now_is_not_future_event(self):
+        # Mirrors the real run: run_id frozen at 07:03:27Z; atomize takes ~13
+        # minutes; janitor actually reads the ledger (usage_now) at 07:16:51Z.
+        # An offered/read event written at 07:10:23Z — after the frozen `now`
+        # but before janitor's actual read — must not be flagged.
+        result = self._scan(
+            [{"tool": "claude-code", "session_id": "9105547d", "sl_id": "sl-a",
+              "source": "read", "ts": "2026-07-27T07:10:23Z"}],
+            now="2026-07-27T07:03:27Z",
+            usage_now="2026-07-27T07:16:51Z",
+        )
+
+        self.assertEqual(
+            [w for w in result["warnings"] if "usage ledger diagnostics" in w], []
+        )
+
+    def test_genuine_clock_skew_beyond_usage_now_still_warns(self):
+        # A real clock-skew event (postdates even the janitor's own read time)
+        # must still be caught — the fix narrows the *false positive* window,
+        # it must not blind the diagnostic altogether.
+        result = self._scan(
+            [{"tool": "claude-code", "session_id": "9105547d", "sl_id": "sl-a",
+              "source": "read", "ts": "2026-07-27T08:00:00Z"}],
+            now="2026-07-27T07:03:27Z",
+            usage_now="2026-07-27T07:16:51Z",
+        )
+
+        self.assertTrue(
+            any("usage ledger diagnostics" in w and "future_event" in w
+                for w in result["warnings"]),
+            result["warnings"],
+        )
+
+    def test_default_usage_now_uses_call_time_not_frozen_run_now(self):
+        # Regression guard on the default itself: with no usage_now override
+        # (how the real dream/janitor CLIs call run_scan), a concurrent write
+        # timestamped at "real now" must not be future_event even though the
+        # run's frozen `now` is far earlier — proving the usage clock default
+        # is NOT simply `now`.
+        near_now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = self._scan(
+            [{"tool": "claude-code", "session_id": "9105547d", "sl_id": "sl-a",
+              "source": "read", "ts": near_now}],
+            now="2026-07-27T07:03:27Z",
+            usage_now=None,
+            pass_usage_now=False,
+        )
+
+        self.assertEqual(
+            [w for w in result["warnings"] if "usage ledger diagnostics" in w], []
         )
 
 

--- a/tests/test_janitor_scanner.py
+++ b/tests/test_janitor_scanner.py
@@ -149,8 +149,15 @@ class UsageDiagnosticsWarningTests(unittest.TestCase):
                 encoding="utf-8",
             )
             cfg, cfg_hash = janitor_config.load_config(override_path=None)
+            # #70: usage diagnostics window off usage_now (defaults to real
+            # wall-clock time), not the run's `now`. Pin usage_now explicitly
+            # here so this fixed 2026-05 event timestamp doesn't drift out of
+            # the 30-day window as real time passes (would otherwise become a
+            # time bomb: spuriously fails once run more than ~30 days after
+            # the fixture dates were authored).
             result = scanner.run_scan(root, knowledge_root=kroot, config=cfg, config_hash=cfg_hash,
-                                      now="2026-05-31T00:00:00Z", source_path_exists=lambda r: True)
+                                      now="2026-05-31T00:00:00Z", source_path_exists=lambda r: True,
+                                      usage_now="2026-05-31T00:00:00Z")
             self.assertFalse(
                 [w for w in result["warnings"] if w.startswith("usage ledger diagnostics")]
             )
@@ -168,7 +175,8 @@ class UsageDiagnosticsWarningTests(unittest.TestCase):
             )
             cfg, cfg_hash = janitor_config.load_config(override_path=None)
             result = scanner.run_scan(root, knowledge_root=kroot, config=cfg, config_hash=cfg_hash,
-                                      now="2026-05-31T00:00:00Z", source_path_exists=lambda r: True)
+                                      now="2026-05-31T00:00:00Z", source_path_exists=lambda r: True,
+                                      usage_now="2026-05-31T00:00:00Z")
             usage_warnings = [w for w in result["warnings"] if w.startswith("usage ledger diagnostics")]
             self.assertEqual(len(usage_warnings), 1)
             self.assertIn("json_decode_error", usage_warnings[0])


### PR DESCRIPTION
## 摘要

Closes #70

dream 以單一 `now` 釘住整輪（`orchestrator.py:90`），atomize 先跑（因 rglob 效能問題可達
10+ 分鐘），janitor 後跑卻沿用 run 起點的 `now`——期間其他 agent 併發寫入的 offered/read
事件（prompt-time hook 每次送出提示都寫一筆）ts 晚於凍結的 `now`，被 `collect_usage_reads`
判為 `future_event`、升 warning、令整輪降 `partial`。實測 run now=07:03:27、atomize 13 分鐘、
期間 4 筆 offered 寫入 → `future_event: 2`。這是「良性狀態被當錯誤訊號釘死 dream」反模式
第三例（前兩例 #64、#66/#67 已修）。

### 變更

- `janitor.scanner.run_scan` 新增 keyword-only 參數 `usage_now: str | None = None`：
  usage ledger（offered/read）診斷的時間基準改用它，**預設為 janitor 實際讀檔的牆鐘時間**
  而非 run 起點凍結的 `now`。
- `now` 的其他用途（TTL/decay/reactivation 判定、lifecycle 事件 ts）完全不動。
- 兩個呼叫端（`dream/cli.py`、`janitor/cli.py`）無需改參數——預設值即為修復。
- 交互安全性：`rules.py:81` 既有 `read_dt <= now` 防護確保 wall-clock 收集到的較新 read
  不會延長以 `now` 判定的 TTL（future read 不延長 TTL 的 #41 v5 邊界維持不變）。
- 真時鐘偏移（ts > 實際牆鐘）仍照常記 `future_event`、照常 warning。

### TDD 證據

RED：新增 `JanitorUsageNowConcurrencyTests` 三案（併發寫入不誤判／真時鐘偏移仍警告／
預設值即牆鐘）後先跑 → `7 failed`（`TypeError: run_scan() got an unexpected keyword
argument 'usage_now'`）→ 實作後同批 `13 passed`。同時把兩個測試檔中依賴舊行為的寫死
時間戳測試改為顯式注入 `usage_now`，消除隨真實時間推移落出 30 天窗的定時炸彈。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

證據：

- **乾淨環境全套 pytest**（sibling worktree，非巢狀）：`1623 passed, 4 skipped, 154 subtests, 0 failed`。
  （worker 於巢狀 worktree 環境回報的 2 個 `test_project_resolver` 失敗，經 sibling worktree
  複測消失，且 worker 已用 git stash 驗證 pre-fix 即存在——確認為巢狀環境假訊號，非本變更。）
- **policy_check**：R-01～R-26 全 pass，唯 R-22 既有 warn（24 筆陳年 dangling doc reference，
  與本變更檔案無關）。
- **openspec validate --all --strict**：13 passed, 0 failed。
- **三路最終確認**：主 agent 人工 diff 審查 ✓、乾淨環境全套測試 ✓、adversarial reviewer ✓。
- 無 CLI 介面變動；`docs/` 無需同步；`VERSION` 維持 0.1.1（非 release PR）。

## 風險與回復

- 生產 diff 僅 `janitor/scanner.py` 單點；read-only 路徑，無 ledger 寫入變更。
- 行為變更方向：`future_event` 假陽性消除；診斷靈敏度（真偏移）不變。
- 回復：revert 單一 commit 即可，無殘留狀態。
- 尚未完成的 acceptance：合併重部署後由 live dream run 驗證 janitor 不再因併發寫入 warning
  （與 #69 部署後一併驗）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yjKTs6YvDe6CziKsWc4V3
