### PR TITLE
docs(atomize): 補 issue #80 規劃三件套與 cortex work item

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -14,6 +14,20 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/plans/2026-07-15-issue-34-atomization-release.md'
     excludes: []
+  issue-80-atomize-chunk-budget:
+    title: 'issue-80-atomize-chunk-budget'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-hippo#80'
+      - kind: path
+        ref: 'docs/superpowers/specs/2026-07-28-issue-80-atomize-chunk-budget-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/2026-07-28-issue-80-atomize-chunk-budget-design.md'
+      - kind: path
+        ref: 'docs/superpowers/plans/2026-07-28-issue-80-atomize-chunk-budget.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/issue-80-atomize-chunk-budget/todo.md'
+    excludes: []
   issue-64-ledger-torn-line-repair:
     title: 'issue-64-ledger-torn-line-repair'
     links:

--- a/changelog.d/80-planning-artifacts.md
+++ b/changelog.d/80-planning-artifacts.md
@@ -1,0 +1,7 @@
+---
+type: change
+scope: docs
+---
+### Changed
+
+- 新增 issue #80（大 session 的 chunk 序列總時間超出 chain 預算、且部分完成成果被整批丟棄）的規劃三件套與 workstream todo，並在 `.cortex/work-items.yaml` 登錄對應 work item `issue-80-atomize-chunk-budget`（連結 issue 與四份 artifact）。三個落地方向依風險遞增排序為獨立 Task：session 預算隨 chunk 數縮放（600s 下限／240s per chunk／1800s 上限，per-call 300s hang 防護不動）、profile 以宣告式 `max_session_chunks` 表達適用範圍（超出者走既有 ineligible 路徑、不耗 agent call、不新增 fallback category）、以及已驗證 chunk 成果跨 profile 保留與續跑（provenance 誠實記載 per-chunk profile，混合時標既有的 `degraded-success`）。本 PR 只含規劃產物，不含實作。

