### PR TITLE
feat(shortlist): offer 早停——8 事件無讀取即停止自動 offer，顯式 recall 不受限

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 ## [Unreleased]
 
 ### Added
+- Prompt-time shortlist 新增 offer 早停機制：同一 `(tool, session_id)` 歷史 offer 事件數達
+  `OFFER_STOP_AFTER_EVENTS`（8）門檻、且 session 從未出現讀取或 applied 訊號時，
+  `build_shortlist_and_record` 提前回傳空字串，不再注入 shortlist、不記新 offered ledger
+  事件。實測：9 次 offered→read 中 7 次發生在第 0-1 個 offer 事件、第 7 個事件之後零讀取，
+  對長期不讀的 session 持續 offer 是純 context 污染；曾有讀取／applied 的 session 永不早停。
+  事件計數搭在既有 offered ledger 掃描路徑上，無新增 ledger 掃描成本。
 - `moc.search` 新增可注入 UTC `usage_now`／`usage_window_days` 的 usage-boost index metadata；預設窗口 30 天，`usage_boost = min(0.04, 0.01*log2(1+read_count))`，`base_score` 間距 > `0.04` 不被反轉。
 - janitor retention base 改為 `max(captured_at, active_since_ts, valid last_read_at)`；future read 不得延長 TTL，`superseded`／`source_invalid` 優先序與 read 不 reactivation 維持不變。CLI usage/funnel 以 one-shot raw iterators 折疊 compact per-session/per-slice state，不再保留 ledger-wide raw row lists。
 - `hippo usage funnel`：新增 session 層級漏斗報表，以收到非空記憶 brief 的 session 為分母，統計 offered → read → applied 的轉換率，並提供 per-tool 與被讀取 slice 的 top-N 特徵；支援 `--since`、`--json` 及既有／新版 offered ledger 格式（#18）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
   `build_shortlist_and_record` 提前回傳空字串，不再注入 shortlist、不記新 offered ledger
   事件。實測：9 次 offered→read 中 7 次發生在第 0-1 個 offer 事件、第 7 個事件之後零讀取，
   對長期不讀的 session 持續 offer 是純 context 污染；曾有讀取／applied 的 session 永不早停。
-  事件計數搭在既有 offered ledger 掃描路徑上，無新增 ledger 掃描成本。
+  事件計數搭在既有 offered ledger 掃描路徑上，無新增 ledger 掃描成本。`build_shortlist_and_
+  record` 新增 `bypass_early_stop` 參數，`hippo recall`（使用者主動召回）傳 `True` 略過早停，
+  自動 UserPromptSubmit hook 維持早停；`memory_usage.jsonl` 判讀改串流逐行讀，不整檔載入。
 - `moc.search` 新增可注入 UTC `usage_now`／`usage_window_days` 的 usage-boost index metadata；預設窗口 30 天，`usage_boost = min(0.04, 0.01*log2(1+read_count))`，`base_score` 間距 > `0.04` 不被反轉。
 - janitor retention base 改為 `max(captured_at, active_since_ts, valid last_read_at)`；future read 不得延長 TTL，`superseded`／`source_invalid` 優先序與 read 不 reactivation 維持不變。CLI usage/funnel 以 one-shot raw iterators 折疊 compact per-session/per-slice state，不再保留 ledger-wide raw row lists。
 - `hippo usage funnel`：新增 session 層級漏斗報表，以收到非空記憶 brief 的 session 為分母，統計 offered → read → applied 的轉換率，並提供 per-tool 與被讀取 slice 的 top-N 特徵；支援 `--since`、`--json` 及既有／新版 offered ledger 格式（#18）。

--- a/changelog.d/shortlist-offer-decay.md
+++ b/changelog.d/shortlist-offer-decay.md
@@ -15,3 +15,10 @@ type: feat
   的逐行讀取（`_session_has_engaged`）為本次唯一新增 I/O，且只在事件數達門檻時才觸發，未達門檻
   的一般 prompt 完全不受影響。早停狀態不落任何新檔——每次重算，無 schema migration、無 reconcile
   負擔。
+- `build_shortlist_and_record` 新增 `bypass_early_stop: bool = False` 參數：`hippo recall` CLI
+  （`cli.py` `_recall`）傳 `bypass_early_stop=True`——顯式召回是使用者主動操作，意圖明確，不應
+  被自動 UserPromptSubmit hook 專用的早停靜默擋掉；`claude_user_prompt_submit` / `copilot_user_
+  prompt_submit` 兩條自動 hook 路徑不帶參數，維持早停。
+- `_session_has_engaged` 改為串流逐行讀（`open("rb")` 逐行 iterate、命中即提前 return），不再
+  `read_text()` 整檔載入——`memory_usage.jsonl` 會隨時間持續成長，且早停中的 session 每個
+  prompt 都要掃一次；單行 UTF-8 解碼失敗或 JSON 壞行皆略過，不中止掃描。

