### PR TITLE
fix(atomize): parked evidence 補 attempts_detail 可觀測性，doctor probe 改驗單一 JSON 契約

### DIFF
--- a/changelog.d/69-agent-observability-probe.md
+++ b/changelog.d/69-agent-observability-probe.md
@@ -5,3 +5,7 @@
 ### Fixed
 
 - `hippo doctor --probe-profiles`／`--fix-backend` 的 smoke probe 改為要求單一 JSON 回覆，驗證條件比照 atomize 既有的嚴格解析（`llm_output.parse_single_json_value`）——不再只驗「exit 0 + 非空」，修正與真實 atomize 結果反相關的誤判（守 JSON 契約但 prompt 未觸發 JSON 的 backend 誤判 FAIL；能回話但不守契約的 backend 誤判 ✓）。
+
+### Security
+
+- `agent_profiles.sanitize_stderr` 補上 redaction-先於-截斷（Codex 複驗 BLOCKING）：先前「先截斷（500 字元）才交給下游 `processing.sanitize_error_text` 做 secret redaction」的順序，會在 secret（如 GitHub PAT）跨越截斷邊界時把 token 腰斬成低於 redaction 規則最小長度的殘片，令比對失配、殘片明文落入 `runtime/queue/_failed/*.json`；現在 `sanitize_stderr` 在自身截斷之前就先套用同一份 baseline secret redaction，同時修好共用此函式的 `distiller.attempts` frontmatter 路徑同型風險。

--- a/changelog.d/69-agent-observability-probe.md
+++ b/changelog.d/69-agent-observability-probe.md
@@ -1,0 +1,7 @@
+### Added
+
+- parked evidence（`runtime/queue/_failed/*.json`）新增 `attempts_detail`：逐一 external agent fallback 嘗試的 `profile_id`／`exit_code`／`duration_seconds`／`stderr_tail`（既有 secret-redaction 淨化＋≤2000 字元截斷）／`stdout_bytes`／`failure_kind`（`timeout`／`nonzero_exit`／`empty_output`／`invalid_output`／`decode_error`），讓 timeout、CLI 靜默失敗、rate limit、進程被殺不再無法區分；既有欄位皆不變。
+
+### Fixed
+
+- `hippo doctor --probe-profiles`／`--fix-backend` 的 smoke probe 改為要求單一 JSON 回覆，驗證條件比照 atomize 既有的嚴格解析（`llm_output.parse_single_json_value`）——不再只驗「exit 0 + 非空」，修正與真實 atomize 結果反相關的誤判（守 JSON 契約但 prompt 未觸發 JSON 的 backend 誤判 FAIL；能回話但不守契約的 backend 誤判 ✓）。

--- a/paulsha_hippo/agent_profiles.py
+++ b/paulsha_hippo/agent_profiles.py
@@ -87,7 +87,20 @@ ResponseValidator = Callable[[str], object]
 
 
 def sanitize_stderr(value: object, *, limit: int = 500) -> str:
-    """只留下 bounded、可持久化的 stderr evidence。"""
+    """只留下 bounded、可持久化的 stderr evidence。
+
+    Codex 複驗 BLOCKING：redaction 必須先於截斷。這是兩層 sanitize 的第一層
+    （下游 pipeline 的 attempts_detail 會再用
+    ``ledger.processing.sanitize_error_text`` 覆蓋一次），但它只看得到已經
+    被本函式截斷過的文字——若 secret（如 GitHub PAT）跨越 ``limit`` 邊界，
+    「先截斷」會把 token 腰斬成低於 ``policy/secrets.yaml`` 規則最小長度的
+    殘片，令 regex 比對不到，殘片明文就會落入
+    ``runtime/queue/_failed/*.json``。因此這裡在最終截斷之前先套用 baseline
+    secret redaction（``ledger.processing.redact_secret_text``，fail-closed、
+    不可被 override 弱化），對齊 ``processing.sanitize_error_text`` 已明文的
+    既有契約。既有行為順序（ANSI 剝除／控制字元過濾／具名前綴遮蔽／home
+    替換）維持不變，只在「截斷之前」插入這一層。
+    """
     text = str(value or "")
     text = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
     text = "".join(char for char in text if char in "\n\t" or ord(char) >= 32)
@@ -95,7 +108,11 @@ def sanitize_stderr(value: object, *, limit: int = 500) -> str:
     home = str(Path.home())
     if home and home != "/":
         text = text.replace(home, "~")
-    return " ".join(text.split())[:limit]
+    text = " ".join(text.split())
+    from .ledger.processing import redact_secret_text
+
+    text = redact_secret_text(text)
+    return text[:limit]
 
 
 def _tuple_strings(

--- a/paulsha_hippo/agent_profiles.py
+++ b/paulsha_hippo/agent_profiles.py
@@ -73,12 +73,14 @@ class AgentRunError(RuntimeError):
         profile_id: str | None = None,
         exit_code: int | None = None,
         stderr: str = "",
+        output_bytes: int = 0,
     ) -> None:
         super().__init__(message)
         self.category = category
         self.profile_id = profile_id
         self.exit_code = exit_code
         self.stderr = stderr
+        self.output_bytes = output_bytes
 
 
 ResponseValidator = Callable[[str], object]
@@ -435,6 +437,7 @@ class AgentRunResult:
     fallback_reason: str | None = None
     priority: int = 0
     response_schema: str = RESPONSE_SCHEMA_VERSION
+    output_bytes: int = 0
 
 
 def classify_failure(stderr: object, *, exit_code: int | None = None) -> str:
@@ -583,6 +586,7 @@ class ExternalAgentRouter:
                 category="invalid_output",
                 profile_id=profile.id,
                 stderr=sanitize_stderr(exc),
+                output_bytes=len(raw.encode("utf-8", errors="replace")),
             ) from exc
 
     @staticmethod
@@ -726,6 +730,7 @@ class ExternalAgentRouter:
                             profile_id=profile.id,
                             stderr=stderr,
                             exit_code=exit_code,
+                            output_bytes=len(raw.encode("utf-8", errors="replace")),
                         )
                     self._validate_response(profile, raw, response_validator)
                     outputs.append(raw)
@@ -746,6 +751,9 @@ class ExternalAgentRouter:
                     None if not attempts else "degraded-success",
                     profile.priority,
                     RESPONSE_SCHEMA_VERSION,
+                    output_bytes=sum(
+                        len(output.encode("utf-8", errors="replace")) for output in outputs
+                    ),
                 )
                 attempts.append(result)
                 self.last_result = result
@@ -759,6 +767,7 @@ class ExternalAgentRouter:
                         profile_id=profile.id,
                         exit_code=getattr(caught, "exit_code", None),
                         stderr=getattr(caught, "stderr", ""),
+                        output_bytes=int(getattr(caught, "output_bytes", 0) or 0),
                     )
                 category = self._transition_category(profile, caught)
                 self._last_error = caught
