### PR TITLE
docs(atomize): 補 issue #80 的 OpenSpec change 與 stage2-llm-distillation spec delta

### DIFF
--- a/changelog.d/80-openspec-change.md
+++ b/changelog.d/80-openspec-change.md
@@ -1,0 +1,7 @@
+---
+type: change
+scope: docs
+---
+### Changed
+
+- 新增 issue #80 的 OpenSpec change `issue-80-atomize-chunk-budget`（proposal／tasks／`stage2-llm-distillation` spec delta）。本次必須走 spec delta 而非單純實作，是因為方向三（已驗證 chunk 跨 profile 保留）直接牴觸既有 canonical 契約——「Deterministic tiered fallback」原文要求 fallback 時「restart the complete session from frozen input」，即後續 profile 必須從 chunk 0 完整重跑。delta 將該語意改為「從第一個未驗證的 chunk 續跑」，同時明訂全域預算隨 chunk 數縮放（per-call 上限不得因此放寬）、profile 可宣告適用的最大 session 大小（超出者 ineligible 且不耗 agent call），並擴充 provenance 要求為「多 profile 分段完成時須逐 chunk 指出產出者」。耗盡仍 park 一次、仍不做 partial publication 的語意維持不變。

--- a/openspec/changes/issue-80-atomize-chunk-budget/proposal.md
+++ b/openspec/changes/issue-80-atomize-chunk-budget/proposal.md
@@ -1,0 +1,36 @@
+---
+status: accepted
+work_item: issue-80-atomize-chunk-budget
+---
+
+## Why
+
+修好 tier-1 的輸出契約（#77）之後，**有真實 ingress 的 dream timer cycle 仍然產不出任何 accepted atom**。`2026-07-28T07:00:42Z` 那輪是修復後第一個有 ingress 的 cycle：`split_sessions=1`、`slices=0`、`status=partial`，session 被 park；parked evidence 顯示 claude 跑了 299.7s 後 `timeout`（`stdout_bytes=0`，最後一次呼叫只剩 2 秒），codex 接手只剩 1 秒。
+
+根因是算術：claude 單 chunk 實測 190.5s（另次 244s），47 fragments／212,950 bytes 的 session 打包成 **7 chunks**，7 × 190s ≈ 1,330s，而整條 fallback 鏈的預算固定 600s。router 給每次呼叫 `min(profile.timeout, remaining_seconds)`，因此 tier-1 跑到第二、三個 chunk 就把整條鏈的時間用光。
+
+第二層問題讓浪費加倍：現行契約要求「後續 profile 從 frozen input 完整重跑整個 session」，於是 claude 在那 299.7s 內**已經產出且已驗證通過**的前段 chunk 全被丟棄，codex 拿著剩下的 1 秒從 chunk 0 重來。
+
+後果是 AR-11 soak 結構性無法累積：沒有 ingress 的 cycle 不計分，有 ingress 的 cycle 因 session 過大而必然 park、同樣不計分。
+
+## What Changes
+
+- **session 預算隨 chunk 數縮放**：有效預算改為 `min(1800, max(600, 240 × chunk 數))`。600s 成為下限（單／雙 chunk 的小 session 行為不變）、240s 取自實測單 chunk 上緣、1800s 上限確保單一 session 不吃掉每小時 timer 視窗的一半以上。**單次呼叫上限 `FIXED_TIMEOUT_SECONDS = 300` 完全不動**，hang 防護不受影響。
+- **profile 宣告適用範圍**：`AgentProfile` 新增 `max_session_chunks`（預設 `None` = 不限）。超出宣告範圍的 profile 在該 session 判為 ineligible（沿用既有 `ineligible` 類別，不新增 fallback category），記入 attempt provenance 但**消耗零個 agent call**，讓路給能在預算內完成的 profile。
+- **已驗證的 chunk 成果跨 profile 保留**：後續 profile 從第一個**未驗證**的 chunk 續跑，而非從 chunk 0 完整重跑。這修改了「restart the complete session from frozen input」這條既有契約，因此需要本次的 spec delta。frozen prompt 序列與 per-chunk 驗證不變；耗盡時仍 park、仍不做 partial publication。
+- **provenance 誠實化**：一個 session 由多個 profile 分段完成時，逐 chunk 記錄實際產出它的 profile，session 層沿用既有的 `degraded-success`。禁止把混合 profile 的 session 記成單一 profile 產出。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `stage2-llm-distillation`：
+  - 「Deterministic tiered fallback」的全域預算由固定值改為隨 chunk 數縮放的有界函式；fallback 的重跑語意由「完整重跑整個 session」改為「從第一個未驗證的 chunk 續跑」；新增以宣告式 `max_session_chunks` 判定 profile 對該 session 是否適用的 ineligible 條件。
+  - 「Profile-bound cache and attempt provenance」擴充為：session 由多個 profile 分段完成時，provenance 必須能逐 chunk 指出實際產出者。
+
+## Non-Goals
+
+- 不調整 `FIXED_TIMEOUT_SECONDS`（單次呼叫 300s）；放寬它等於放棄 hang 防護。
+- 不改變 chunk 打包演算法（`budget.pack_prompt_chunks` 的 token／bytes 上限）。
+- 不處理 #74（`local-vllm` map-reduce 只切輸出不切輸入）。
+- 不改變耗盡時的行為：仍 park 一次、仍不做 partial publication。