--- a/changelog.d/shortlist-offer-decay.md
+++ b/changelog.d/shortlist-offer-decay.md
@@ -1,0 +1,17 @@
+---
+type: feat
+---
+- Prompt-time shortlist 新增 offer 早停機制：`build_shortlist_and_record`（`_shortlist_common.py`）
+  在同一 `(tool, session_id)` 的歷史 offer 事件數達 `OFFER_STOP_AFTER_EVENTS`（8）門檻、且該
+  session 於 `memory_usage.jsonl` 中從未出現讀取（`source=="read"`，不分 offered true/false）
+  或 applied（`kind=="applied"`）訊號時提前 `return ""`——不注入 shortlist、不記新 offered
+  ledger 事件。實測依據：每個 user prompt 觸發一次 offer、每次 3 個新 slice，長 session 因此
+  累積 p90=39、max=127 個唯一 offered slice；但 9 次 offered→read 中 7 次發生在第 0-1 個 offer
+  事件、2 次在第 6 個，第 7 個事件之後零讀取——對「一直沒在讀的 session」持續 offer 是純
+  context 污染。門檻取 8（比實測讀取發生的最後一個事件序號 6 多兩個事件）保留安全邊際；
+  session 只要曾有讀取或 applied，判定恆真、永不早停（使用者證明在消費，繼續供給）。
+- 事件計數搭在既有 `offered.jsonl` 掃描路徑上（`_reconcile_offered_map` 內的 `_scan_offered_ledger`
+  單一 pass 同時回傳 pairs 與事件筆數），不為早停判斷新增一次 ledger 掃描；`memory_usage.jsonl`
+  的逐行讀取（`_session_has_engaged`）為本次唯一新增 I/O，且只在事件數達門檻時才觸發，未達門檻
+  的一般 prompt 完全不受影響。早停狀態不落任何新檔——每次重算，無 schema migration、無 reconcile
+  負擔。

--- a/paulsha_hippo/cli.py
+++ b/paulsha_hippo/cli.py
@@ -1345,11 +1345,16 @@ def _memory_usage_funnel(args: argparse.Namespace) -> int:
 
 
 def _recall(args: argparse.Namespace) -> int:
-    """跨 CLI consumer API：重用 prompt-time shortlist 管線（best-effort，恆 exit 0）。"""
+    """跨 CLI consumer API：重用 prompt-time shortlist 管線（best-effort，恆 exit 0）。
+
+    bypass_early_stop=True：顯式 recall 是使用者主動操作，意圖明確，不受
+    OFFER_STOP_AFTER_EVENTS 早停（自動 UserPromptSubmit hook 專用的雜訊抑制）影響。
+    """
     from .hooks._shortlist_common import build_shortlist_and_record
 
     block = build_shortlist_and_record(
-        Path(args.memory_root), args.tool, args.session_id, args.cwd, args.prompt)
+        Path(args.memory_root), args.tool, args.session_id, args.cwd, args.prompt,
+        bypass_early_stop=True)
     if block:
         print(block)
     return 0