@@ -779,6 +788,7 @@ class ExternalAgentRouter:
                     None,
                     profile.priority,
                     RESPONSE_SCHEMA_VERSION,
+                    output_bytes=int(getattr(caught, "output_bytes", 0) or 0),
                 )
                 attempts.append(result)
                 self._circuit_open_until[profile.id] = time.monotonic() + 60.0

--- a/paulsha_hippo/atomizer/agent_exec.py
+++ b/paulsha_hippo/atomizer/agent_exec.py
@@ -23,11 +23,20 @@ from ..agent_profiles import (
 class AgentExecError(Exception):
     """Raised when an agent subprocess cannot produce usable output."""
 
-    def __init__(self, message: str, *, category: str = "process", stderr: str = "", exit_code: int | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        category: str = "process",
+        stderr: str = "",
+        exit_code: int | None = None,
+        output_bytes: int = 0,
+    ) -> None:
         super().__init__(message)
         self.category = category
         self.stderr = stderr
         self.exit_code = exit_code
+        self.output_bytes = output_bytes
 
 
 class AgentUnavailableError(AgentExecError):
@@ -95,12 +104,15 @@ class AgentExecClient(AgentClient):
                 f"agent command not executable: {self._command[0]}"
             ) from exc
         except subprocess.TimeoutExpired as exc:
+            partial_stdout = str(getattr(exc, "stdout", "") or "")
             raise AgentTransientError(
                 f"agent timed out after {self._timeout}s",
                 category="timeout",
                 stderr=sanitize_stderr(getattr(exc, "stderr", "")),
+                output_bytes=len(partial_stdout.encode("utf-8", errors="replace")),
             ) from exc
         stderr = sanitize_stderr(completed.stderr)
+        stdout_bytes = len(completed.stdout.encode("utf-8", errors="replace"))
         if completed.returncode != 0:
             raise AgentTransientError(
                 f"agent exited with code {completed.returncode}",
@@ -109,6 +121,7 @@ class AgentExecClient(AgentClient):
                 ),
                 stderr=stderr,
                 exit_code=completed.returncode,
+                output_bytes=stdout_bytes,
             )
         if not completed.stdout.strip():
             raise AgentTransientError(
@@ -116,6 +129,7 @@ class AgentExecClient(AgentClient):
                 category="empty_output",
                 stderr=stderr,
                 exit_code=completed.returncode,
+                output_bytes=stdout_bytes,
             )
         self.last_result = {
             "stderr": stderr,

--- a/paulsha_hippo/atomizer/llm_output.py
+++ b/paulsha_hippo/atomizer/llm_output.py
@@ -283,15 +283,28 @@ def _parse_proposals(data: Any, known_projects: list[str]) -> list[SliceProposal
     return proposals
 
 
-def parse_response(raw: str, known_projects: list[str]) -> ParsedResponse:
-    """Parse the strict v1 wrapper or one-version non-empty legacy array."""
+def parse_single_json_value(raw: str) -> Any:
+    """Parse ``raw`` as exactly one JSON value with no surrounding noise.
+
+    Shared strict-parsing primitive: the atomize response parser
+    (`parse_response`) and the `hippo doctor` smoke-probe validation
+    (issue #69 子項 B) both need "this output must be one parseable JSON
+    value, nothing else" — this is the single implementation, not a parallel
+    one, so the contract and its error message stay identical everywhere it
+    is enforced.
+    """
     stripped = raw.strip()
     if not stripped:
         raise LlmOutputError("agent output is empty")
     try:
-        data = json.loads(stripped)
+        return json.loads(stripped)
     except json.JSONDecodeError as exc:
         raise LlmOutputError("agent output must be one JSON value without surrounding noise") from exc
+
+
+def parse_response(raw: str, known_projects: list[str]) -> ParsedResponse:
+    """Parse the strict v1 wrapper or one-version non-empty legacy array."""
+    data = parse_single_json_value(raw)
 
     if isinstance(data, list):
         if not data:

--- a/paulsha_hippo/atomizer/llm_promoter.py
+++ b/paulsha_hippo/atomizer/llm_promoter.py
@@ -258,7 +258,7 @@ class LLMPromoter(Promoter):
             result = getattr(self._agent._inner, "last_result", None)
         return result if isinstance(result, AgentRunResult) else None
 
-    def _router_attempts(self) -> tuple[AgentRunResult, ...]:
+    def router_attempts(self) -> tuple[AgentRunResult, ...]:
         router = self._router()
         if router is not None:
             return tuple(
@@ -379,7 +379,7 @@ class LLMPromoter(Promoter):
                             router_result,
                             config_hash=self._config_hash,
                             skill_hash=sha256_text(self._skill),
-                            attempts=self._router_attempts(),
+                            attempts=self.router_attempts(),
                         )
                     )
                 return validator(raw)
@@ -539,7 +539,7 @@ class LLMPromoter(Promoter):
                         router_result,
                         config_hash=self._config_hash,
                         skill_hash=sha256_text(self._skill),
-                        attempts=self._router_attempts(),
+                        attempts=self.router_attempts(),
                     )
                 )
             return responses, cache_keys
@@ -547,7 +547,7 @@ class LLMPromoter(Promoter):
             raise PromoteError(
                 f"llm promote failed after session attempt(s): {exc}",
                 category=_failure_category(exc),
-                attempts=len(self._router_attempts()),
+                attempts=len(self.router_attempts()),
             ) from exc
 
     def promote(self, fragments: list[Fragment], config: AtomizerConfig) -> list[Slice]:

--- a/paulsha_hippo/atomizer/pipeline.py
+++ b/paulsha_hippo/atomizer/pipeline.py
@@ -23,8 +23,12 @@ LOGGER = logging.getLogger(__name__)
 _ATOMIZER_INBOX_FILE_MAX_BYTES = 64 * 1024 * 1024
 # park evidence 的 attempts_detail.stderr_tail 上限（issue #69 子項 A）。router
 # 已在建構 AgentRunResult 時以 sanitize_stderr 套用 500 字元上限；這裡再用既有的
-# secret-redaction 錯誤文字淨化（sanitize_error_text）覆蓋一次並以本上限截斷，
-# 是 park evidence 落盤前唯一的 choke point，不依賴上游是否已經夠短。
+# secret-redaction 錯誤文字淨化（sanitize_error_text）覆蓋一次並以本上限截斷。
+# 兩層都遵循「redaction 先於截斷」的契約：sanitize_stderr 本身已在其 500 字元
+# 截斷之前先套用 baseline secret redaction（Codex 複驗 BLOCKING 修復——先前
+# 「先截斷才 redact」會把跨邊界的 secret 腰斬成殘片致比對失配），本函式在此
+# 之上再覆蓋一次、以本上限截斷，是 park evidence 落盤前的第二層 choke point，
+# 但不再是唯一防線；即使上游意外沒截夠短，這裡的 redact-先於-截斷仍會擋下。
 _ATTEMPTS_DETAIL_STDERR_LIMIT = 2000
 
 