--- a/openspec/changes/issue-80-atomize-chunk-budget/specs/stage2-llm-distillation/spec.md
+++ b/openspec/changes/issue-80-atomize-chunk-budget/specs/stage2-llm-distillation/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Deterministic tiered fallback
+
+The default ordered groups SHALL be Tier 1 `claude` and `codex` as difficult-decision judges, Tier 2 `agy` and `cg` as fast-response/heavy-work agents, and Tier 3 `co-gem`, `claude-gem`, and custom local profiles as low-cost fallback. Exact order within a tier SHALL use explicit numeric priority. Traits SHALL be reviewable routing metadata, not free-form instructions that permit the model to choose its successor. The fallback graph SHALL be acyclic and constrained by a global deadline, maximum attempts, maximum agent calls, and per-profile circuit breaker/cooldown. Dream profiles SHALL disable CLI-native model fallback/retry; a CLI for which preflight cannot prove native fallback is disabled SHALL be ineligible, so Hippo remains the sole routing and budget authority.
+
+The global deadline SHALL scale with the number of prompt chunks the session was packed into, bounded by a fixed floor and a fixed ceiling, so that a session's chain budget bears a defined relationship to the work it contains. The per-call timeout SHALL remain a separate fixed bound and MUST NOT be widened by this scaling; hang protection is not negotiable. A profile MAY declare a maximum session size it is suited for; when a session exceeds that declaration the profile SHALL be ineligible for that session, SHALL be recorded in attempt provenance, and MUST NOT consume an agent call.
+
+A valid `no_findings` response SHALL be success and MUST NOT trigger fallback. Allowlisted profile-ineligible, auth, rate-limit, capacity, timeout, transport/process, empty-output, and invalid-output categories MAY advance; deterministic input-contract, policy/config, unsafe, or context-budget failures MUST NOT. Success after one or more failed profiles SHALL be reported as `degraded-success`, retaining every prior failure and the fallback reason. Exhaustion SHALL park the session once.
+
+Chunk outputs that already passed response validation SHALL be retained across profile transitions: the next eligible profile SHALL resume from the first chunk that has no validated output rather than repeating validated work. The prompt sequence SHALL remain frozen and every chunk SHALL still be validated individually. Retention MUST NOT weaken exhaustion semantics: when no profile can complete the remaining chunks the session SHALL still be parked exactly once with no partial publication.
+
+#### Scenario: Primary auth failure falls back deterministically
+- **WHEN** the first Tier 1 profile returns a sanitized auth failure and policy allows fallback
+- **THEN** the next eligible profile in explicit priority order SHALL continue the session from the first chunk without a validated output and successful output SHALL be marked `degraded-success`
+
+#### Scenario: Chain budget scales with session size
+- **WHEN** a session is packed into more chunks than the fixed floor budget can cover
+- **THEN** the chain deadline SHALL scale with the chunk count up to the fixed ceiling, and each individual agent call SHALL still be bounded by the unchanged per-call timeout
+
+#### Scenario: Oversized session skips an unsuited profile without cost
+- **WHEN** a session's chunk count exceeds a profile's declared maximum session size
+- **THEN** that profile SHALL be ineligible for the session, SHALL appear in attempt provenance, and SHALL consume no agent call
+
+#### Scenario: Validated chunks survive a profile transition
+- **WHEN** a profile validates the first chunks of a session and then fails on a later chunk
+- **THEN** the next eligible profile SHALL be asked only for the chunks that have no validated output, and the validated outputs SHALL be reused rather than regenerated
+
+#### Scenario: Safety failure does not fallback
+- **WHEN** a profile attempt detects an input-contract, policy, unsafe, invalid-config, or context-budget failure
+- **THEN** the session SHALL fail closed immediately without invoking another agent
+
+#### Scenario: Entire chain is exhausted
+- **WHEN** every allowed profile fails within the global budgets or is circuit-open/ineligible
+- **THEN** the session SHALL be parked exactly once with the ordered attempt chain and no partial publication
+
+#### Scenario: Native fallback cannot be disabled
+- **WHEN** profile preflight cannot prove that the external CLI's own model fallback/retry is disabled
+- **THEN** that profile SHALL be ineligible for Dream and MUST NOT consume a session attempt
+
+### Requirement: Profile-bound cache and attempt provenance
+
+Distillation cache identity SHALL include task class/operation, response-schema hash/version, router-contract version, profile ID/revision, tier, requested model, requested effort, rendered command fingerprint, effective config hash, skill hash, and prompt hash. Processing records and atoms SHALL retain the selected profile/tier, attempt index, requested model/effort, observed model when verifiable, model-verification status, elapsed time, sanitized failure category, fallback reason, and command/config/skill/build identities. A cache entry or staged output from one operation, schema, profile, or profile revision MUST NOT satisfy another.
+
+When more than one profile contributed validated chunks to a single session, provenance SHALL identify the producing profile for each chunk, and the session-level record SHALL report `degraded-success`. A session completed by multiple profiles MUST NOT be recorded as the product of a single profile. Routing declarations that change which profile is eligible for a session SHALL participate in cache-namespace identity so that a routing change cannot replay outputs produced under different routing, while leaving the rendered command fingerprint unchanged when the command itself is unchanged.
+
+#### Scenario: Agent configuration change invalidates cache
+- **WHEN** task class, response schema, router contract, profile, model, effort, command template, config, skill, or prompt changes
+- **THEN** the previous cache entry SHALL not be reused and provenance SHALL identify the new request independently
+
+#### Scenario: Mixed-profile session records a producer per chunk
+- **WHEN** one profile validates some chunks of a session and another profile validates the rest
+- **THEN** provenance SHALL record which profile produced each chunk and the session SHALL be reported as `degraded-success`