--- a/paulsha_hippo/hooks/_shortlist_common.py
+++ b/paulsha_hippo/hooks/_shortlist_common.py
@@ -21,6 +21,13 @@ from paulsha_hippo.hooks._wakeup_common import (
 SHORTLIST_K = 3
 SHORTLIST_FETCH_K = 12
 
+# Offer 早停門檻（issue：shortlist offer 訊噪比）。實測：每個 user prompt 觸發一次
+# offer、長 session 累積 p90=39、max=127 個唯一 offered slice，但 9 次 offered→read
+# 中 7 次發生在第 0-1 個 offer 事件、2 次在第 6 個，第 7 個事件之後零讀取——對「一直
+# 沒在讀的 session」持續 offer 是純 context 污染。8 保留完整安全邊際（比實測讀取發生
+# 的最後一個事件序號 6 多兩個事件）。
+OFFER_STOP_AFTER_EVENTS = 8
+
 
 def _norm_title_key(s: str) -> str:
     return re.sub(r"[\W_]+", "", s).lower()
@@ -70,19 +77,21 @@ def _redact(root: Path, tool: str, project: str, session_ref: str, text: str) ->
         return ""
 
 
-def _offered_pairs_from_ledger(root: Path, tool: str, session_id: str) -> list[tuple[str, str]]:
-    """從 append-only offered ledger 還原本 (tool, session_id) 曾 offer 的 (sl_id, path) 清單。
+def _scan_offered_ledger(root: Path, tool: str, session_id: str) -> tuple[list[tuple[str, str]], int]:
+    """單一 pass 掃描 offered ledger：回傳（本 (tool, session_id) 的 (sl_id, path) 清單，事件筆數）。
 
-    ledger 是 offered 的**單一真值**、跨 session 共用（同一 offered.jsonl）；依 session_id＋tool
-    過濾出本 session 的事件。per-session map 為此清單的衍生 cache——硬中止或 cache 寫入失敗
-    落在「ledger 有、map 無」時，這裡是重建 map／判定 offered 的權威來源。讀不到（不存在／IO／
-    單行壞）一律略過該來源（fail-open），不讓恢復路徑因殘缺 ledger 崩掉。
+    事件筆數＝符合 session_id＋tool 的 ledger 行數（同一行＝同一次 offer 事件，不論該行
+    內含幾個 (sl_id, path)）——OFFER_STOP_AFTER_EVENTS 早停判斷即以此為準。與
+    `_offered_pairs_from_ledger`（見下）共用同一次檔案讀取／逐行 parse，讓事件計數
+    「近乎免費」地搭在既有掃描路徑上，不需為早停判斷再多掃一遍 offered.jsonl。
+    讀不到（不存在／IO／單行壞）一律略過該來源（fail-open），不讓恢復路徑因殘缺 ledger 崩掉。
     """
     pairs: list[tuple[str, str]] = []
+    event_count = 0
     try:
         raw = (root / "runtime" / "ledger" / "offered.jsonl").read_text(encoding="utf-8")
     except OSError:
-        return pairs
+        return pairs, event_count
     for line in raw.splitlines():
         line = line.strip()
         if not line:
@@ -93,11 +102,24 @@ def _offered_pairs_from_ledger(root: Path, tool: str, session_id: str) -> list[t
             continue
         if ev.get("session_id") != session_id or ev.get("tool") != tool:
             continue
+        event_count += 1
         for item in ev.get("offered") or []:
             sid = item.get("sl_id") if isinstance(item, dict) else None
             p = item.get("path") if isinstance(item, dict) else None
             if sid and p:
                 pairs.append((str(sid), str(p)))
+    return pairs, event_count
+
+
+def _offered_pairs_from_ledger(root: Path, tool: str, session_id: str) -> list[tuple[str, str]]:
+    """從 append-only offered ledger 還原本 (tool, session_id) 曾 offer 的 (sl_id, path) 清單。
+
+    ledger 是 offered 的**單一真值**、跨 session 共用（同一 offered.jsonl）；依 session_id＋tool
+    過濾出本 session 的事件。per-session map 為此清單的衍生 cache——硬中止或 cache 寫入失敗
+    落在「ledger 有、map 無」時，這裡是重建 map／判定 offered 的權威來源。讀不到（不存在／IO／
+    單行壞）一律略過該來源（fail-open），不讓恢復路徑因殘缺 ledger 崩掉。
+    """
+    pairs, _ = _scan_offered_ledger(root, tool, session_id)
     return pairs
 
 
@@ -191,7 +213,7 @@ def _commit_offered_map(mpath: Path, offered: list[tuple[str, str]]) -> None:
         raise
 
 
-def _reconcile_offered_map(root: Path, tool: str, session_id: str, mpath: Path) -> None:
+def _reconcile_offered_map(root: Path, tool: str, session_id: str, mpath: Path) -> int:
     """以 offered ledger（單一真值）補齊 per-session map——ledger 有但 map 無的 slice 寫回 map。呼叫端持 flock。
 
     map 是 ledger 的衍生 cache。反轉發布順序（先 ledger 後 map）後，硬中止或 map cache 寫入
@@ -204,10 +226,14 @@ def _reconcile_offered_map(root: Path, tool: str, session_id: str, mpath: Path) 
     條件聯集 ledger sl_id，去重正確性不依賴這次快取健化是否成功。補寫失敗（磁碟滿／權限／IO——
     正是 _publish_offered 明文容忍的同一類故障）僅 log_warn、不 raise，避免無關的儲存層故障讓整輪
     claim/redact/publish fail-closed 而吞掉全新、從未 offer 過的命中 slice；下一輪仍會以 ledger 重試。
+
+    回傳本 (tool, session_id) 的歷史 offer 事件筆數——與上面 reconcile 用的 pairs 出自同一次
+    `_scan_offered_ledger` 掃描，供呼叫端做 OFFER_STOP_AFTER_EVENTS 早停判斷，不需為此再多掃
+    一遍 offered.jsonl（見該常數與 build_shortlist_and_record 的早停分支）。
     """
-    pairs = _offered_pairs_from_ledger(root, tool, session_id)
+    pairs, event_count = _scan_offered_ledger(root, tool, session_id)
     if not pairs:
-        return
+        return event_count
     by_id: dict = {}
     try:
         payload = json.loads(mpath.read_text(encoding="utf-8"))
@@ -226,6 +252,7 @@ def _reconcile_offered_map(root: Path, tool: str, session_id: str, mpath: Path) 
             log_warn(root, tool,
                      f"offered map reconcile write failed; ledger remains authoritative "
                      f"and map will be retried from ledger next round: {exc}")
+    return event_count
 
 
 def _publish_offered(root: Path, tool: str, session_id: str, project: str,
@@ -273,6 +300,39 @@ def _record_offered(root: Path, tool: str, session_id: str, project: str,
         log_warn(root, tool, f"failed to record offered: {exc}")
 
 
+def _session_has_engaged(root: Path, tool: str, session_id: str) -> bool:
+    """本 (tool, session_id) 在 memory_usage.jsonl 中是否曾有讀取／applied 事件。
+
+    判定依據（不分 offered true/false 的直讀也算——直讀一樣證明使用者主動在看記憶檔）：
+      - ``source == "read"``（claude/copilot post-tool-use hook 對 Read 記下的事件）
+      - ``kind == "applied"``（`hippo usage mark-applied` 寫入的顯式採用訊號）
+
+    供 OFFER_STOP_AFTER_EVENTS 早停判斷使用：只要 session 證明過在消費記憶，就永不早停
+    （繼續供給）。memory_usage.jsonl 目前檔案小（~220KB 量級），直接逐行讀取，不建索引；
+    這是本次早停功能唯一新增的檔案掃描成本（offered.jsonl 的計數搭在既有掃描路徑上）。
+    讀不到（不存在／IO／單行壞）一律視為未曾讀取／未曾 applied（fail-open）——與
+    `_offered_pairs_from_ledger` 同款式：新 session 本就不存在此檔，這是常態而非例外。
+    """
+    path = root / "runtime" / "ledger" / "memory_usage.jsonl"
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        if ev.get("session_id") != session_id or ev.get("tool") != tool:
+            continue
+        if ev.get("source") == "read" or ev.get("kind") == "applied":
+            return True
+    return False
+
+
 def _applied_hint(root: Path, tool: str, session_id: str) -> str:
     """applied 顯式訊號回報指引（契約 8）：附完整可貼命令（session 歸因已填）。"""
     argv = hippo_invocation(root) + [
@@ -318,7 +378,17 @@ def build_shortlist_and_record(root: Path, tool: str, session_id: str,
             # map 為 offered ledger 的衍生 cache：claim 去重前先以 ledger（單一真值）reconcile，
             # 補齊硬中止／前次 cache 寫入失敗殘留的「ledger 有、map 無」，使去重判定與 post-tool
             # 讀取端皆回到 ledger 可重建的真值（seen 亦已聯集 ledger，reconcile 另把真值落回 map）。
-            _reconcile_offered_map(root, tool, session_id, mpath)
+            # 回傳值為本 (tool, session_id) 的歷史 offer 事件筆數——與 reconcile 用的 pairs
+            # 出自同一次 ledger 掃描，供下面的 OFFER_STOP_AFTER_EVENTS 早停判斷使用。
+            offer_event_count = _reconcile_offered_map(root, tool, session_id, mpath)
+            if (offer_event_count >= OFFER_STOP_AFTER_EVENTS
+                    and not _session_has_engaged(root, tool, session_id)):
+                # 早停（實測依據見 OFFER_STOP_AFTER_EVENTS 常數）：session 已 offer 超過門檻次數
+                # 且全程沒有任何讀取／applied 訊號——持續 offer 是純 context 污染。不建 shortlist、
+                # 不記新 offered ledger 事件；早停狀態不落任何新檔，每次重算（無 schema migration、
+                # 無 reconcile 負擔）。session 只要曾有讀取／applied，_session_has_engaged 恆真，
+                # 永不早停（繼續供給）。
+                return ""
             seen = _load_offered_ids(root, tool, session_id)
             claim = [h for h in hits
                      if h.get("slice_id") and h["slice_id"] not in seen][:SHORTLIST_K]

--- a/paulsha_hippo/hooks/_shortlist_common.py
+++ b/paulsha_hippo/hooks/_shortlist_common.py
@@ -308,29 +308,38 @@ def _session_has_engaged(root: Path, tool: str, session_id: str) -> bool:
       - ``kind == "applied"``（`hippo usage mark-applied` 寫入的顯式採用訊號）
 
     供 OFFER_STOP_AFTER_EVENTS 早停判斷使用：只要 session 證明過在消費記憶，就永不早停
-    （繼續供給）。memory_usage.jsonl 目前檔案小（~220KB 量級），直接逐行讀取，不建索引；
-    這是本次早停功能唯一新增的檔案掃描成本（offered.jsonl 的計數搭在既有掃描路徑上）。
+    （繼續供給）。這是本次早停功能唯一新增的檔案掃描成本，且早停中的 session 每個 prompt
+    都要掃一次——串流逐行讀取（`open()` 逐行 iterate，不 `read_text()` 整檔載入）、命中
+    即提前 return，memory_usage.jsonl 會隨時間持續成長，不應假設整檔能常駐記憶體一次讀完。
     讀不到（不存在／IO／單行壞）一律視為未曾讀取／未曾 applied（fail-open）——與
     `_offered_pairs_from_ledger` 同款式：新 session 本就不存在此檔，這是常態而非例外。
     """
     path = root / "runtime" / "ledger" / "memory_usage.jsonl"
     try:
-        raw = path.read_text(encoding="utf-8")
+        handle = path.open("rb")
     except OSError:
         return False
-    for line in raw.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            ev = json.loads(line)
-        except Exception:
-            continue
-        if ev.get("session_id") != session_id or ev.get("tool") != tool:
-            continue
-        if ev.get("source") == "read" or ev.get("kind") == "applied":
-            return True
-    return False
+    try:
+        for raw_line in handle:
+            try:
+                line = raw_line.decode("utf-8").strip()
+            except UnicodeDecodeError:
+                continue
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except Exception:
+                continue
+            if ev.get("session_id") != session_id or ev.get("tool") != tool:
+                continue
+            if ev.get("source") == "read" or ev.get("kind") == "applied":
+                return True
+        return False
+    except OSError:
+        return False
+    finally:
+        handle.close()
 
 
 def _applied_hint(root: Path, tool: str, session_id: str) -> str:
@@ -347,8 +356,15 @@ def _applied_hint(root: Path, tool: str, session_id: str) -> str:
 
 
 def build_shortlist_and_record(root: Path, tool: str, session_id: str,
-                               cwd: str | None, prompt: str) -> str:
-    """Resolve project, search by prompt, build shortlist, record offered. Returns '' if nothing."""
+                               cwd: str | None, prompt: str,
+                               *, bypass_early_stop: bool = False) -> str:
+    """Resolve project, search by prompt, build shortlist, record offered. Returns '' if nothing.
+
+    bypass_early_stop：跳過 OFFER_STOP_AFTER_EVENTS 早停判斷（其餘去重／redaction／
+    publish 邏輯不變）。預設 False，供 UserPromptSubmit 自動 hook 使用（維持早停）；
+    `hippo recall` CLI（顯式召回，使用者主動操作）改傳 True——早停是為了抑制「自動、
+    session 沒在讀」的持續 offer 噪音，不應靜默擋掉使用者主動要求的一次召回。
+    """
     try:
         # tool 進入 offered-map 檔名；recall 的 --tool 為外部輸入——非法即整條
         # pipeline fail-closed（不注入、不記 offered），不讓歸因破損的 shortlist 流出。