@@ -203,14 +207,20 @@ def _read_attempts(counter: Path) -> int:
 def _attempt_failure_kind(category: str | None, exit_code: int | None) -> str:
     """Map one router attempt's bounded diagnostics to a park-evidence failure_kind.
 
-    ``timeout``／``empty_output``／``invalid_output`` already carry an unambiguous
-    router category. A nonzero exit code that fell through those (e.g. a bare
-    ``process`` category) is a genuine ``nonzero_exit``. Anything left——no exit
-    code and no specific category (missing executable races, subprocess-level
-    decode failures)——has no exit-code signal at all and is reported as
+    ``timeout``／``empty_output``／``invalid_output``／``ineligible``／``budget``
+    already carry an unambiguous router category and are passed through
+    unchanged. ``ineligible`` (profile enabled but not currently runnable, e.g.
+    missing executable) and ``budget`` (session deadline／call budget
+    exhausted) are router-internal classifications that never spawn a
+    subprocess——``exit_code`` is always ``None`` for them——so fallback-mapping
+    them would mislabel a routing decision as a subprocess decode failure. A
+    nonzero exit code that fell through those (e.g. a bare ``process``
+    category) is a genuine ``nonzero_exit``. Anything left——no exit code and
+    no specific category (missing executable races, subprocess-level decode
+    failures)——has no exit-code signal at all and is reported as
     ``decode_error`` so it stays distinguishable from a clean nonzero exit.
     """
-    if category in {"timeout", "empty_output", "invalid_output"}:
+    if category in {"timeout", "empty_output", "invalid_output", "ineligible", "budget"}:
         return category
     if exit_code is not None and exit_code != 0:
         return "nonzero_exit"

--- a/paulsha_hippo/atomizer/pipeline.py
+++ b/paulsha_hippo/atomizer/pipeline.py
@@ -8,8 +8,9 @@ import re
 import shutil
 from dataclasses import replace
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
+from ..agent_profiles import AgentRunResult
 from ..ledger import processing, relations
 from ..noise import DocCorpus, classify_noise
 from . import slice_frontmatter, splitter
@@ -20,6 +21,11 @@ from .splitter import Fragment
 
 LOGGER = logging.getLogger(__name__)
 _ATOMIZER_INBOX_FILE_MAX_BYTES = 64 * 1024 * 1024
+# park evidence 的 attempts_detail.stderr_tail 上限（issue #69 子項 A）。router
+# 已在建構 AgentRunResult 時以 sanitize_stderr 套用 500 字元上限；這裡再用既有的
+# secret-redaction 錯誤文字淨化（sanitize_error_text）覆蓋一次並以本上限截斷，
+# 是 park evidence 落盤前唯一的 choke point，不依賴上游是否已經夠短。
+_ATTEMPTS_DETAIL_STDERR_LIMIT = 2000
 
 
 def _parse_frontmatter(text: str) -> tuple[Mapping[str, Any] | None, str]:
@@ -194,9 +200,57 @@ def _read_attempts(counter: Path) -> int:
         return 0
 
 
+def _attempt_failure_kind(category: str | None, exit_code: int | None) -> str:
+    """Map one router attempt's bounded diagnostics to a park-evidence failure_kind.
+
+    ``timeout``／``empty_output``／``invalid_output`` already carry an unambiguous
+    router category. A nonzero exit code that fell through those (e.g. a bare
+    ``process`` category) is a genuine ``nonzero_exit``. Anything left——no exit
+    code and no specific category (missing executable races, subprocess-level
+    decode failures)——has no exit-code signal at all and is reported as
+    ``decode_error`` so it stays distinguishable from a clean nonzero exit.
+    """
+    if category in {"timeout", "empty_output", "invalid_output"}:
+        return category
+    if exit_code is not None and exit_code != 0:
+        return "nonzero_exit"
+    return "decode_error"
+
+
+def _attempts_detail_from_attempts(
+    attempts: Sequence[AgentRunResult],
+) -> list[dict[str, Any]]:
+    """Project bounded per-attempt subprocess evidence for a parked session.
+
+    Reuses the same per-attempt data the external agent runner layer already
+    captures for ``distiller.attempts`` (issue #69 子項 A：這批資料本來就存在，
+    只是 park 路徑先前沒有讀取）。Successful attempts (``failure_category is
+    None``) are skipped: they never reach a parked session on their own.
+    """
+    detail: list[dict[str, Any]] = []
+    for attempt in attempts:
+        category = getattr(attempt, "failure_category", None)
+        if category is None:
+            continue
+        detail.append(
+            {
+                "profile_id": attempt.profile_id,
+                "exit_code": attempt.exit_code,
+                "duration_seconds": round(float(attempt.elapsed_seconds), 6),
+                "stderr_tail": processing.sanitize_error_text(
+                    attempt.stderr, limit=_ATTEMPTS_DETAIL_STDERR_LIMIT
+                ),
+                "stdout_bytes": int(getattr(attempt, "output_bytes", 0) or 0),
+                "failure_kind": _attempt_failure_kind(category, attempt.exit_code),
+            }
+        )
+    return detail
+
+
 def _park_session(memory_root: Path, *, session_key: str, category: str, attempts: int,
                   cache_key: str, error_text: str, now: str, config_hash: str,
-                  last_output_excerpt: str = "") -> None:
+                  last_output_excerpt: str = "",
+                  attempts_detail: Sequence[Mapping[str, Any]] | None = None) -> None:
     """parked 終態：證據落盤 → 淘汰毒快取＋sidecar（保留 split fragments）→ 記 ledger。
 
     ledger append 放最後當 commit point：中途 crash 只會多一次 bounded 重試（fail-open），
@@ -223,6 +277,7 @@ def _park_session(memory_root: Path, *, session_key: str, category: str, attempt
         "ts": now,
         "last_output_bytes": len(output_bytes),
         "last_output_sha256": hashlib.sha256(output_bytes).hexdigest(),
+        "attempts_detail": [dict(item) for item in (attempts_detail or ())],
     }
     _atomic_write(
         _failed_evidence_path(memory_root, session_key),
@@ -341,6 +396,7 @@ def _handle_promote_failure(
     if counter is None:
         return "", False
     attempts = int(getattr(exc, "attempts", 0))
+    attempts_detail = _attempts_detail_from_attempts(promoter.router_attempts())
     promoter.clear_last_chunk_caches()
     promoter.clear_cache_for_fragments(fragments)
     _park_session(
@@ -353,6 +409,7 @@ def _handle_promote_failure(
         now=now,
         config_hash=config_hash,
         last_output_excerpt=str(getattr(promoter, "last_raw_output", "")),
+        attempts_detail=attempts_detail,
     )
     return f" (parked: {category} after {attempts} bounded chunk attempt(s))", True
 

--- a/paulsha_hippo/ops.py
+++ b/paulsha_hippo/ops.py
@@ -629,8 +629,13 @@ def _probe_environment() -> tuple[dict[str, str], bool]:
 
 
 _PROBE_TIMEOUT_SECS = 60
+# #69 子項 B：舊 prompt 只求「有回應」（reply with the single word ok），與真實
+# atomize 的輸出契約（單一 JSON、無夾帶散文）無關——會把「能回話但不守 JSON
+# 契約」的 backend（如 cg：launcher 強制輸出 JSON，模型卻回散文 → exit 3）
+# 誤判為 FAIL 以外的另一種反相關；也會把「回話但不是 JSON」誤判為健康。改成
+# 要求單一 JSON，驗證條件比照 atomize 的嚴格解析（parse_single_json_value）。
 _PROBE_SMOKE_PROMPT = (
-    "hippo doctor smoke probe: reply with the single word ok and nothing else."
+    'Reply with exactly this JSON and nothing else: {"ok":true}'
 )
 _PROBE_MAX_TOKENS = 32
 
@@ -686,24 +691,34 @@ def _probe_external_profiles(*, live: bool) -> tuple[list[str], bool]:
                 failed = True
                 continue
             command[0] = resolved
-        ok, detail = _exec_probe_service_effective(command, probe_env)
+        ok, detail, _kind = _exec_probe_service_effective(command, probe_env)
         lines.append(f"{label} {'✓' if ok else 'FAIL'} {detail}")
         failed = failed or not ok
     return lines, failed
 
 
 def _exec_probe_service_effective(command: list[str], probe_env: dict[str, str],
-                                  *, runner=subprocess.run) -> tuple[bool, str]:
+                                  *, runner=subprocess.run) -> tuple[bool, str, str]:
     """以 probe_env（見 `_probe_environment`）對 backend argv 送 bounded smoke prompt。
 
     doctor 是恢復序列的前置 gate（spec §4.1「實際喚起 backend 一次」）。早前
     判定把 timeout 與 126/127 以外的任何 exit code 都視為 PASS——backend hang
     （上游卡住）與認證／model／quota／config 錯誤（一律非零 exit）全被誤判為
