### PR TITLE
docs(atomize): workstream todo 補派工環境前置與 cortex planner identity 繞法

### DIFF
--- a/docs/superpowers/workstreams/issue-80-atomize-chunk-budget/todo.md
+++ b/docs/superpowers/workstreams/issue-80-atomize-chunk-budget/todo.md
@@ -26,3 +26,9 @@ work_item: issue-80-atomize-chunk-budget
 
 - [ ] 同步使用者 live config `~/.config/paulsha-hippo/config.yaml` 補 tier-1 的 `max_session_chunks`
 - [ ] 觀察後續有 ingress 的 timer cycle 是否產出 accepted atom（AR-11 的前置條件）
+
+## 派工環境前置（2026-07-28 實測）
+
+- cortex 套件預設的 canonical planning identity `agy / "Gemini 3.1 Pro (High)"` 已失效：probe 以字面比對 `agy models` 輸出，而 agy 現在輸出 kebab id（`gemini-3.1-pro-high`），比不到即回 `model-not-listed`，令 workflow run 永遠停在 `define` / `needs_human`（cortex #255）。繞法是在 `~/.agents/config/paulsha/model-identities.yaml` 以真實 id 另宣告一個 agy planning identity。
+- builder 身分由 `model-identities.yaml` 決定（workflow 路徑的 launcher 直接取 `identity.executor` 與 `identity.model_id`），沒有 `PSC_MANAGER_MODEL` 這個環境變數可 pin 模型。本批次的 builder 為 `codex / gpt-5.3-codex-spark`。
+- `PSC_PREFLIGHT_CMD` 未設時 `cortex doctor` 報 FAIL，且 run 走到 verify/ship 會失敗；本機已設為 `policy-preflight --repo-visibility private`。


### PR DESCRIPTION
## 摘要

在 issue-80 的 workstream todo 補上派工環境前置，並記錄 cortex planner identity 的繞法。

實測發現：cortex 套件預設的 canonical planning identity `agy / "Gemini 3.1 Pro (High)"` **必然 probe 失敗** —— probe 以字面比對 `agy models` 的輸出行，而 agy 現在輸出 kebab id（`gemini-3.1-pro-high`），顯示名不在清單內即回 `model-not-listed`。預設下那是唯一的 planning identity，因此 work-item workflow run 永遠停在 `define` / `needs_human`，對外只表現成 `sizing_unavailable: true` 與空的 evidence 目錄。已於 cortex repo 開 issue 記錄（hamanpaul/paulsha-cortex#255）。

一併記下另兩項環境事實：builder 身分只能由 `model-identities.yaml` 決定（無 `PSC_MANAGER_MODEL` env 可 pin 模型），以及 `PSC_PREFLIGHT_CMD` 未設會讓 verify/ship 階段失敗。

這份記載的用途很實際：下一個接手的人不必重新查一次為什麼 run 不動。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過 —— 純文件變更，無程式碼；不涉及測試面
- [x] `python3 -m policy_check --repo .`（含 PR context）通過 —— 無 failure，僅 R-22 陳年 WARN
- [x] OpenSpec validation 與 repo 額外 gates 通過 —— 未改動 openspec 產物，既有 14 passed 不受影響
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由 —— 標 `skip-changelog`：本 PR 只在 workstream todo 追加環境備註，不影響任何使用者可見行為，亦不在 `code_paths` 內
- [x] `VERSION` 與 release 意圖一致 —— 維持 `0.1.1`
- [x] 文件與 CLI help 已同步 —— 本 PR 即為文件；無 CLI 介面變動

## 風險與回復

- 純文件，無程式碼、無資料遷移、無部署影響；`git revert` 即可回復。
- 副作用（刻意）：本 PR 會改變 work item 的 authority digest，令 cortex 產生新的 claim ——這正是讓 planning runtime 在修好的 planner identity 下重跑的安全途徑（`abandon` 會使 work item 卡在 `blocked` 且無 GC 桿，見 cortex #178，故不採用）。