@@ -381,13 +397,14 @@ def build_shortlist_and_record(root: Path, tool: str, session_id: str,
             # 回傳值為本 (tool, session_id) 的歷史 offer 事件筆數——與 reconcile 用的 pairs
             # 出自同一次 ledger 掃描，供下面的 OFFER_STOP_AFTER_EVENTS 早停判斷使用。
             offer_event_count = _reconcile_offered_map(root, tool, session_id, mpath)
-            if (offer_event_count >= OFFER_STOP_AFTER_EVENTS
+            if (not bypass_early_stop
+                    and offer_event_count >= OFFER_STOP_AFTER_EVENTS
                     and not _session_has_engaged(root, tool, session_id)):
                 # 早停（實測依據見 OFFER_STOP_AFTER_EVENTS 常數）：session 已 offer 超過門檻次數
                 # 且全程沒有任何讀取／applied 訊號——持續 offer 是純 context 污染。不建 shortlist、
                 # 不記新 offered ledger 事件；早停狀態不落任何新檔，每次重算（無 schema migration、
                 # 無 reconcile 負擔）。session 只要曾有讀取／applied，_session_has_engaged 恆真，
-                # 永不早停（繼續供給）。
+                # 永不早停（繼續供給）。bypass_early_stop=True（顯式 recall）永遠跳過此判斷。
                 return ""
             seen = _load_offered_ids(root, tool, session_id)
             claim = [h for h in hits

--- a/tests/test_recall_cli.py
+++ b/tests/test_recall_cli.py
@@ -50,6 +50,27 @@ def test_recall_missing_required_flags_exit2(capsys):
     assert cli.main(["recall"]) == 2
 
 
+def test_recall_bypasses_offer_early_stop(tmp_path, monkeypatch, capsys):
+    # BLOCKING（review）：hippo recall 是使用者主動操作，不應被 UserPromptSubmit 自動
+    # hook 專用的 OFFER_STOP_AFTER_EVENTS 早停靜默擋掉。即使 session 已 offer 超過門檻
+    # 次數且全程無讀取，`hippo recall` 仍必須照常回傳 shortlist。
+    monkeypatch.setattr(SC, "resolve_project", lambda cwd, memory_root: "proj")
+    _seed(tmp_path)
+    for i in range(SC.OFFER_STOP_AFTER_EVENTS):
+        SC._append_offered_ledger(
+            tmp_path, "codex", "sidCliBypass", "proj",
+            [(f"sl-hist{i:012d}", str(tmp_path / "knowledge" / "proj" / f"hist{i}.md"))])
+
+    rc = cli.main(["recall", "--memory-root", str(tmp_path), "--cwd", "/x",
+                   "--tool", "codex", "--session-id", "sidCliBypass",
+                   "--prompt", "SerialWrap 執行"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    note = str(tmp_path / "knowledge" / "proj" / "a.md")
+    assert note in out
+
+
 def test_recall_traversal_tool_rejected_exit2(tmp_path, capsys):
     # 迴歸（#17 review [high]）：--tool 夾帶路徑分隔符時，過去會把 offered map
     # 原子 replace 到 memory root 之外——argparse 層直接拒絕（exit 2），零落檔。

--- a/tests/test_shortlist_common.py
+++ b/tests/test_shortlist_common.py
@@ -374,6 +374,105 @@ def test_build_shortlist_concurrent_same_session_claims_slice_once(tmp_path, mon
     assert "sl-aaaaaaaaaaaaaaaa" in SC._load_offered_ids(tmp_path, "claude-code", "sidRACE")
 
 
+def _seed_offer_events(mr: Path, tool: str, session_id: str, n: int) -> None:
+    """直接向 offered ledger 寫入 n 筆歷史 offer 事件（略過完整 pipeline，加速測試）。
+
+    事件間彼此互斥的假 slice_id/path——不與 `_seed()` 的真實命中 sl-aaaaaaaaaaaaaaaa
+    重疊，故測試中對「SerialWrap 執行」的真實搜尋命中不會被這些歷史雜訊去重擋掉。
+    """
+    for i in range(n):
+        SC._append_offered_ledger(
+            mr, tool, session_id, "proj",
+            [(f"sl-hist{i:012d}", str(mr / "knowledge" / "proj" / f"hist{i}.md"))])
+
+
+def _append_memory_usage_event(mr: Path, ev: dict) -> None:
+    led = mr / "runtime" / "ledger"
+    led.mkdir(parents=True, exist_ok=True)
+    with (led / "memory_usage.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(ev, ensure_ascii=False) + "\n")
+
+
+def test_offer_early_stop_after_threshold_events_with_no_reads(tmp_path, monkeypatch):
+    # 實測依據（見 OFFER_STOP_AFTER_EVENTS 常數註解）：讀取全部發生在第 7 個 offer 事件
+    # 之前，第 8 個事件之後零讀取。歷史事件數達門檻且本 session 全程無讀取/applied
+    # 訊號時，第 9 次呼叫必須早停：不注入 shortlist、不記新 offered ledger 行。
+    monkeypatch.setattr(SC, "resolve_project", lambda cwd, memory_root: "proj")
+    _seed(tmp_path)
+    _seed_offer_events(tmp_path, "claude-code", "sidStop", SC.OFFER_STOP_AFTER_EVENTS)
+
+    out = SC.build_shortlist_and_record(
+        tmp_path, "claude-code", "sidStop", cwd="/x", prompt="SerialWrap 執行")
+
+    assert out == ""
+    assert len(_offered_events(tmp_path)) == SC.OFFER_STOP_AFTER_EVENTS
+
+
+def test_offer_continues_below_threshold_events(tmp_path, monkeypatch):
+    # 事件數未達門檻（差一次）——早停不生效，照常 offer（第 8 筆寫入 ledger）。
+    monkeypatch.setattr(SC, "resolve_project", lambda cwd, memory_root: "proj")
+    _seed(tmp_path)
+    _seed_offer_events(tmp_path, "claude-code", "sidBelow", SC.OFFER_STOP_AFTER_EVENTS - 1)
+
+    out = SC.build_shortlist_and_record(
+        tmp_path, "claude-code", "sidBelow", cwd="/x", prompt="SerialWrap 執行")
+
+    assert out != ""
+    assert len(_offered_events(tmp_path)) == SC.OFFER_STOP_AFTER_EVENTS
+
+
+def test_offer_does_not_stop_when_session_has_direct_read(tmp_path, monkeypatch):
+    # 事件數達門檻，但 session 曾有一筆直讀（offered=False 亦算——直讀證明使用者
+    # 主動在看記憶檔）：永不早停，照常 offer。
+    monkeypatch.setattr(SC, "resolve_project", lambda cwd, memory_root: "proj")
+    _seed(tmp_path)
+    _seed_offer_events(tmp_path, "claude-code", "sidRead", SC.OFFER_STOP_AFTER_EVENTS)
+    _append_memory_usage_event(tmp_path, {
+        "ts": "2026-07-01T00:00:00Z", "session_id": "sidRead", "tool": "claude-code",
+        "project": "proj", "sl_id": "", "path": str(tmp_path / "knowledge" / "proj" / "z.md"),
+        "source": "read", "offered": False,
+    })
+
+    out = SC.build_shortlist_and_record(
+        tmp_path, "claude-code", "sidRead", cwd="/x", prompt="SerialWrap 執行")
+
+    assert out != ""
+    assert len(_offered_events(tmp_path)) == SC.OFFER_STOP_AFTER_EVENTS + 1
+
+
+def test_offer_does_not_stop_when_session_has_applied(tmp_path, monkeypatch):
+    # 事件數達門檻，但 session 曾有一筆 applied（顯式採用訊號）：永不早停，照常 offer。
+    monkeypatch.setattr(SC, "resolve_project", lambda cwd, memory_root: "proj")
+    _seed(tmp_path)
+    _seed_offer_events(tmp_path, "claude-code", "sidApplied", SC.OFFER_STOP_AFTER_EVENTS)
+    _append_memory_usage_event(tmp_path, {
+        "kind": "applied", "session_id": "sidApplied", "slice_id": "sl-x",
+        "tool": "claude-code", "ts": "2026-07-01T00:00:00Z",
+    })
+
+    out = SC.build_shortlist_and_record(
+        tmp_path, "claude-code", "sidApplied", cwd="/x", prompt="SerialWrap 執行")
+
+    assert out != ""
+    assert len(_offered_events(tmp_path)) == SC.OFFER_STOP_AFTER_EVENTS + 1
+
+
+def test_offer_early_stop_scoped_to_session(tmp_path, monkeypatch):
+    # 早停判斷以 (tool, session_id) 為界——另一個 session 的歷史事件數與讀取狀態
+    # 不得互相污染。sidOther 事件數達門檻且無讀取；sidFresh 全新 session 照常 offer。
+    monkeypatch.setattr(SC, "resolve_project", lambda cwd, memory_root: "proj")
+    _seed(tmp_path)
+    _seed_offer_events(tmp_path, "claude-code", "sidOther", SC.OFFER_STOP_AFTER_EVENTS)
+
+    out = SC.build_shortlist_and_record(
+        tmp_path, "claude-code", "sidFresh", cwd="/x", prompt="SerialWrap 執行")
+
+    assert out != ""
+    events = _offered_events(tmp_path)
+    assert len(events) == SC.OFFER_STOP_AFTER_EVENTS + 1
+    assert events[-1]["session_id"] == "sidFresh"
+
+
 def _boom_oserror(*a, **k):
     raise OSError("disk full")
 

--- a/tests/test_shortlist_common.py
+++ b/tests/test_shortlist_common.py
@@ -473,6 +473,98 @@ def test_offer_early_stop_scoped_to_session(tmp_path, monkeypatch):
     assert events[-1]["session_id"] == "sidFresh"
 
 
+def test_offer_early_stop_isolated_by_tool(tmp_path, monkeypatch):
+    # 早停判斷以 (tool, session_id) 為界——同一 session_id 但不同 tool 的歷史事件數
+    # 與讀取狀態不得互相污染（例如同一 CLI session_id 同時被 claude-code 與 codex 使用）。
+    monkeypatch.setattr(SC, "resolve_project", lambda cwd, memory_root: "proj")
+    _seed(tmp_path)
+    _seed_offer_events(tmp_path, "claude-code", "sidShared", SC.OFFER_STOP_AFTER_EVENTS)
+
+    out = SC.build_shortlist_and_record(
+        tmp_path, "codex", "sidShared", cwd="/x", prompt="SerialWrap 執行")
+
+    assert out != ""
+    events = _offered_events(tmp_path)
+    assert len(events) == SC.OFFER_STOP_AFTER_EVENTS + 1
+    assert events[-1]["tool"] == "codex"
+    assert events[-1]["session_id"] == "sidShared"
+
+
+def test_offer_resumes_after_read_event_following_early_stop(tmp_path, monkeypatch):
+    # 早停不是永久狀態——它每次重算，不落任何新檔。session 早停期間出現一筆讀取後，
+    # 下一次 prompt 必須立即解封、恢復 offer。
+    monkeypatch.setattr(SC, "resolve_project", lambda cwd, memory_root: "proj")
+    _seed(tmp_path)
+    _seed_offer_events(tmp_path, "claude-code", "sidResume", SC.OFFER_STOP_AFTER_EVENTS)
+
+    out1 = SC.build_shortlist_and_record(
+        tmp_path, "claude-code", "sidResume", cwd="/x", prompt="SerialWrap 執行")
+    assert out1 == ""  # 早停中（前提檢查）
+    assert len(_offered_events(tmp_path)) == SC.OFFER_STOP_AFTER_EVENTS
+
+    _append_memory_usage_event(tmp_path, {
+        "ts": "2026-07-01T00:00:00Z", "session_id": "sidResume", "tool": "claude-code",
+        "project": "proj", "sl_id": "", "path": str(tmp_path / "knowledge" / "proj" / "z.md"),
+        "source": "read", "offered": False,
+    })
+
+    out2 = SC.build_shortlist_and_record(
+        tmp_path, "claude-code", "sidResume", cwd="/x", prompt="SerialWrap 執行")
+    assert out2 != ""  # 解封
+    assert len(_offered_events(tmp_path)) == SC.OFFER_STOP_AFTER_EVENTS + 1
+
+
+def test_offer_event_count_counts_ledger_lines_not_pairs(tmp_path):
+    # 單一 ledger 行（一次 offer 事件）內含多個 (sl_id, path) pairs 時，
+    # OFFER_STOP_AFTER_EVENTS 早停判斷的事件筆數必須算 1（同一行＝同一次事件），
+    # 不能誤算成 pairs 數量（3）——否則早停會遠早於實際門檻觸發。
+    mpath = tmp_path / "runtime" / "wakeup" / "claude-code__sidMulti.offered.json"
+    SC._append_offered_ledger(
+        tmp_path, "claude-code", "sidMulti", "proj",
+        [(f"sl-multi{i:03d}", str(tmp_path / "knowledge" / "proj" / f"multi{i}.md"))
+         for i in range(3)])
+
+    count = SC._reconcile_offered_map(tmp_path, "claude-code", "sidMulti", mpath)
+
+    assert count == 1
+
+
+def test_session_has_engaged_skips_corrupt_line_then_detects_valid_one(tmp_path):
+    # memory_usage.jsonl 逐行掃描須對壞行 fail-soft（略過），且不能因為壞行中止
+    # 掃描——後續合法的 read/applied 行仍要被辨識到。
+    led = tmp_path / "runtime" / "ledger"
+    led.mkdir(parents=True)
+    lines = [
+        "{not valid json",
+        json.dumps({"session_id": "sidCorrupt", "tool": "claude-code", "source": "read"}),
+    ]
+    (led / "memory_usage.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    assert SC._session_has_engaged(tmp_path, "claude-code", "sidCorrupt") is True
+
+
+def test_offer_bypass_early_stop_for_explicit_recall(tmp_path, monkeypatch):
+    # BLOCKING（review）：hippo recall 為使用者主動操作，不應被 UserPromptSubmit 自動
+    # hook 專用的 OFFER_STOP_AFTER_EVENTS 早停靜默擋掉。bypass_early_stop=True 時，
+    # 即使 session 已達門檻且全程無讀取，仍照常回傳 shortlist 並記錄 offered；其餘
+    # 去重／redaction／publish 邏輯不變。
+    monkeypatch.setattr(SC, "resolve_project", lambda cwd, memory_root: "proj")
+    _seed(tmp_path)
+    _seed_offer_events(tmp_path, "claude-code", "sidBypass", SC.OFFER_STOP_AFTER_EVENTS)
+
+    # 前提檢查：不帶 bypass 時維持早停
+    out_default = SC.build_shortlist_and_record(
+        tmp_path, "claude-code", "sidBypass", cwd="/x", prompt="SerialWrap 執行")
+    assert out_default == ""
+    assert len(_offered_events(tmp_path)) == SC.OFFER_STOP_AFTER_EVENTS
+
+    out_bypass = SC.build_shortlist_and_record(
+        tmp_path, "claude-code", "sidBypass", cwd="/x", prompt="SerialWrap 執行",
+        bypass_early_stop=True)
+    assert out_bypass != ""
+    assert len(_offered_events(tmp_path)) == SC.OFFER_STOP_AFTER_EVENTS + 1
+
+
 def _boom_oserror(*a, **k):
     raise OSError("disk full")
 


### PR DESCRIPTION
## 摘要

**問題（實測）**：每個 user prompt 觸發一次 shortlist offer（3 個新 slice，session 內去重），長 session 累積 p90=39、max=127 個唯一 offered slice；但讀取行為集中在 session 開頭——9 次 offered→read 中 7 次發生在第 0-1 個 offer 事件、2 次在第 6 個，**第 7 個事件之後零讀取**。對一直沒在讀的 session 持續 offer 是純 context 污染，並直接壓低 slice 級命中率（近 7 天 2.25%）。

**變更**：
- 新常數 `OFFER_STOP_AFTER_EVENTS = 8`：session 累積 8 個 offer 事件且 memory_usage.jsonl 無任何 read（含 offered=false 直讀）／applied 事件 → `build_shortlist_and_record` 早停（不 offer、不記 ledger）。有任何讀取訊號的 session 永不早停。
- **顯式 `hippo recall` 不受限**：keyword-only `bypass_early_stop=True`（使用者主動操作意圖明確；早停是自動 UserPromptSubmit hook 專用的雜訊抑制）。
- 零額外 offered.jsonl 掃描：事件計數搭既有 `_reconcile_offered_map` 的同一次 ledger 掃描（`_scan_offered_ledger` 單一 pass）。memory_usage.jsonl 以串流逐行讀、命中即返回，且只在事件數達門檻後才掃。
- 早停狀態不落任何新檔案，每次重算——無 schema migration、無 reconcile 負擔。

**預期效果**：以近兩週實測分布，保留 100% 既有讀取行為（全部發生在第 7 事件前），長尾 session 的 offered 分母砍約六成，slice 級命中率預期倍增；並節省長 session 的 context 注入與 FTS 開銷。

reviewer：gemini-3.6-flash-high 兩輪——v1 抓到 1 BLOCKING（顯式 recall 被早停誤殺）與效能/測試建議，v2 逐項 RESOLVED，verdict APPROVE。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過（全套 1678 passed, 4 skipped；11 個新測試含早停邊界、解封、tool 隔離、壞行容錯、bypass 雙層驗證）
- [x] `python3 -m policy_check --repo .`（含 PR context）通過（零 failure）
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片（`shortlist-offer-decay.md`，type: feat，並鏡像 CHANGELOG.md）
- [x] `VERSION` 與 release 意圖一致（未動）
- [x] 文件與 CLI help 已同步（行為變更記於 changelog 與函式 docstring；無 CLI 介面變更）

## 風險與回復

- 生效需重裝 hooks（`hippo install hooks`）——merge 後與另兩個 in-flight 變更統一部署。
- 最壞情況：使用者在第 9+ 個 prompt 才想讀記憶但 shortlist 已停——顯式 `hippo recall` 隨時可召回（bypass），且任何一次 Read 知識檔即永久解封。
- 回復：revert + 重裝 hooks 即回原行為。無資料遷移、無 ledger schema 變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwqHv9Hy7DvnRQnmeMoEW8