-    健康，gate 綠燈後 requeue 立即再度失敗或 parked。改為 fail-closed：經 stdin
-    送 bounded smoke prompt（比照 AgentExecClient.run 的餵入方式），timeout 內
-    exit 0 且 stdout 非空（可解析回應）才 PASS；timeout、任何非零 exit（含
-    126/127）、空輸出、exec 失敗（ENOENT／EACCES、shebang interpreter 斷鏈、
-    輸出非 UTF-8 位元組令 text=True decode 失敗）一律 FAIL。
+    健康，gate 綠燈後 requeue 立即再度失敗或 parked。#69 子項 B 再往前一步：
+    舊版「exit 0 且 stdout 非空」與真實 atomize 的輸出契約無關——會把「能回話
+    但不守 JSON 契約」判成 ✓（如 claude 對真實 payload 吐 0 bytes 以外的散文）、
+    也會把「守 JSON 契約但這個 prompt 沒觸發 JSON」判成 FAIL（如 cg：launcher
+    強制輸出 JSON，模型回散文 → exit 3）。改為 fail-closed 且與 atomize 同契約：
+    經 stdin 送 bounded smoke prompt（比照 AgentExecClient.run 的餵入方式），
+    timeout 內 exit 0 且 stdout 可解析為「恰好一個 JSON value」（重用 atomize
+    既有的嚴格解析 `llm_output.parse_single_json_value`）才 PASS；timeout、
+    任何非零 exit（含 126/127）、空輸出、無法解析為單一 JSON、exec 失敗
+    （ENOENT／EACCES、shebang interpreter 斷鏈、輸出非 UTF-8 位元組令
+    text=True decode 失敗）一律 FAIL。
+
+    回傳 (ok, detail, kind)；``kind`` ∈ {"ok", "timeout", "nonzero", "empty",
+    "invalid_json", "exec_error"}，供呼叫端／測試機器可讀地區分 FAIL 成因，
+    不必反解 detail 的人讀文字。
 
     Codex 複驗 B1：環境由呼叫端以 `_probe_environment()` 顯式構造（僅用來
     決定 service-effective PATH），但真正傳給外部 CLI 的環境仍收斂到
