### PR TITLE
docs(atomize): 派工環境前置改為獨立產物，還原 todo.md 至鎖定 baseline

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -27,6 +27,8 @@ work_items:
         ref: 'docs/superpowers/plans/2026-07-28-issue-80-atomize-chunk-budget.md'
       - kind: path
         ref: 'docs/superpowers/workstreams/issue-80-atomize-chunk-budget/todo.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/issue-80-atomize-chunk-budget/environment.md'
     excludes: []
   issue-64-ledger-torn-line-repair:
     title: 'issue-64-ledger-torn-line-repair'

--- a/docs/superpowers/workstreams/issue-80-atomize-chunk-budget/environment.md
+++ b/docs/superpowers/workstreams/issue-80-atomize-chunk-budget/environment.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+work_item: issue-80-atomize-chunk-budget
+---
+
+# issue-80-atomize-chunk-budget / 派工環境前置
+
+2026-07-28 實測，以 cortex work-item 路徑派工本批次時踩到的環境前置。與實作內容無關，但不先處理就派不出去。
+
+## Decisions
+
+- **builder 身分只能由 `~/.agents/config/paulsha/model-identities.yaml` 決定**。workflow 路徑的 launcher 直接取 `identity.executor` 與 `identity.model_id`，且沒有 `PSC_MANAGER_MODEL` 這類環境變數可 pin 模型（只有 `PSC_MANAGER_EXECUTOR`，且它只管 executor）。本批次 builder 為 `codex / gpt-5.3-codex-spark`。
+- **model id 要用 CLI 接受的完整字串**。本機帳號只吃帶前綴的 `gpt-5.3-codex-spark`；`5.3-codex-spark` 會被回 400 `not supported when using Codex with a ChatGPT account`。派長任務前先用一句可辨識的短 prompt 驗整組 flag，成本遠低於長跑失敗。
+- **cortex 套件預設的 canonical planning identity 已失效**（`agy / "Gemini 3.1 Pro (High)"`）：probe 以字面比對 `agy models` 的輸出行，而 agy 現在輸出 kebab id（`gemini-3.1-pro-high`），顯示名不在清單內即回 `model-not-listed`。預設下那是唯一的 planning identity，因此 work-item workflow 永遠停在 `define` / `needs_human`，對外只表現成 `sizing_unavailable: true` 與空的 evidence 目錄。**繞法**：以真實 id 另宣告一個 agy planning identity（`model_id != AGY_MODEL_ID` 才會走通用 `_probe_identity`），並保持 `independence_domain: google` 與 `live_probe: agy-plan-sandbox`。追蹤於 `hamanpaul/paulsha-cortex` 的 planner identity issue。
+- **`PSC_PREFLIGHT_CMD` 必須設**，否則 `cortex doctor` 報 FAIL 且 run 走到 verify/ship 會失敗。本機值：`~/.local/share/paulsha-conventions/bin/policy-preflight --repo-visibility private`（cortex 會自動附加 `--pr <N>` 與 `--skip-tests`；`--repo-visibility` 要明給，否則 sanitized env 下 gh 認證拿不到會 fallback `unknown` 並以公開 repo 的最嚴標準判 R-21 fail-closed）。
+
+## 操作紀律
+
+- **planning artifact 一旦被 claim 就鎖定 `baseline_sha256`，之後不得修改**。改了會讓 resume 報 `workflow planning artifact current authority drift`，而該狀態的唯一出口 `abandon` 會使 work item 留在 `blocked` 且沒有 GC 桿可清。需要調整內容時，**新增檔案**而非改動既有產物——新增會改變 authority digest 並產生新的 claim，改動則觸發 drift。
+- `cortex work resume` 與 `start` 都要帶 `--payload`（內含 `repo_root`），否則報 `trusted repo registry did not resolve exactly one owner/name root`。
+- 重啟 manager／monitor 後 GitHub provider 會進入 awaiting live refresh，此期間 claim 報 `durable GitHub provider authority invalid`，實測約 90–220 秒恢復，重試即可。
+- `cortex tick --specs-dir` 只驅動 deck/spec 的 fanout 路徑，**不會**推進 work-item workflow run。