--- a/openspec/changes/issue-80-atomize-chunk-budget/tasks.md
+++ b/openspec/changes/issue-80-atomize-chunk-budget/tasks.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+work_item: issue-80-atomize-chunk-budget
+---
+
+# Issue #80 大 session chunk 序列預算與部分成果保留 tasks
+
+依 TDD：每個實作任務前先落紅燈測試，看到預期的失敗原因再實作。測試置於 `tests/test_external_agent_profiles.py`（既有）與相關 atomizer 測試檔。
+
+實作細節與紅線見 `docs/superpowers/plans/2026-07-28-issue-80-atomize-chunk-budget.md`；三個 Task 依風險遞增排序，**Task 3 做不完不影響 Task 1、2 已交付的價值**。
+
+## 1. session 預算隨 chunk 數縮放
+
+- [ ] 1.1 紅燈：有效預算對 1、2、7、100 個 chunk 分別為 600、600、1680、1800 秒
+- [ ] 1.2 紅燈：單次呼叫拿到的 timeout 仍為 `min(profile.timeout, remaining_seconds)` 且不超過 `FIXED_TIMEOUT_SECONDS = 300`
+- [ ] 1.3 綠燈：新增 `FIXED_PER_CHUNK_DEADLINE_SECONDS = 240` 與 `FIXED_SESSION_DEADLINE_CAP_SECONDS = 1800`，`run_session` 改用 `min(CAP, max(FLOOR, PER_CHUNK × chunk 數))`
+- [ ] 1.4 常數處補註解說明三個數字的實測來源
+
+## 2. profile 宣告 `max_session_chunks`
+
+- [ ] 2.1 紅燈：`from_mapping` 接受正整數、拒絕 0／負數／非整數（`ProfileConfigError`）、缺省為 `None`
+- [ ] 2.2 紅燈：`eligible(chunk_count=7)` 在 `max_session_chunks=6` 時回 `(False, "session_size")`；`chunk_count=6` 或 `None` 時 eligible
+- [ ] 2.3 紅燈：router 跳過超出宣告的 profile 時，attempt 進 provenance（`failure_category="ineligible"`）且 agent call 計數不增加
+- [ ] 2.4 紅燈：canonical default 的 `claude`／`codex` 為 6、`cg` 為 `None`，且 `atomizer.yaml` 與 canonical default 一致
+- [ ] 2.5 綠燈：欄位、驗證、`eligible()` 的 keyword-only `chunk_count`、router 傳入 `len(frozen_prompts)`
+- [ ] 2.6 綠燈：`cache_namespace()` 納入 `max_session_chunks`；**不**納入 `command_fingerprint`／`cache_identity`
+
+## 3. 已驗證 chunk 跨 profile 保留與續跑
+
+- [ ] 3.1 紅燈：profile A 完成 chunk 0、1 後於 chunk 2 失敗，profile B 只收到 chunk 2，最終 outputs 為 `[A0, A1, B2]`
+- [ ] 3.2 紅燈：provenance 記得出每個 chunk 的 profile，session 層 `fallback_reason` 為 `degraded-success`
+- [ ] 3.3 紅燈：`CachingAgentClient` 於 chunk 驗證通過當下即落地該 chunk，且不同 profile 的 chunk 不互相污染
+- [ ] 3.4 紅燈（回歸）：全數耗盡時仍拋 `AgentRunError`、仍 park、`attempts_detail` 的 `failure_kind` 分類不變、無 partial publication
+- [ ] 3.5 綠燈：`run_session` 改為「已驗證前綴 + 續跑起點」，per-chunk provenance 傳遞至 `agent_exec` 與 `llm_promoter`
+
+## 4. 交付治理
+
+- [ ] 4.1 `changelog.d/80-atomize-chunk-budget.md`（zh-tw，誠實反映實際完成的 Task 範圍）
+- [ ] 4.2 `rm -rf .psc_tmp`，逐檔 `git add`（不得 `git add -A`）
+- [ ] 4.3 非巢狀 worktree 跑 `python3 -m pytest -q`、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 三者皆綠
+- [ ] 4.4 PR body 用 `.github/pull_request_template.md`、checklist 全勾、附實際測試輸出數字、以 closing keyword 關閉 issue #80