@@ -717,6 +732,7 @@ def _exec_probe_service_effective(command: list[str], probe_env: dict[str, str],
     真實 session 寫回 queue，重新引入遞迴自捕捉／queue 污染。
     """
     from .agent_profiles import child_environment
+    from .atomizer.llm_output import LlmOutputError, parse_single_json_value
 
     env = child_environment({"PATH": probe_env.get("PATH", _FALLBACK_SERVICE_PATH)})
     try:
@@ -730,27 +746,32 @@ def _exec_probe_service_effective(command: list[str], probe_env: dict[str, str],
         )
     except subprocess.TimeoutExpired:
         return False, (f"smoke prompt {_PROBE_TIMEOUT_SECS}s 內未完成"
-                       "（backend hang／上游卡住；fail-closed）")
+                       "（backend hang／上游卡住；fail-closed）"), "timeout"
     except FileNotFoundError:
-        return False, "exec 失敗：檔案或 shebang interpreter 不存在"
+        return False, "exec 失敗：檔案或 shebang interpreter 不存在", "exec_error"
     except PermissionError:
-        return False, "exec 失敗：無執行權限"
+        return False, "exec 失敗：無執行權限", "exec_error"
     except OSError as exc:
-        return False, f"exec 失敗：{exc}"
+        return False, f"exec 失敗：{exc}", "exec_error"
     except UnicodeDecodeError as exc:
         # text=True 以 locale 編碼解 stdout/stderr，backend 吐非 UTF-8 位元組
         # （跑錯 binary／crash dump／locale 錯亂的錯誤文字）時 decode 於 run()
         # 內拋 UnicodeDecodeError（ValueError 子類，非 OSError）。此正是本 probe
         # 要偵測的故障類；比照恢復 gate fail-closed 語意判 FAIL，不得逸出崩潰 CLI。
         return False, (f"exec 失敗：backend 輸出非 UTF-8 位元組"
-                       f"（跑錯 binary／crash dump／locale 錯亂；fail-closed）：{exc}")
+                       f"（跑錯 binary／crash dump／locale 錯亂；fail-closed）：{exc}"), "invalid_json"
     if completed.returncode != 0:
         stderr_tail = " ".join(str(completed.stderr or "").split())[:200]
         return False, (f"exit {completed.returncode}（smoke prompt 失敗；"
-                       f"認證／model／quota／config 錯誤同屬此類）：{stderr_tail}")
-    if not str(completed.stdout or "").strip():
-        return False, "exit 0 但回應為空（無可解析輸出）"
-    return True, "smoke prompt exit 0、回應非空"
+                       f"認證／model／quota／config 錯誤同屬此類）：{stderr_tail}"), "nonzero"
+    stdout = str(completed.stdout or "")
+    if not stdout.strip():
+        return False, "exit 0 但回應為空（無可解析輸出）", "empty"
+    try:
+        parse_single_json_value(stdout)
+    except LlmOutputError as exc:
+        return False, f"exit 0 但回應不是單一 JSON（{exc}；atomize 同契約下同樣會判 invalid_output）", "invalid_json"
+    return True, "smoke prompt exit 0、回應為單一 JSON", "ok"
 
 
 def _probe_backend_service_effective(*, live: bool = False) -> tuple[str, bool]:
@@ -814,7 +835,7 @@ def _probe_backend_service_effective(*, live: bool = False) -> tuple[str, bool]:
             "（hippo doctor --fix-backend 可嘗試自動遷移）",
             True,
         )
-    ok, detail = _exec_probe_service_effective(command, probe_env)
+    ok, detail, _kind = _exec_probe_service_effective(command, probe_env)
     if ok:
         return (
             f"- distiller backend：✓ {command[0]}（{env_label} smoke probe；{detail}）",

--- a/paulsha_hippo/ops.py
+++ b/paulsha_hippo/ops.py
@@ -759,7 +759,7 @@ def _exec_probe_service_effective(command: list[str], probe_env: dict[str, str],
         # 內拋 UnicodeDecodeError（ValueError 子類，非 OSError）。此正是本 probe
         # 要偵測的故障類；比照恢復 gate fail-closed 語意判 FAIL，不得逸出崩潰 CLI。
         return False, (f"exec 失敗：backend 輸出非 UTF-8 位元組"
-                       f"（跑錯 binary／crash dump／locale 錯亂；fail-closed）：{exc}"), "invalid_json"
+                       f"（跑錯 binary／crash dump／locale 錯亂；fail-closed）：{exc}"), "exec_error"
     if completed.returncode != 0:
         stderr_tail = " ".join(str(completed.stderr or "").split())[:200]
         return False, (f"exit {completed.returncode}（smoke prompt 失敗；"

--- a/tests/test_external_agent_profiles.py
+++ b/tests/test_external_agent_profiles.py
@@ -142,6 +142,24 @@ def test_failure_classification_is_bounded(stderr, category):
     assert classify_failure(stderr) == category
 
 
+def test_sanitize_stderr_redacts_secret_that_spans_the_truncation_boundary():
+    # Codex 複驗 BLOCKING：sanitize_stderr 舊行為「先截斷（limit=500）才交給
+    # 下游 processing.sanitize_error_text 做 secret redaction」——若 secret 跨越
+    # 第 500 字元邊界，截斷會把 token 腰斬成低於 policy/secrets.yaml github_pat
+    # 規則最小長度（ghp_ 後 20+ chars）的殘片，令 regex 比對不到，殘片明文
+    # 落入 runtime/queue/_failed/*.json。redaction 必須先於截斷（比照
+    # ledger.processing.sanitize_error_text 既有契約），本測試釘住這個順序。
+    from paulsha_hippo.agent_profiles import sanitize_stderr
+
+    token = "ghp_" + "A1b2C3d4" * 5  # 44 字元的 GitHub PAT 形狀
+    raw = "x" * 490 + " " + token + " trailing"
+
+    sanitized = sanitize_stderr(raw)
+
+    assert "ghp_" not in sanitized
+    assert "A1b2C3d4" not in sanitized
+
+
 def test_router_falls_back_by_tier_and_marks_degraded_success():
     profiles = (_profile("first", tier=1), _profile("second", tier=2))
     calls: list[str] = []

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -536,6 +536,14 @@ class DoctorBackendProbeTests(unittest.TestCase):
             self._doctor_with_command(("/bin/sh", "-c", r'printf "\377\376\200\201" >&2')),
             1,
         )
+        # 非阻擋修正 2：這是 exec 層故障（decode 於 subprocess.run() 內部拋出，
+        # 根本沒走到 JSON 解析），kind 必須回報 "exec_error"、不得誤標
+        # "invalid_json"（釘住這個選擇，避免與真正「回應不是單一 JSON」混淆）。
+        ok, detail, kind = ops._exec_probe_service_effective(
+            ["/bin/sh", "-c", r'printf "\377\376\200\201"'], {"PATH": "/usr/bin:/bin"})
+        self.assertFalse(ok)
+        self.assertEqual(kind, "exec_error")
+        self.assertTrue(detail)
 
     def test_probe_smoke_prompt_requests_single_json(self):
         # #69 子項 B：smoke prompt 必須要求單一 JSON，而非只求「有回應」——

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -462,8 +462,8 @@ class DoctorBackendProbeTests(unittest.TestCase):
     def test_probe_passes_with_absolute_executable(self):
         with TemporaryDirectory() as tmp:
             exe = Path(tmp) / "claude"
-            # fail-closed 判定下 PASS 需 exit 0＋非空回應（不只 exec 得起來）
-            exe.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+            # fail-closed 判定下 PASS 需 exit 0＋單一 JSON 回應（不只 exec 得起來）
+            exe.write_text('#!/bin/sh\nprintf \'{"ok":true}\'\n', encoding="utf-8")
             exe.chmod(0o755)
             cfg = self._fake_cfg(agent_exec_command=(str(exe), "-p"))
             with mock.patch.dict("os.environ", self._ENV), \
@@ -537,10 +537,91 @@ class DoctorBackendProbeTests(unittest.TestCase):
             1,
         )
 
+    def test_probe_smoke_prompt_requests_single_json(self):
+        # #69 子項 B：smoke prompt 必須要求單一 JSON，而非只求「有回應」——
+        # 否則「能回話但不守 JSON 契約」的 backend 會被誤判為健康。
+        self.assertIn("json", ops._PROBE_SMOKE_PROMPT.lower())
+
+    def test_probe_passes_on_single_json_reply(self):
+        # #69：回單一 JSON 且 exit 0 → PASS，kind="ok"
+        with TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "claude"
+            exe.write_text(
+                '#!/bin/sh\ncat >/dev/null\nprintf \'{"ok":true}\'\n',
+                encoding="utf-8",
+            )
+            exe.chmod(0o755)
+            ok, detail, kind = ops._exec_probe_service_effective(
+                [str(exe)], {"PATH": "/usr/bin:/bin"})
+            self.assertTrue(ok)
+            self.assertEqual(kind, "ok")
+            self.assertTrue(detail)
+
+    def test_probe_fails_invalid_json_kind_on_prose_reply(self):
+        # #69 回歸：cg 的失敗形狀——exit 0、非空，但輸出是散文而非單一 JSON。
+        # 舊版「exit 0 + 非空即 PASS」的判定與真實 atomize 契約反相關；
+        # 新契約必須把這種情況判 FAIL，並回報 kind="invalid_json"。
+        with TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "claude"
+            exe.write_text(
+                '#!/bin/sh\ncat >/dev/null\n'
+                'printf \'Sure, here is your answer: everything looks ok.\'\n',
+                encoding="utf-8",
+            )
+            exe.chmod(0o755)
+            ok, detail, kind = ops._exec_probe_service_effective(
+                [str(exe)], {"PATH": "/usr/bin:/bin"})
+            self.assertFalse(ok)
+            self.assertEqual(kind, "invalid_json")
+            self.assertTrue(detail)
+
+    def test_probe_fails_empty_kind_on_empty_output(self):
+        # #69：claude 的實戰失敗形狀——exit 0 但 0 bytes 輸出；kind 必須可與
+        # invalid_json／nonzero／timeout 區分，才能對應 issue 的四類成因。
+        with TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "claude"
+            exe.write_text("#!/bin/sh\ncat >/dev/null\nexit 0\n", encoding="utf-8")
+            exe.chmod(0o755)
+            ok, detail, kind = ops._exec_probe_service_effective(
+                [str(exe)], {"PATH": "/usr/bin:/bin"})
+            self.assertFalse(ok)
+            self.assertEqual(kind, "empty")
+            self.assertTrue(detail)
+
+    def test_probe_fails_nonzero_kind_on_nonzero_exit(self):
+        with TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "claude"
+            exe.write_text(
+                '#!/bin/sh\ncat >/dev/null\necho boom >&2\nexit 3\n',
+                encoding="utf-8",
+            )
+            exe.chmod(0o755)
+            ok, detail, kind = ops._exec_probe_service_effective(
+                [str(exe)], {"PATH": "/usr/bin:/bin"})
+            self.assertFalse(ok)
+            self.assertEqual(kind, "nonzero")
+            self.assertTrue(detail)
+
+    def test_probe_fails_timeout_kind_on_hang(self):
+        with mock.patch.object(ops, "_PROBE_TIMEOUT_SECS", 0.2):
+            ok, detail, kind = ops._exec_probe_service_effective(
+                ["/bin/sleep", "5"], {"PATH": "/usr/bin:/bin"})
+        self.assertFalse(ok)
+        self.assertEqual(kind, "timeout")
+        self.assertTrue(detail)
+
     def test_probe_passes_when_smoke_prompt_answered(self):
-        # cat 把 stdin 的 smoke prompt 原樣回吐：exit 0＋非空輸出 → PASS，
-        # 同時驗證 prompt 確實經 stdin 餵入（比照 AgentExecClient.run）
-        self.assertEqual(self._doctor_with_command(("/bin/cat",)), 0)
+        # 假 backend 讀完 stdin 的 smoke prompt 後回覆單一 JSON：
+        # exit 0＋單一 JSON → PASS，同時驗證 prompt 確實經 stdin 餵入
+        # （比照 AgentExecClient.run；讀不完 stdin 就結束會讓 pipe 提早關閉）。
+        with TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "claude"
+            exe.write_text(
+                '#!/bin/sh\ncat >/dev/null\nprintf \'{"ok":true}\'\n',
+                encoding="utf-8",
+            )
+            exe.chmod(0o755)
+            self.assertEqual(self._doctor_with_command((str(exe),)), 0)
 
     def test_probe_env_carries_self_session_marker(self):
         # #7 回歸：probe 實跑 backend argv，需比照 agent_exec.AgentExecClient.run
@@ -550,11 +631,12 @@ class DoctorBackendProbeTests(unittest.TestCase):
             out = Path(tmp) / "env.txt"
             fake_backend = Path(tmp) / "claude"
             fake_backend.write_text(
-                f'#!/bin/sh\nprintf "%s" "${{HIPPO_SELF_SESSION:-MISSING}}" > "{out}"\necho ok\n',
+                f'#!/bin/sh\nprintf "%s" "${{HIPPO_SELF_SESSION:-MISSING}}" > "{out}"\n'
+                'printf \'{"ok":true}\'\n',
                 encoding="utf-8",
             )
             fake_backend.chmod(0o755)
-            ok, _ = ops._exec_probe_service_effective(
+            ok, _detail, _kind = ops._exec_probe_service_effective(
                 [str(fake_backend), "-p"], {"PATH": "/usr/bin:/bin"})
             self.assertTrue(ok)
             self.assertEqual(out.read_text(encoding="utf-8"), "1")
@@ -1071,8 +1153,8 @@ class FixBackendMigrationTests(unittest.TestCase):
     def _real_exe(self, tmp: str) -> Path:
         exe = Path(tmp) / "bin" / "claude"
         exe.parent.mkdir(parents=True, exist_ok=True)
-        # migration 後 doctor 會對 exe 做 smoke probe：需 exit 0＋非空回應
-        exe.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+        # migration 後 doctor 會對 exe 做 smoke probe：需 exit 0＋單一 JSON 回應
+        exe.write_text('#!/bin/sh\ncat >/dev/null\nprintf \'{"ok":true}\'\n', encoding="utf-8")
         exe.chmod(0o755)
         return exe
 

--- a/tests/test_park_evidence_observability.py
+++ b/tests/test_park_evidence_observability.py
@@ -160,6 +160,50 @@ class ParkEvidenceAttemptsDetailTests(unittest.TestCase):
         self.assertEqual(attempt["failure_kind"], "timeout")
         self.assertLessEqual(len(attempt["stderr_tail"]), 2000)
 
+    def test_secret_spanning_truncation_boundary_is_fully_redacted(self):
+        # Codex 複驗 BLOCKING boundary-bisection 案例，走完整 park evidence 路徑：
+        # fake agent 吐出「490 字元 padding + 44 字元 ghp_ token」的 stderr，
+        # 若兩層 sanitize（agent_profiles.sanitize_stderr 先截斷、
+        # processing.sanitize_error_text 後 redact）順序有缺，token 會在
+        # sanitize_stderr 就被腰斬成低於 github_pat 規則最小長度的殘片，
+        # 令下游 redaction 比對不到，殘片明文落入 attempts_detail.stderr_tail。
+        token = "ghp_" + "A1b2C3d4" * 5
+        padding = "x" * 490
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            script = _write_fake_agent(
+                tmp_path,
+                "fake-secret-boundary.sh",
+                "#!/bin/sh\ncat >/dev/null\n"
+                f"echo '{padding} {token} trailing' >&2\n"
+                "exit 2\n",
+            )
+            payload = self._run_once(tmp_path, script)
+
+        detail = payload["attempts_detail"]
+        self.assertEqual(len(detail), 1)
+        attempt = detail[0]
+        self.assertEqual(attempt["failure_kind"], "nonzero_exit")
+        self.assertNotIn("ghp_", attempt["stderr_tail"])
+        self.assertNotIn("ghp_", json.dumps(payload))
+
+
+class AttemptFailureKindMappingTests(unittest.TestCase):
+    """非阻擋修正 1：router 內部分類（從未 spawn subprocess）不得誤標 decode_error。
+
+    ``ineligible``（profile 啟用但目前不可執行，如 executable 缺失）與
+    ``budget``（deadline／call budget 耗盡）都是 router 自己的判斷，從未
+    spawn 過子行程——``exit_code`` 恆為 ``None``。舊行為把這兩類 fallback
+    成 ``decode_error``，誤導值班者以為是子行程解碼失敗；已帶明確語意的
+    category 必須直接透傳為 failure_kind。
+    """
+
+    def test_ineligible_category_passes_through_unchanged(self):
+        self.assertEqual(pipeline._attempt_failure_kind("ineligible", None), "ineligible")
+
+    def test_budget_category_passes_through_unchanged(self):
+        self.assertEqual(pipeline._attempt_failure_kind("budget", None), "budget")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_park_evidence_observability.py
+++ b/tests/test_park_evidence_observability.py
@@ -1,0 +1,165 @@
+"""issue #69 子項 A：external agent 呼叫的可觀測性。
+
+parked evidence 過去只有 attempts/cache_key/error/failure_category/
+last_output_bytes/last_output_sha256——timeout、CLI 靜默失敗、rate limit、
+進程被殺完全無法區分（實例：claude 對真實 payload 吐 0 bytes，evidence 無
+stderr、無 exit code 可查）。這裡新增 attempts_detail，逐一以 fake agent
+shell script（真實 subprocess，走 ExternalAgentRouter → AgentExecClient）
+模擬 empty_output／nonzero_exit／timeout 三種失敗形狀，驗證 park evidence
+JSON 含每次嘗試的 profile_id/exit_code/duration_seconds/stderr_tail/
+stdout_bytes/failure_kind，且 stderr_tail 已去敏截斷。
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from paulsha_hippo.agent_profiles import AgentProfile, ExternalAgentRouter
+from paulsha_hippo.atomizer import agent_exec, config as atomizer_config, llm_promoter, pipeline
+from paulsha_hippo.ledger import processing
+
+_RAW = """---
+memory_layer: inbox
+project: paulshaclaw
+source_agent: claude
+source_session: s1
+source_artifact: research
+captured_at: "2026-07-27T00:00:00Z"
+provenance:
+  repo: paulshaclaw
+  commit: c
+  path: docs/x.md
+---
+# Topic A
+alpha body
+# Topic B
+beta body
+"""
+
+
+def _seed_raw(root: Path) -> Path:
+    raw = root / "inbox" / "research" / "claude" / "2026-07-27" / "s1.md"
+    raw.parent.mkdir(parents=True, exist_ok=True)
+    raw.write_text(_RAW, encoding="utf-8")
+    return raw
+
+
+def _write_fake_agent(tmp: Path, name: str, script: str) -> Path:
+    path = tmp / name
+    path.write_text(script, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _profile_for_script(script_path: Path, *, timeout: int = 30) -> AgentProfile:
+    return AgentProfile(
+        id="fakeagent",
+        tier=1,
+        priority=1,
+        traits=("test",),
+        task_classes=("atomization",),
+        model="test-model",
+        effort="medium",
+        supported_efforts=("medium",),
+        argv=(str(script_path),),
+        supported_models=("test-model",),
+        timeout=timeout,
+    )
+
+
+class ParkEvidenceAttemptsDetailTests(unittest.TestCase):
+    def _run_once(self, tmp: Path, script_path: Path, *, timeout: int = 30):
+        root = tmp / "memory"
+        _seed_raw(root)
+        cfg, config_hash = atomizer_config.load_config(override_path=None)
+        profile = _profile_for_script(script_path, timeout=timeout)
+        router = ExternalAgentRouter((profile,))
+        cached = agent_exec.CachingAgentClient(
+            router, root / "runtime" / "cache" / "atomize"
+        )
+        promoter = llm_promoter.LLMPromoter(
+            cached, skill_text="OBS-SKILL",
+            known_projects=["paulshaclaw"], model="fake-llm",
+        )
+        pipeline.run(
+            root, config=cfg, config_hash=config_hash,
+            now="2026-07-27T01:00:00Z", promoter=promoter,
+        )
+        self.assertEqual(processing.state_of(root, "claude:s1"), "parked")
+        evidence_path = root / "runtime" / "queue" / "_failed" / "claude__s1.json"
+        self.assertTrue(evidence_path.exists())
+        return json.loads(evidence_path.read_text(encoding="utf-8"))
+
+    def test_empty_output_failure_kind(self):
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            script = _write_fake_agent(
+                tmp_path,
+                "fake-empty.sh",
+                "#!/bin/sh\ncat >/dev/null\n"
+                "echo 'boom: no output produced' >&2\n"
+                "exit 0\n",
+            )
+            payload = self._run_once(tmp_path, script)
+
+        # 既有欄位一個都不動
+        self.assertEqual(payload["session_key"], "claude:s1")
+        self.assertIn("last_output_bytes", payload)
+        self.assertIn("last_output_sha256", payload)
+
+        detail = payload["attempts_detail"]
+        self.assertEqual(len(detail), 1)
+        attempt = detail[0]
+        self.assertEqual(attempt["profile_id"], "fakeagent")
+        self.assertEqual(attempt["failure_kind"], "empty_output")
+        self.assertEqual(attempt["exit_code"], 0)
+        self.assertEqual(attempt["stdout_bytes"], 0)
+        self.assertIn("boom: no output produced", attempt["stderr_tail"])
+        self.assertLessEqual(len(attempt["stderr_tail"]), 2000)
+
+    def test_nonzero_exit_failure_kind_and_stderr_redaction(self):
+        secret = "ghp_" + "A1b2C3d4" * 5
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            script = _write_fake_agent(
+                tmp_path,
+                "fake-nonzero.sh",
+                "#!/bin/sh\ncat >/dev/null\n"
+                f"echo 'fatal: auth token {secret} rejected' >&2\n"
+                "exit 2\n",
+            )
+            payload = self._run_once(tmp_path, script)
+
+        detail = payload["attempts_detail"]
+        self.assertEqual(len(detail), 1)
+        attempt = detail[0]
+        self.assertEqual(attempt["profile_id"], "fakeagent")
+        self.assertEqual(attempt["failure_kind"], "nonzero_exit")
+        self.assertEqual(attempt["exit_code"], 2)
+        self.assertLessEqual(len(attempt["stderr_tail"]), 2000)
+        # 既有 secret-redaction 淨化必須套用在 stderr_tail 上
+        self.assertNotIn(secret, attempt["stderr_tail"])
+        self.assertNotIn(secret, json.dumps(payload))
+
+    def test_timeout_failure_kind(self):
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            script = _write_fake_agent(
+                tmp_path,
+                "fake-hang.sh",
+                "#!/bin/sh\ncat >/dev/null\nsleep 30\n",
+            )
+            payload = self._run_once(tmp_path, script, timeout=1)
+
+        detail = payload["attempts_detail"]
+        self.assertEqual(len(detail), 1)
+        attempt = detail[0]
+        self.assertEqual(attempt["profile_id"], "fakeagent")
+        self.assertEqual(attempt["failure_kind"], "timeout")
+        self.assertLessEqual(len(attempt["stderr_tail"]), 2000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

Closes #69

修復 issue #69 的兩個程式面子項（方向 5 與方向 3）。環境面成因（codex quota 至 2026-08-02、
local-vllm 啟用評估）不在本 PR 範圍，於 issue 追蹤。

### 子項 A — parked evidence 可觀測性（方向 5）

claude 對真實 atomization payload 吐 0 bytes 時，parked evidence 只有
`last_output_bytes = 0`，timeout／CLI 靜默失敗／rate limit／進程被殺完全無法區分。
而 runner 層（`ExternalAgentRouter`）其實**已經擷取** per-attempt 的
stderr/exit_code/elapsed（promoted atom 的 `distiller.attempts` 有），park 路徑把它丟了。

- parked evidence 新增 `attempts_detail`：`{profile_id, exit_code, duration_seconds,
  stderr_tail, stdout_bytes, failure_kind}` per attempt。
- `failure_kind` ∈ {timeout, nonzero_exit, empty_output, invalid_output, decode_error}。
- `stderr_tail` 經既有 `processing.sanitize_error_text` 淨化（redaction 先於截斷，
  `processing.py:57` 既有契約）再截斷 ≤2000 字元；park 落盤前唯一 choke point，
  不依賴上游長度。
- 新增 `AgentRunResult.output_bytes` 貫穿 `agent_exec.py → agent_profiles.py → pipeline.py`。
- 既有欄位一個不動；`attempts_detail` 預設空列表，init-failure 等其他 park 路徑向後相容。

### 子項 B — doctor probe 可信度（方向 3）

舊 probe 只驗「exit 0 + stdout 非空」，與真實 atomize 契約反相關（實測 3 個 profile 判反 2 個）：
claude 判 ✓ 但真實任務失敗；cg 判 FAIL 但其實可用（launcher 強制 JSON 輸出，probe prompt
沒要求 JSON，模型回散文 → launcher exit 3 假陰性）。

- smoke prompt 改為 `Reply with exactly this JSON and nothing else: {"ok":true}`。
- 驗證改為「stdout 可解析為恰好一個 JSON value」——從 `llm_output.parse_response` 抽出
  `parse_single_json_value` 供 atomize 與 probe 共用（純搬移、行為保持、錯誤訊息逐字不變），
  非平行實作。
- `_exec_probe_service_effective` 回傳 2-tuple → 3-tuple（新增機器可讀 `kind` ∈
  {ok, timeout, nonzero, empty, invalid_json, exec_error}）；兩個生產呼叫端已同步。
- install 閘門語意（profile_probe 全過才放行）刻意未動。

### 對抗複核後的補修（`8a5c4af`）

第一版（`7f08255`）經 adversarial review 擋下一個 BLOCKING，已修復並經主 agent 複驗：

- **[Security] `sanitize_stderr` 改 redaction-先於-截斷**：先前「先截斷（500 字元）才交給
  下游 `sanitize_error_text` 做 secret redaction」的順序，會在 secret 跨越截斷邊界時把
  token 腰斬成低於 redaction 規則最小長度的殘片，令比對失配、殘片明文落入 parked
  evidence（主 agent 實測重現：`ghp_A1b2C` 殘片穿透兩層）。修復後主 agent 以
  **邊界位置掃描**複驗（token 起點掃 430~520 全區域、github_pat + openai key 兩型）：
  零洩漏。此修復同時涵蓋共用此函式的既有 `distiller.attempts` frontmatter 路徑。
- `_attempt_failure_kind`：`ineligible`／`budget`（router 內部分類、從未 spawn
  subprocess）直接透傳，不再誤標 `decode_error`。
- probe 的 UnicodeDecodeError 分支 kind 由 `invalid_json` 改 `exec_error`（未走到 JSON
  解析，屬 exec 層），並以測試釘住字面值。

### TDD 證據

- 子項 A RED：`tests/test_park_evidence_observability.py`（新檔）三案（empty_output／
  nonzero_exit／timeout，以真實可執行 fake script 走完整 `pipeline.run()`）皆
  `KeyError: 'attempts_detail'` → 實作後轉綠。
- 子項 B RED：`tests/test_ops.py` 7 案先失敗（5 案 `ValueError: not enough values to
  unpack`、prompt 內容斷言失敗等）→ 實作後 probe 相關 31 案全綠。
- 補修 RED（`8a5c4af`）：boundary-bisection 兩案（unit-level + 走完整 park evidence
  路徑）修復前殘留 `ghp_A1b2C`；`ineligible`／`budget` 兩案修復前回傳 `decode_error`；
  non-UTF-8 案修復前 kind 為 `invalid_json`——全部先 RED 後轉綠。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

證據：

- **乾淨環境全套 pytest**（sibling worktree，非巢狀，含補修後）：`1633 passed, 4 skipped,
  154 subtests, 0 failed`。
- **policy_check**：R-01～R-26 全 pass，唯 R-22 既有 warn。
- **openspec validate --all --strict**：13 passed, 0 failed。
- **四路最終確認**：主 agent 人工 diff 審查 ✓（兩個 commit 皆審：parse 重構行為保持、
  3-tuple 呼叫端齊全、park 路徑向後相容、補修的 redact 插入點）、乾淨環境全套測試 ✓、
  adversarial reviewer 初審 block → 補修 → 主 agent 邊界掃描複驗 ✓、CI ✓。
- 已知限縮（誠實記載）：`failure_kind` 五值中 timeout／empty_output／nonzero_exit 有專屬
  fake-script 測試；invalid_output／decode_error 為分類兜底，無穩定重現的簡單 fake script，
  未加專屬測試。probe 的 exec_error kind 沿用既有測試路徑驗行為、未斷言 kind 字面值。
- 無使用者面 CLI 介面變動（doctor 輸出文字更精確化）；`VERSION` 維持 0.1.1。

## 風險與回復

- 子項 B 觸及 atomize 生產解析路徑，但重構為純搬移（`parse_single_json_value` ←
  `parse_response` 原內文），錯誤訊息逐字不變，全套測試綠。
- probe 判定變嚴（JSON 契約）：doctor `--probe-profiles` 與 `install all --force` 的
  `profile_probe` 會更誠實地 FAIL 不守契約的 backend——這是修復目的；閘門語意本身未動。
- park evidence 為 append-only 落盤路徑，新增欄位向後相容。
- 回復：revert 單一 commit 即可。
- 尚未完成的 acceptance：合併重部署後，requeue 一個 parked session 實測 attempts_detail
  在真實失敗下的內容（live 驗證段）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yjKTs6YvDe6CziKsWc4V3