--- a/docs/superpowers/plans/2026-07-28-issue-80-atomize-chunk-budget.md
+++ b/docs/superpowers/plans/2026-07-28-issue-80-atomize-chunk-budget.md
@@ -1,0 +1,74 @@
+---
+status: accepted
+work_item: issue-80-atomize-chunk-budget
+---
+
+# 大 session 的 chunk 序列預算與部分成果保留 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for every task — write the failing test first, watch it fail for the right reason, then implement. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓有真實 ingress 的 dream timer cycle 能穩定產出至少一個 accepted atom：大 session 的 fallback 鏈拿得到與其 chunk 數相稱的時間、明顯做不完的 profile 不再空耗預算、已驗證的 chunk 成果不因後段失敗而整批丟棄。
+
+**Architecture:** 三個 Task 依風險遞增排序，彼此可獨立交付。Task 1 只動 `agent_profiles.py` 的常數與 `run_session` 的預算算式；Task 2 新增一個宣告式 profile 欄位並接進既有的 ineligible 路徑；Task 3 改 router 的 session 契約（已驗證前綴可保留、跨 profile 續跑）並讓 provenance 誠實反映混合 profile。**做不完 Task 3 不影響 Task 1、2 的價值**——請依序完成並各自保持全綠，不要為了 Task 3 而讓前兩者處於半完成狀態。
+
+**Tech Stack:** Python 3.12、標準庫、pytest。無新增外部相依。
+
+## Global Constraints
+
+- **語言**：PR 標題、內文、commit message、changelog 碎片一律 zh-tw（repo 屬 `github.com/hamanpaul/*`）。
+- **TDD 強制**：每個 Task 先寫測試看到 RED 再實作。測試通過即定案，不追加超出 Task 範圍的重構。
+- **不得放寬 `FIXED_TIMEOUT_SECONDS`**（單次呼叫 300s hang 防護）。任何改動若使單次呼叫可超過 300s 即為違規。
+- **不得新增 fallback category**。`FALLBACK_ON` 是不可變 allowlist，新的不適用情境沿用既有的 `ineligible`。
+- **不得弱化既有失敗語意**：耗盡仍須 park、仍須寫 parked evidence 與 `attempts_detail`，`failure_kind` 分類不變。
+- **出貨模板漂移守門**：`atomizer.yaml` 的 profile argv 必須與 `agent_profiles.default_profiles()` 逐 token 相同（`tests/test_external_agent_profiles.py::test_packaged_config_template_argv_matches_canonical_defaults`）。改 profile 定義時兩處必須同步。
+- **交付治理**：同一 PR 必須新增 `changelog.d/<slug>.md` 碎片；`python3 -m pytest -q`、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全數通過；PR body 用 repo 的 `.github/pull_request_template.md` 且 checklist 全勾；PR body 以 `Closes #80` 關閉 issue。
+- **測試環境**：跑全套測試請使用非巢狀的 sibling worktree。在 repo 目錄底下的巢狀 worktree（`.claude/worktrees/*`）執行時，`tests/test_project_resolver.py::ResolveAutoDetectTests` 會有 2 個固定失敗，那是環境假訊號而非缺陷。
+- **清理**：測試會生出 `.psc_tmp/`（`tests/stage2_integration_check.sh` 無 trap 清理且未進 `.gitignore`）。commit 前務必 `rm -rf .psc_tmp`，且**不要用 `git add -A`**。
+
+## Task 1: session 預算隨 chunk 數縮放
+
+**檔案**：`paulsha_hippo/agent_profiles.py`、`tests/test_external_agent_profiles.py`
+
+- [ ] 先寫測試：以 stub executor 建構 `ExternalAgentRouter`，斷言 `run_session` 對 1、2、7、100 個 prompt 分別採用的有效 deadline 為 600、600、1680、1800 秒。建議做法是把有效預算抽成可單獨呼叫的純函式（例如 `session_deadline_seconds(chunk_count)`）以便直接斷言，router 內部改呼叫它。
+- [ ] 先寫測試：斷言單次呼叫拿到的 timeout 仍是 `min(profile.timeout, remaining_seconds)` 且永不超過 `FIXED_TIMEOUT_SECONDS`。
+- [ ] 實作：新增 `FIXED_PER_CHUNK_DEADLINE_SECONDS = 240` 與 `FIXED_SESSION_DEADLINE_CAP_SECONDS = 1800`；`FIXED_SESSION_DEADLINE_SECONDS = 600` 維持不變並成為下限。
+- [ ] 實作：`run_session` 以 `min(CAP, max(FLOOR, PER_CHUNK * len(frozen_prompts)))` 取代直接使用 `self.deadline_seconds`。空序列的早退分支維持不變。
+- [ ] 在常數處補註解說明三個數字的來源（實測 190.5s／244s 單 chunk、每小時 timer 視窗、hang 防護不動）。
+- [ ] 全套測試綠。
+
+## Task 2: profile 以 `max_session_chunks` 宣告適用範圍
+
+**檔案**：`paulsha_hippo/agent_profiles.py`、`paulsha_hippo/atomizer/atomizer.yaml`、`paulsha_hippo/atomizer/config.py`、`tests/test_external_agent_profiles.py`
+
+- [ ] 先寫測試：`AgentProfile.from_mapping` 接受正整數 `max_session_chunks`；`0`、負數、非整數一律 `ProfileConfigError`；缺省時為 `None`。
+- [ ] 先寫測試：`profile.eligible(task_class="atomization", chunk_count=7)` 在 `max_session_chunks=6` 時回 `(False, "session_size")`，`chunk_count=6` 或 `chunk_count=None` 時回 `(True, "eligible")`。
+- [ ] 先寫測試：router 對 7-chunk session 跳過 `max_session_chunks=6` 的 profile 時，該 attempt 進 `attempts` provenance（`failure_category="ineligible"`）且 **agent call 計數不增加**，並繼續 fallback 到下一個 profile。
+- [ ] 先寫測試：canonical default 的 `claude` 與 `codex` 皆為 `max_session_chunks=6`，`cg` 為 `None`；且 `atomizer.yaml` 與 canonical default 一致（沿用既有的模板漂移守門測試風格）。
+- [ ] 實作：`AgentProfile` 新增欄位與驗證、`eligible()` 新增 keyword-only `chunk_count`、`run_session` 以 `len(frozen_prompts)` 傳入。
+- [ ] 實作：`cache_namespace()` 的 profile 描述加入 `max_session_chunks`（路由語意變更不得跨快取重放）。**不要**加進 `command_fingerprint`／`cache_identity`——它不改變送出的命令，混入會使既有快取全數失效。
+- [ ] 實作：`atomizer.yaml` 與 `config.py` 同步。
+- [ ] 全套測試綠。
+
+## Task 3: 已驗證的 chunk 成果跨 profile 保留與續跑
+
+**檔案**：`paulsha_hippo/agent_profiles.py`、`paulsha_hippo/atomizer/agent_exec.py`、`paulsha_hippo/atomizer/llm_promoter.py`、對應測試
+
+- [ ] 先寫測試：三個 chunk 的 session，profile A 完成 chunk 0、1 後在 chunk 2 失敗；斷言 profile B 收到的 prompt 序列**只有 chunk 2**，且最終回傳的 outputs 為 `[A0, A1, B2]`。
+- [ ] 先寫測試：上述情境的 provenance 記得出每個 chunk 的 profile，且 session 層 `fallback_reason` 為既有的 `degraded-success`。
+- [ ] 先寫測試：`CachingAgentClient` 在 chunk 驗證通過當下即落地該 chunk 的快取（不必等整個 session 成功），且不同 profile 產出的 chunk 不互相污染。
+- [ ] 先寫測試（回歸）：所有 profile 都無法完成剩餘 chunk 時仍拋 `AgentRunError`、pipeline 仍 park、`attempts_detail` 的 `failure_kind` 分類不變。
+- [ ] 實作：`run_session` 以「已驗證前綴 + 續跑起點」取代「全有全無」；保留 frozen prompt 序列與 per-chunk 驗證不變。
+- [ ] 實作：per-chunk provenance 結構與其在 `agent_exec` / `llm_promoter` 的傳遞；slice `distiller` 欄位誠實反映混合 profile。
+- [ ] 實作：`CachingAgentClient` 改為 per-chunk 落地。
+- [ ] 全套測試綠。
+
+## Task 4: 交付治理
+
+- [ ] `changelog.d/80-atomize-chunk-budget.md`：zh-tw，說明三個 Task 的實際落地範圍與量測依據（若 Task 3 未完成，誠實只寫已完成的部分）。
+- [ ] `rm -rf .psc_tmp`，逐檔 `git add`（不得 `git add -A`）。
+- [ ] 非巢狀 worktree 跑 `python3 -m pytest -q`、`python3 -m policy_check --repo .`、`openspec validate --all --strict`，三者皆綠。
+- [ ] PR body 用 `.github/pull_request_template.md`，checklist 全勾，內含 `Closes #80`，並附上實際測試輸出數字（不得寫「應該會過」）。
+
+## Blockers
+
+- [ ] 無