### PR DESCRIPTION
## 摘要

補上 issue #80 的 OpenSpec change：`proposal.md`、`tasks.md`，以及 `stage2-llm-distillation` 的 MODIFIED spec delta。

這是 cortex workflow `define` 階段 `openspec-propose` card 明列的產出（run `workflow-37e15dbe21bde73a329b` 目前停在 `define` / `needs_human`，就是在等這兩個檔）。**本 PR 仍不含實作**。

## 為什麼需要 spec delta，而不只是實作

方向三（已驗證的 chunk 跨 profile 保留與續跑）**直接牴觸現行 canonical 契約**。`openspec/specs/stage2-llm-distillation/spec.md` 的「Deterministic tiered fallback」原文：

> the next eligible profile in explicit priority order SHALL **restart the complete session from frozen input**

也就是說「後續 profile 必須從 chunk 0 完整重跑」是寫進 spec 的，不是實作偶然。要保留已驗證的 chunk，就必須先改契約——這正是 openspec 流程該攔下來的東西，寫實作前先改 spec。

delta 內容：

| 契約 | 變更 |
|---|---|
| Deterministic tiered fallback | 全域預算改為隨 chunk 數縮放（有下限與上限）；per-call 上限明訂**不得**因此放寬；profile 可宣告適用的最大 session 大小，超出者 ineligible 且**不耗 agent call**；fallback 由「完整重跑」改為「從第一個未驗證的 chunk 續跑」 |
| Profile-bound cache and attempt provenance | 多 profile 分段完成的 session，provenance 須**逐 chunk**指出實際產出者，session 層報 `degraded-success`；路由宣告參與 cache-namespace 但不改變 command fingerprint |

刻意**不動**的語意：耗盡仍 park 一次、仍不做 partial publication、safety failure 仍 fail closed、native fallback 不可證明停用者仍 ineligible。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過 —— 本 PR 為純規格文件，無程式碼變更；每條 delta 需求皆附 scenario（strict validation 要求），實作階段的測試要求逐條寫在 `tasks.md`
- [x] `python3 -m policy_check --repo .`（含 PR context）通過 —— 無 failure，僅 R-22 陳年 WARN
- [x] OpenSpec validation 與 repo 額外 gates 通過 —— `openspec validate --all --strict` **14 passed, 0 failed**（新增本 change 後由 13 增為 14）；`openspec validate issue-80-atomize-chunk-budget --strict` 回報 valid
- [x] `changelog.d/` 已有對應碎片 —— `changelog.d/80-openspec-change.md`
- [x] `VERSION` 與 release 意圖一致 —— 維持 `0.1.1`
- [x] 文件與 CLI help 已同步 —— 本 PR 即為規格文件；無 CLI 介面變動

## 風險與回復

- 純規格產物，無程式碼、無資料遷移、無部署影響；`git revert` 即可回復。
- delta 在 change 被 archive 前不影響 canonical spec 的既有內容，因此不會讓現行實作立即違規。
- **尚未完成的 acceptance**：實作本身。本 PR merge 後 resume cortex run，由 codex builder 依 `tasks.md` 實作，實作 PR 屆時帶 closing keyword 關閉對應 issue。

Refs #80