--- a/docs/superpowers/workstreams/issue-80-atomize-chunk-budget/todo.md
+++ b/docs/superpowers/workstreams/issue-80-atomize-chunk-budget/todo.md
@@ -26,9 +26,3 @@ work_item: issue-80-atomize-chunk-budget
 
 - [ ] 同步使用者 live config `~/.config/paulsha-hippo/config.yaml` 補 tier-1 的 `max_session_chunks`
 - [ ] 觀察後續有 ingress 的 timer cycle 是否產出 accepted atom（AR-11 的前置條件）
-
-## 派工環境前置（2026-07-28 實測）
-
-- cortex 套件預設的 canonical planning identity `agy / "Gemini 3.1 Pro (High)"` 已失效：probe 以字面比對 `agy models` 輸出，而 agy 現在輸出 kebab id（`gemini-3.1-pro-high`），比不到即回 `model-not-listed`，令 workflow run 永遠停在 `define` / `needs_human`（cortex #255）。繞法是在 `~/.agents/config/paulsha/model-identities.yaml` 以真實 id 另宣告一個 agy planning identity。
-- builder 身分由 `model-identities.yaml` 決定（workflow 路徑的 launcher 直接取 `identity.executor` 與 `identity.model_id`），沒有 `PSC_MANAGER_MODEL` 這個環境變數可 pin 模型。本批次的 builder 為 `codex / gpt-5.3-codex-spark`。
-- `PSC_PREFLIGHT_CMD` 未設時 `cortex doctor` 報 FAIL，且 run 走到 verify/ship 會失敗；本機已設為 `policy-preflight --repo-visibility private`。


### PR DESCRIPTION
## 摘要

修正上一輪（PR 83）的一個操作錯誤，並把環境備註改以獨立產物承載。

上一輪把備註直接追加進 `workstreams/issue-80-atomize-chunk-budget/todo.md`，但該檔已在 cortex claim 當下被鎖定 `baseline_sha256`。修改它使後續 resume 報：

```
ValueError: workflow planning artifact current authority drift
```

而 drift 狀態的唯一documented 出口是 `abandon`，它會讓 work item 留在 `blocked` 且沒有 GC 桿可清。等於為了推進 run 而把 run 推進不了的坑挖得更深。

## 修法

- `todo.md` 還原至鎖定的 baseline —— `sha256` 為 `28a524c5ba6d7d6564eb7295744caae380b3822550d9a9a29e7f695b53894d24`，與 run 記錄的 baseline 逐位元組吻合，drift 因此解除。
- 內容改以新增的 `environment.md` 承載（builder 身分來源、model id 完整字串、cortex planner identity 繞法、`PSC_PREFLIGHT_CMD` 前置，以及操作紀律）。
- `.cortex/work-items.yaml` 補上該檔連結。

## 為什麼是新增而不是改動

實測出來的規律，已寫進 `environment.md`：

| 動作 | 結果 |
|---|---|
| **新增**產物 | authority digest 改變 → 產生新的 claim（安全） |
| **改動**已鎖定的產物 | `authority drift` → 唯一出口 `abandon` → work item 卡 `blocked` |

所以需要調整規劃內容時，一律新增檔案，不動既有產物。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過 —— 純文件與設定，無程式碼變更
- [x] `python3 -m policy_check --repo .`（含 PR context）通過 —— 無 failure，僅 R-22 陳年 WARN
- [x] OpenSpec validation 與 repo 額外 gates 通過 —— 未改動 openspec 產物
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由 —— 標 `skip-changelog`：只動 workstream 文件與 work-item 連結，不在 `code_paths` 內、無使用者可見行為變更
- [x] `VERSION` 與 release 意圖一致 —— 維持 `0.1.1`
- [x] 文件與 CLI help 已同步 —— 本 PR 即為文件；無 CLI 介面變動

## 風險與回復

- 純文件與 work-item 連結，`git revert` 即可回復。
- `todo.md` 的還原以 sha256 逐位元組驗證，不是「看起來一樣」。