--- a/docs/superpowers/specs/2026-07-28-issue-80-atomize-chunk-budget-design.md
+++ b/docs/superpowers/specs/2026-07-28-issue-80-atomize-chunk-budget-design.md
@@ -1,0 +1,92 @@
+---
+status: accepted
+work_item: issue-80-atomize-chunk-budget
+---
+
+# 大 session 的 chunk 序列預算與部分成果保留（issue #80）設計
+
+- 日期：2026-07-28
+- Issue：[#80](https://github.com/hamanpaul/paulsha-hippo/issues/80)
+- 狀態：已核可，待實作
+
+## 背景
+
+三個相鄰但不同的缺陷已分別定位：#75（chain 預算被單次呼叫上限封頂，已修）、#74（`local-vllm` map-reduce 只切輸出不切輸入，未修、不在本次範圍）、以及本案。本案處理的是「時間夠不夠」與「已完成的部分算不算數」，證據見 spec。
+
+三個方向依風險遞增排序落地：預算縮放（最小、純常數與算式）→ profile 適用性宣告（中等、動到 eligibility）→ 部分成果保留（最深、動到 router 的 session 契約）。順序本身即是設計決定：前兩者可獨立產生價值，第三者做不完也不影響前兩者已交付的部分。
+
+## Decisions
+
+### D1：session 預算由 chunk 數決定，per-call 上限不動
+
+`ExternalAgentRouter.run_session(prompts)` 在呼叫當下就知道 `len(prompts)`，因此有效預算改為在 `run_session` 內依 chunk 數計算，而非固定用建構子傳入的常數。
+
+```
+effective_deadline = min(
+    FIXED_SESSION_DEADLINE_CAP_SECONDS,
+    max(FIXED_SESSION_DEADLINE_SECONDS, FIXED_PER_CHUNK_DEADLINE_SECONDS * len(prompts)),
+)
+```
+
+- `FIXED_SESSION_DEADLINE_SECONDS = 600` 維持不變，成為**下限**（單／雙 chunk 的小 session 行為完全不變，向後相容）。
+- 新增 `FIXED_PER_CHUNK_DEADLINE_SECONDS = 240`：取自實測 190.5s／244s 的上緣，讓 tier-1 有機會跑完而不是必然餓死。
+- 新增 `FIXED_SESSION_DEADLINE_CAP_SECONDS = 1800`：上限。dream timer 每小時觸發，單一 session 不得吃掉半小時以上的視窗，否則同輪其他 session 全被排擠。7 chunks → `min(1800, max(600, 1680)) = 1680s`。
+- `FIXED_TIMEOUT_SECONDS = 300` 完全不動，`_run_one` 仍收 `min(profile.timeout, remaining_seconds)`。hang 防護不受影響。
+
+`external_agents.deadline_seconds` 的 config 驗證維持既有語意（它界定的是下限那個值），不新增可調參數——這些是契約常數，不是 operator 旋鈕。
+
+### D2：profile 以宣告式 `max_session_chunks` 表達適用範圍
+
+`AgentProfile` 新增欄位 `max_session_chunks: int | None = None`（`None` = 不限）。`eligible()` 增加一個 keyword-only 參數 `chunk_count: int | None = None`；當 `max_session_chunks` 有值且 `chunk_count` 超過它時回 `(False, "session_size")`。
+
+- router 在 `run_session` 內以 `len(frozen_prompts)` 呼叫 `eligible(...)`，不適用的 profile 走既有的 ineligible 路徑：**記入 attempts provenance、消耗零個 agent call**，與現行 `disabled`／`task_class` 的處理一致。
+- 失敗類別沿用既有的 `ineligible`（已在 `FALLBACK_ON` 內），不新增 fallback category，避免動到不可變的 transition allowlist。
+- 出貨模板與 canonical default 只為 tier-1 設值（依 240s／chunk 與 1800s 上限推算，`claude` 與 `codex` 皆設 `max_session_chunks: 6`）；`cg`（26s/chunk）不設，維持不限。
+- `max_session_chunks` 進入 `command_fingerprint`／`cache_identity` 的判定？**不進**。它不改變送給 agent 的命令，只影響路由；混入指紋會讓既有快取全數失效。但它必須進 `cache_namespace()` 的 profile 描述，理由與 `fallback_on` 相同：路由改變時快取不得跨語意重放。
+
+### D3：已驗證的 chunk 成果可跨 profile 續用
+
+`run_session` 的「全有全無」語意改為「已驗證的前綴可保留」：
+
+- 維持既有的 per-chunk 驗證（`_validate_response`）與 frozen prompt 序列不變。
+- 某個 profile 在第 k 個 chunk 失敗時，`0..k-1` 的已驗證輸出連同「產出它們的 profile」一併保留；下一個 profile **從第 k 個 chunk 開始**，不再從 chunk 0 重跑。
+- 全部 chunk 完成後回傳的仍是完整的 outputs 序列，呼叫端（`llm_promoter`）不需要改變其消費方式。
+- provenance 誠實化：新增 per-chunk 的 `chunk_provenance`（`chunk_index` → `profile_id` / `tier` / `elapsed_seconds`），並在多於一個 profile 貢獻時把 session 層的 `fallback_reason` 記為既有的 `degraded-success`。**不得**把混合 profile 的 session 記成單一 profile 產出——那會讓 slice frontmatter 的 `distiller.profile_id` 說謊。
+- 快取：`CachingAgentClient` 已是 per-chunk cache key，改為「每個 chunk 驗證通過即可落地」，而非整個 session 成功才落地。cache key 內既有的 profile 維度維持不變，因此不同 profile 產出的 chunk 不會互相污染。
+- 真正耗盡（所有 profile 都無法完成剩餘 chunk）時的行為不變：拋 `AgentRunError`、pipeline park session、寫 parked evidence 與 `attempts_detail`。
+
+## 元件
+
+| 檔案 | 變更 |
+|---|---|
+| `paulsha_hippo/agent_profiles.py` | 新增兩個預算常數與 `max_session_chunks` 欄位；`eligible()` 增 `chunk_count`；`run_session` 改用有效預算、ineligible-by-size、續跑與 per-chunk provenance |
+| `paulsha_hippo/atomizer/agent_exec.py` | `CachingAgentClient` 改為 per-chunk 落地，並攜帶 per-chunk provenance |
+| `paulsha_hippo/atomizer/llm_promoter.py` | 消費 per-chunk provenance，寫入 slice `distiller` 欄位 |
+| `paulsha_hippo/atomizer/atomizer.yaml` | tier-1 profile 補 `max_session_chunks: 6`（受 argv 漂移守門保護，需與 canonical default 一致） |
+| `paulsha_hippo/atomizer/config.py` | profile 設定解析接受並驗證 `max_session_chunks`（正整數或缺省） |
+
+## 錯誤處理
+
+- `max_session_chunks` 非正整數 → `ProfileConfigError`（fail-closed，與既有 profile 欄位驗證一致）。
+- 有效預算計算不得因 `len(prompts) == 0` 而回 0：空序列在 `run_session` 既有的早退分支就已回傳，不進入預算計算。
+- per-chunk provenance 缺漏時不得靜默：若某個已回傳的 chunk 沒有對應的 provenance 記錄，視為程式錯誤而非可容忍狀態。
+
+## 測試
+
+每個 Task 均需先寫失敗測試再實作（見 plan）。至少涵蓋：
+
+- 單 chunk 與雙 chunk session 的有效預算等於 600s（向後相容）；7 chunks 等於 1680s；100 chunks 被 cap 在 1800s。
+- `FIXED_TIMEOUT_SECONDS` 不受影響：單次呼叫拿到的仍是 `min(300, remaining)`。
+- `max_session_chunks` 超過時 profile 判 `(False, "session_size")`，該 attempt 進 provenance 且 agent call 計數不增加。
+- 第 k 個 chunk 失敗後，次一 profile 由第 k 個 chunk 開始（以 executor 收到的 prompt 序列斷言），且前段輸出不重跑。
+- 混合 profile 完成的 session，provenance 記得出每個 chunk 的 profile，且 session 層標記 `degraded-success`。
+- 全數耗盡時仍 park，`attempts_detail` 的 `failure_kind` 分類不變。
+
+## 不在範圍
+
+- `FIXED_TIMEOUT_SECONDS` 的值、chunk 打包演算法、`local-vllm`（#74）、以及 AR-11 soak 本身的累積（那是本案落地後的自然結果，不是本案的驗收項）。
+
+## 合併後的 runtime 待辦
+
+- 同步使用者 live config `~/.config/paulsha-hippo/config.yaml`（repo 外）補上 tier-1 的 `max_session_chunks`，否則部署端沿用舊設定。
+- 觀察後續三輪有 ingress 的 timer cycle 是否產出 accepted atom，作為 AR-11 的前置條件。

--- a/docs/superpowers/specs/2026-07-28-issue-80-atomize-chunk-budget-spec.md
+++ b/docs/superpowers/specs/2026-07-28-issue-80-atomize-chunk-budget-spec.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+work_item: issue-80-atomize-chunk-budget
+---
+
+# 大 session 的 chunk 序列預算與部分成果保留（issue #80）規格
+
+## Problem and Outcome
+
+#77 修好 tier-1 `claude` profile 的輸出契約之後，**有真實 ingress 的 timer cycle 仍然產不出任何 accepted atom**。
+
+`2026-07-28T07:00:42Z` 那輪 timer 是修復後第一個有 ingress 的 cycle：`split_sessions=1`、`slices=0`、`status=partial`，session `claude-code:9105547d…` 被 park。parked evidence 的 `attempts_detail` 顯示 claude 跑了 299.7s 後 `timeout`（`stdout_bytes=0`、最後一次呼叫只剩 2 秒），codex 接手時只剩 1 秒。
+
+根因是算術，不是契約：
+
+| 量測項 | 值 |
+|---|---|
+| claude 單 chunk | 190.5s（另一次量測 244s） |
+| cg 單 chunk | 26.0s |
+| 47 fragments／212,950 bytes 的 session | 打包成 **7 chunks** |
+| chain 預算 `FIXED_SESSION_DEADLINE_SECONDS` | 600s |
+| 單次呼叫上限 `FIXED_TIMEOUT_SECONDS` | 300s |
+
+7 × 190s ≈ 1,330s，是 chain 預算的兩倍以上。router 給每次呼叫的是 `min(profile.timeout, remaining_seconds)`，所以 tier-1 跑到第二、三個 chunk 就把整條鏈的時間用完，後續 profile 只拿得到個位數秒。
+
+第二層問題使浪費加倍：`ExternalAgentRouter.run_session()` 的契約是「每個 chunk 都驗證通過才算該 profile 成功」，**後段 chunk 失敗會丟棄前段所有已驗證的 outputs**，下一個 profile 從 chunk 0 重跑。claude 那 299.7s 內確實已產出合法 JSON（同一批 fragments 的 chunk 0 單獨重跑得 exit 0／190.5s／15,858 bytes／`parse_response()` 通過），卻整批作廢。
+
+預期結果：大 session 不再必然 park；有 ingress 的 timer cycle 能穩定產出至少一個 accepted atom，使 AR-11 soak 具備累積條件；已經產出的合法內容不因後段失敗而丟棄。
+
+## Goals
+
+- 整條 fallback 鏈的時間預算隨該 session 實際的 chunk 數縮放，而非固定 600s；單次呼叫 300s 的 hang 防護維持不變。
+- 明顯超出某個 profile 可完成範圍的 session，不再耗盡預算才失敗，而是在耗用 agent call 之前就判定該 profile 不適用並讓路給更快的 profile。
+- 後段 chunk 失敗時，前段已驗證的 chunk 成果可被保留與續用，且 provenance 誠實記載哪個 chunk 由哪個 profile 產出。
+- 既有的失敗語意不被弱化：真正耗盡時仍 park、仍寫 parked evidence，`attempts_detail` 仍可區分 `timeout`／`invalid_output`／`empty_output`。
+
+## Non-Goals
+
+- 不調整 `FIXED_TIMEOUT_SECONDS`（單次呼叫 300s）。放寬單次上限等於放棄 hang 防護。
+- 不處理 #74（`local-vllm` map-reduce 只切輸出不切輸入）。那是另一支 harness 的獨立缺陷。
+- 不改變 chunk 打包演算法本身（`budget.pack_prompt_chunks` 的 token/bytes 上限維持不動）。降低 chunk 數需要重新評估截斷與品質風險，不在本次範圍。
+- 不改變 atomize 的輸出 schema 或 slice frontmatter 的既有欄位語意。

--- a/docs/superpowers/workstreams/issue-80-atomize-chunk-budget/todo.md
+++ b/docs/superpowers/workstreams/issue-80-atomize-chunk-budget/todo.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: issue-80-atomize-chunk-budget
+---
+
+# issue-80-atomize-chunk-budget / todo
+
+規劃三件套：
+
+- spec — `docs/superpowers/specs/2026-07-28-issue-80-atomize-chunk-budget-spec.md`
+- design — `docs/superpowers/specs/2026-07-28-issue-80-atomize-chunk-budget-design.md`
+- plan — `docs/superpowers/plans/2026-07-28-issue-80-atomize-chunk-budget.md`
+
+## Tasks
+
+- [ ] session 預算隨 chunk 數縮放（600s 為下限、240s/chunk、1800s 上限；per-call 300s 不動）
+- [ ] profile 宣告 `max_session_chunks`，超出者以既有 ineligible 路徑讓路且不耗 agent call
+- [ ] 已驗證的 chunk 成果跨 profile 保留與續跑，provenance 誠實記載 per-chunk profile
+- [ ] changelog.d 碎片、全套 pytest、policy_check、openspec strict validate
+
+## Blockers
+
+- [ ] 無
+
+## 合併後 runtime 待辦（不在 PR diff 內）
+
+- [ ] 同步使用者 live config `~/.config/paulsha-hippo/config.yaml` 補 tier-1 的 `max_session_chunks`
+- [ ] 觀察後續有 ingress 的 timer cycle 是否產出 accepted atom（AR-11 的前置條件）


### PR DESCRIPTION
## 摘要

補上 issue #80 的規劃三件套與 cortex work item 登錄。**本 PR 只含規劃產物，不含實作**——實作將由 cortex 派工給 codex builder 執行。

規劃產物必須先落地 main 的原因：cortex 在 claim 當下會鎖定每份 planning artifact 的 `baseline_sha256`，claim 後再改會觸發 `workflow planning artifact current authority drift`，只能 abandon，而 abandon 後 work item 會留在 `blocked` 且沒有 GC 桿可清（cortex #178）。

## 三個方向依風險遞增排為獨立 Task

| Task | 內容 | 風險 |
|---|---|---|
| 1 | session 預算隨 chunk 數縮放：`600s` 為下限、`240s` per chunk、`1800s` 上限 | 低（純常數與算式） |
| 2 | profile 宣告 `max_session_chunks`，超出者走既有 ineligible 路徑 | 中（動 eligibility） |
| 3 | 已驗證的 chunk 成果跨 profile 保留與續跑 | 高（動 router 的 session 契約） |

排序本身是設計決定：**Task 3 做不完不影響 Task 1、2 已交付的價值**。

數字來源全部來自實測（見 spec）：claude 單 chunk 190.5s／244s、cg 26.0s、47 fragments 打包成 7 chunks、`2026-07-28T07:00:42Z` 那輪 timer 的 parked evidence（claude 299.7s timeout、`stdout_bytes=0`、最後一次呼叫只剩 2s）。

## 明文寫進 Global Constraints 的紅線

- 不得放寬 `FIXED_TIMEOUT_SECONDS`（單次呼叫 300s hang 防護）
- 不得新增 fallback category（`FALLBACK_ON` 是不可變 allowlist，新情境沿用既有的 `ineligible`）
- 不得弱化既有失敗語意（耗盡仍 park、仍寫 parked evidence、`failure_kind` 分類不變）
- `max_session_chunks` 進 `cache_namespace()` 但**不**進 `command_fingerprint`／`cache_identity`——它改的是路由不是命令，混入會讓既有快取全數失效
- 出貨模板漂移守門（#78 新增）要求 `atomizer.yaml` 與 `default_profiles()` 逐 token 一致，改 profile 定義時兩處必須同步

另把兩個已知環境坑寫進 plan 供 builder 參考：巢狀 worktree 會讓 `test_project_resolver.py` 產生 2 個假失敗；測試會生出 `.psc_tmp/` 且未進 `.gitignore`，commit 前須清且不得用 `git add -A`。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過 —— 本 PR 為純文件／設定，無程式碼變更；`python3 -m policy_check --repo .` 與 `openspec validate --all --strict` 均綠（見下），實作階段的測試要求已逐條寫入 plan 的每個 Task
- [x] `python3 -m policy_check --repo .`（含 PR context）通過 —— 無 failure，僅 R-22 陳年 WARN
- [x] OpenSpec validation 與 repo 額外 gates 通過 —— `openspec validate --all --strict` 13 passed, 0 failed
- [x] `changelog.d/` 已有對應碎片 —— `changelog.d/80-planning-artifacts.md`
- [x] `VERSION` 與 release 意圖一致 —— 維持 `0.1.1`，本 PR 不動版號
- [x] 文件與 CLI help 已同步 —— 本 PR 即為文件；無 CLI 介面變動

## 風險與回復

- 純規劃產物與 work-item 登錄，無程式碼、無資料遷移、無部署影響；`git revert` 即可回復。
- **尚未完成的 acceptance**：#80 的實作本身。本 PR merge 後才會 claim work item 派工，實作以另一個 PR 交付，屆時由該 PR 以 closing keyword 關閉對應 issue。

Refs #80
