### PR TITLE
feat(local-harness): map-reduce per-concept write 依 fragment indices 裁切輸入

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           grep -Eq '[1-9][0-9]* tests collected' "$RUNNER_TEMP/pytest-collection.log"
 
       - name: Run test suite
-        run: python -m pytest tests/ -q
+        run: python -m pytest tests/ contrib/local-harness/tests/ -q
 
       - name: Build and smoke clean wheel install
         run: |

--- a/changelog.d/74-harness-input-slicing.md
+++ b/changelog.d/74-harness-input-slicing.md
@@ -1,4 +1,4 @@
 ---
 type: fix
 ---
-- `contrib/local-harness/harness.py`：map-reduce 第二階段（per-concept write）依 concept `fragment_indices` 裁切 prompt 輸入（±1 鄰域 `slice_prompt_by_fragments`），大 session 時避免重複發送全量 payload 導致 max_tokens 截斷。
+- `contrib/local-harness/harness.py`：map-reduce 第二階段（per-concept write）依 concept `fragment_indices` 裁切 prompt 輸入（±1 鄰域 `slice_prompt_by_fragments`），大 session 時避免重複發送全量 payload 導致 max_tokens 截斷。fragment 標記正則逐字對齊 `build_prompt` 實際格式（行首、小寫、閉合括號、可選 `part X/Y` 後綴），body 內引用的假標記不再誤切；三種裁切不可信情況（無標記／空索引集合／全部越界）皆退回全量並記 stderr warning；每個 concept write 記錄 indices 與 sliced/full bytes 供稽核。

--- a/changelog.d/74-harness-input-slicing.md
+++ b/changelog.d/74-harness-input-slicing.md
@@ -1,0 +1,4 @@
+---
+type: fix
+---
+- `contrib/local-harness/harness.py`：map-reduce 第二階段（per-concept write）依 concept `fragment_indices` 裁切 prompt 輸入（±1 鄰域 `slice_prompt_by_fragments`），大 session 時避免重複發送全量 payload 導致 max_tokens 截斷。

--- a/contrib/local-harness/harness.py
+++ b/contrib/local-harness/harness.py
@@ -305,7 +305,18 @@ def request_json(base_url: str, api_key: str, payload: dict, validate, what: str
     return None  # unreachable
 
 
-FRAGMENT_HEADER_RE = re.compile(r"^\s*\[fragment\s+(\d+)", re.IGNORECASE)
+# Must match build_prompt's marker format verbatim: line-anchored, lowercase,
+# closing bracket, optional multi-part suffix — `[fragment N]` or
+# `[fragment N part X/Y]`. Anything looser (indentation, no closing bracket,
+# IGNORECASE) mistakes quoted markers inside fragment bodies for real block
+# boundaries and silently corrupts the slice.
+FRAGMENT_HEADER_RE = re.compile(r"^\[fragment (\d+)(?: part \d+/\d+)?\]\s*$")
+
+
+def _slice_warn(detail: str) -> None:
+    sys.stderr.write(
+        f"hippo-local-harness: warning: input slicing {detail}, falling back to full prompt\n"
+    )
 
 
 def slice_prompt_by_fragments(
@@ -326,6 +337,7 @@ def slice_prompt_by_fragments(
         target_set = set()
 
     if not target_set:
+        _slice_warn(f"got no usable fragment indices from {indices!r}")
         return prompt
 
     expanded_indices = set()
@@ -343,31 +355,33 @@ def slice_prompt_by_fragments(
     current_frag_lines: list[str] = []
 
     for line in lines:
+        if state == "tail":
+            # Once in the tail every line is kept verbatim — even one that
+            # looks like a fragment marker must never be silently dropped.
+            tail_lines.append(line)
+            continue
         match = FRAGMENT_HEADER_RE.match(line)
         if match:
-            if state == "preamble":
-                state = "fragments"
-            elif state == "fragments":
-                if current_frag_idx is not None:
-                    fragments.append((current_frag_idx, current_frag_lines))
+            if state == "fragments" and current_frag_idx is not None:
+                fragments.append((current_frag_idx, current_frag_lines))
+            state = "fragments"
             current_frag_idx = int(match.group(1))
             current_frag_lines = [line]
-        elif state == "fragments" and line.rstrip().startswith("## Output"):
+        elif state == "fragments" and line.rstrip() == "## Output":
             if current_frag_idx is not None:
                 fragments.append((current_frag_idx, current_frag_lines))
             state = "tail"
             tail_lines = [line]
         elif state == "preamble":
             preamble_lines.append(line)
-        elif state == "fragments":
+        else:  # state == "fragments"
             current_frag_lines.append(line)
-        elif state == "tail":
-            tail_lines.append(line)
 
     if state == "fragments" and current_frag_idx is not None:
         fragments.append((current_frag_idx, current_frag_lines))
 
     if not fragments:
+        _slice_warn("found no fragment markers")
         return prompt
 
     selected_lines: list[str] = []
@@ -378,9 +392,7 @@ def slice_prompt_by_fragments(
             selected_lines.extend(frag_lines)
 
     if not has_match:
-        sys.stderr.write(
-            f"hippo-local-harness: warning: input slicing match failed for indices {indices!r}, falling back to full prompt\n"
-        )
+        _slice_warn(f"match failed for indices {indices!r}")
         return prompt
 
     return "".join(preamble_lines) + "".join(selected_lines) + "".join(tail_lines)
@@ -494,12 +506,19 @@ def main() -> None:
     all_titles = [c["title"] for c in concepts]
     findings: list[dict] = []
     seen: set[str] = set()
+    full_bytes = len(prompt.encode("utf-8"))
     for concept in concepts:
         siblings = [t for t in all_titles if t != concept["title"]] or ["(none)"]
         write_payload = dict(base_payload)
         write_payload.update(thinking_off)
-        sliced_prompt = slice_prompt_by_fragments(
-            prompt, concept.get("fragment_indices", []), neighbor=1
+        concept_indices = concept.get("fragment_indices", [])
+        sliced_prompt = slice_prompt_by_fragments(prompt, concept_indices, neighbor=1)
+        # Audit trail (issue #74): make pass-1 index attribution and the actual
+        # bytes reduction observable per concept write.
+        sys.stderr.write(
+            f"hippo-local-harness: write[{concept['title'][:30]}]: "
+            f"indices={concept_indices} "
+            f"input {len(sliced_prompt.encode('utf-8'))}/{full_bytes} bytes\n"
         )
         write_payload["messages"] = [
             {

--- a/contrib/local-harness/harness.py
+++ b/contrib/local-harness/harness.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -304,6 +305,87 @@ def request_json(base_url: str, api_key: str, payload: dict, validate, what: str
     return None  # unreachable
 
 
+FRAGMENT_HEADER_RE = re.compile(r"^\s*\[fragment\s+(\d+)", re.IGNORECASE)
+
+
+def slice_prompt_by_fragments(
+    prompt: str,
+    indices: set[int] | list[int] | int,
+    neighbor: int = 1,
+) -> str:
+    """Slice prompt to keep preamble, selected fragment blocks (±neighbor), and tail (## Output).
+
+    If indices is empty, out of range, or prompt contains no fragment markers,
+    fails safe by returning the original prompt.
+    """
+    if isinstance(indices, int):
+        target_set = {indices}
+    elif isinstance(indices, (set, list, tuple)):
+        target_set = {idx for idx in indices if isinstance(idx, int)}
+    else:
+        target_set = set()
+
+    if not target_set:
+        return prompt
+
+    expanded_indices = set()
+    for idx in target_set:
+        for offset in range(-neighbor, neighbor + 1):
+            expanded_indices.add(idx + offset)
+
+    lines = prompt.splitlines(keepends=True)
+    preamble_lines: list[str] = []
+    fragments: list[tuple[int, list[str]]] = []
+    tail_lines: list[str] = []
+
+    state = "preamble"
+    current_frag_idx: int | None = None
+    current_frag_lines: list[str] = []
+
+    for line in lines:
+        match = FRAGMENT_HEADER_RE.match(line)
+        if match:
+            if state == "preamble":
+                state = "fragments"
+            elif state == "fragments":
+                if current_frag_idx is not None:
+                    fragments.append((current_frag_idx, current_frag_lines))
+            current_frag_idx = int(match.group(1))
+            current_frag_lines = [line]
+        elif state == "fragments" and line.rstrip().startswith("## Output"):
+            if current_frag_idx is not None:
+                fragments.append((current_frag_idx, current_frag_lines))
+            state = "tail"
+            tail_lines = [line]
+        elif state == "preamble":
+            preamble_lines.append(line)
+        elif state == "fragments":
+            current_frag_lines.append(line)
+        elif state == "tail":
+            tail_lines.append(line)
+
+    if state == "fragments" and current_frag_idx is not None:
+        fragments.append((current_frag_idx, current_frag_lines))
+
+    if not fragments:
+        return prompt
+
+    selected_lines: list[str] = []
+    has_match = False
+    for frag_idx, frag_lines in fragments:
+        if frag_idx in expanded_indices:
+            has_match = True
+            selected_lines.extend(frag_lines)
+
+    if not has_match:
+        sys.stderr.write(
+            f"hippo-local-harness: warning: input slicing match failed for indices {indices!r}, falling back to full prompt\n"
+        )
+        return prompt
+
+    return "".join(preamble_lines) + "".join(selected_lines) + "".join(tail_lines)
+
+
 def finding_errors(item: object) -> list[str]:
     """Validate one finding object (pass-2 output) against hippo hard rules."""
     wrapper = {
@@ -416,6 +498,9 @@ def main() -> None:
         siblings = [t for t in all_titles if t != concept["title"]] or ["(none)"]
         write_payload = dict(base_payload)
         write_payload.update(thinking_off)
+        sliced_prompt = slice_prompt_by_fragments(
+            prompt, concept.get("fragment_indices", []), neighbor=1
+        )
         write_payload["messages"] = [
             {
                 "role": "user",
@@ -426,7 +511,7 @@ def main() -> None:
                     siblings=", ".join(siblings),
                 )
                 + "\n\n"
-                + prompt,
+                + sliced_prompt,
             }
         ]
         item = request_json(

--- a/contrib/local-harness/tests/test_harness_slicing.py
+++ b/contrib/local-harness/tests/test_harness_slicing.py
@@ -62,21 +62,176 @@ def test_slice_prompt_by_fragments_neighbor_zero():
     assert "[fragment 3]" not in sliced
 
 
-def test_slice_prompt_by_fragments_empty_indices_failsafe():
+def test_slice_prompt_by_fragments_empty_indices_failsafe(capsys):
     prompt = _make_sample_prompt(5)
-    # Empty indices should fail-safe return original prompt
+    # Empty indices should fail-safe return original prompt AND warn on stderr
     sliced = harness.slice_prompt_by_fragments(prompt, indices=set(), neighbor=1)
     assert sliced == prompt
+    err = capsys.readouterr().err
+    assert "warning: input slicing" in err
+    assert "falling back to full prompt" in err
 
 
-def test_slice_prompt_by_fragments_out_of_bounds_failsafe():
+def test_slice_prompt_by_fragments_out_of_bounds_failsafe(capsys):
     prompt = _make_sample_prompt(5)
     # Indices completely out of bounds should fail-safe return original prompt
     sliced = harness.slice_prompt_by_fragments(prompt, indices={99, 100}, neighbor=1)
     assert sliced == prompt
+    err = capsys.readouterr().err
+    assert "warning: input slicing" in err
+    assert "falling back to full prompt" in err
 
 
-def test_slice_prompt_by_fragments_no_fragments_failsafe():
+def test_slice_prompt_by_fragments_no_fragments_failsafe(capsys):
     prompt = "# Task: simple prompt with no fragment markers\n## Output\nReturn JSON."
     sliced = harness.slice_prompt_by_fragments(prompt, indices={0}, neighbor=1)
     assert sliced == prompt
+    err = capsys.readouterr().err
+    assert "warning: input slicing" in err
+    assert "falling back to full prompt" in err
+
+
+def test_slice_prompt_single_fragment_hit():
+    prompt = _make_sample_prompt(1)
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={0}, neighbor=1)
+
+    assert "# Task: atomize session" in sliced
+    assert "[fragment 0]" in sliced
+    assert "Content of fragment 0." in sliced
+    assert "## Output" in sliced
+    assert "Return ONLY a canonical JSON object." in sliced
+
+
+def test_slice_prompt_single_fragment_miss_failsafe(capsys):
+    prompt = _make_sample_prompt(1)
+    # neighbor=0 so index 5 cannot reach fragment 0 -> fail-safe full prompt
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={5}, neighbor=0)
+    assert sliced == prompt
+    err = capsys.readouterr().err
+    assert "warning: input slicing" in err
+    assert "falling back to full prompt" in err
+
+
+def _make_multipart_prompt() -> str:
+    parts = [
+        "# Task: atomize session",
+        "",
+        "## Session fragments to atomize",
+        "[fragment 0]",
+        "Body of fragment 0. " * 10,
+        "",
+        "[fragment 1 part 1/2]",
+        "First half of fragment 1. " * 10,
+        "",
+        "[fragment 1 part 2/2]",
+        "Second half of fragment 1. " * 10,
+        "",
+        "[fragment 5]",
+        "Body of fragment 5. " * 10,
+        "",
+        "## Output",
+        "Return ONLY a canonical JSON object.",
+    ]
+    return "\n".join(parts)
+
+
+def test_slice_prompt_multipart_selected_keeps_all_parts():
+    prompt = _make_multipart_prompt()
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={1}, neighbor=0)
+
+    # Both parts of fragment 1 share one index and must be kept together
+    assert "[fragment 1 part 1/2]" in sliced
+    assert "First half of fragment 1." in sliced
+    assert "[fragment 1 part 2/2]" in sliced
+    assert "Second half of fragment 1." in sliced
+    # Non-selected fragments must be dropped (neighbor=0, 5 is out of window)
+    assert "[fragment 5]" not in sliced
+    assert "Body of fragment 5." not in sliced
+
+
+def test_slice_prompt_multipart_unselected_drops_all_parts():
+    prompt = _make_multipart_prompt()
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={5}, neighbor=0)
+
+    assert "[fragment 5]" in sliced
+    assert "Body of fragment 5." in sliced
+    # Both parts of unselected fragment 1 must be dropped together
+    assert "[fragment 1 part 1/2]" not in sliced
+    assert "First half of fragment 1." not in sliced
+    assert "[fragment 1 part 2/2]" not in sliced
+    assert "Second half of fragment 1." not in sliced
+
+
+def _make_prompt_with_fake_markers() -> str:
+    """Fragment bodies quoting marker-lookalike lines (indented / uppercase /
+    unclosed) and a `## Output`-prefixed body line: none of these may act as a
+    block boundary, and no input line may be silently dropped."""
+    parts = [
+        "# Task: atomize session",
+        "",
+        "## Session fragments to atomize",
+        "[fragment 0]",
+        "Discussing the prompt format:",
+        "    [fragment 7] quoted example inside a session transcript",
+        "and also [Fragment 3] uppercase mention mid-line.",
+        "[fragment 9 without closing bracket",
+        "## Output formats considered: JSON, YAML",
+        "still body of fragment 0.",
+        "",
+        "[fragment 1]",
+        "Body of fragment 1. " * 10,
+        "",
+        "## Output",
+        "Return ONLY a canonical JSON object.",
+    ]
+    return "\n".join(parts)
+
+
+def test_fake_markers_in_body_do_not_split_fragments():
+    prompt = _make_prompt_with_fake_markers()
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={0}, neighbor=0)
+
+    # The whole body of fragment 0 stays attributed to fragment 0
+    assert "[fragment 0]" in sliced
+    assert "    [fragment 7] quoted example inside a session transcript" in sliced
+    assert "[Fragment 3] uppercase mention mid-line." in sliced
+    assert "[fragment 9 without closing bracket" in sliced
+    assert "## Output formats considered: JSON, YAML" in sliced
+    assert "still body of fragment 0." in sliced
+    # Real fragment 1 is a separate block and is dropped (neighbor=0)
+    assert "Body of fragment 1." not in sliced
+    # Real tail retained
+    assert "Return ONLY a canonical JSON object." in sliced
+
+
+def test_fake_markers_in_body_not_selectable_as_fragment():
+    prompt = _make_prompt_with_fake_markers()
+    # Index 7 exists only as a quoted lookalike inside fragment 0's body; it
+    # must NOT be treated as a real block -> fail-safe full prompt.
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={7}, neighbor=0)
+    assert sliced == prompt
+
+
+def test_marker_line_after_output_tail_is_preserved():
+    # A marker-shaped line inside the tail must never be silently dropped.
+    parts = [
+        "# Task: atomize session",
+        "",
+        "[fragment 0]",
+        "Body of fragment 0.",
+        "",
+        "[fragment 1]",
+        "Body of fragment 1.",
+        "",
+        "## Output",
+        "Return ONLY a canonical JSON object.",
+        "[fragment 0]",
+        "e.g. cite markers like the line above verbatim.",
+    ]
+    prompt = "\n".join(parts)
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={1}, neighbor=0)
+
+    assert "Body of fragment 1." in sliced
+    assert "Body of fragment 0." not in sliced
+    # Tail preserved verbatim, including the marker-shaped line
+    assert "Return ONLY a canonical JSON object.\n[fragment 0]\ne.g. cite markers like the line above verbatim." in sliced

--- a/contrib/local-harness/tests/test_harness_slicing.py
+++ b/contrib/local-harness/tests/test_harness_slicing.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+
+# Add contrib/local-harness directory to sys.path so harness can be imported
+HARNESS_DIR = Path(__file__).resolve().parent.parent
+if str(HARNESS_DIR) not in sys.path:
+    sys.path.insert(0, str(HARNESS_DIR))
+
+import harness
+
+
+def _make_sample_prompt(num_fragments: int = 8) -> str:
+    parts = [
+        "# Task: atomize session",
+        "",
+        "## Known projects",
+        "paulsha-hippo, _unknown",
+        "",
+        "## Session fragments to atomize",
+    ]
+    for i in range(num_fragments):
+        parts.append(f"[fragment {i}]")
+        parts.append(f"Content of fragment {i}. " * 20)
+        parts.append("")
+    parts.append("## Output")
+    parts.append("Return ONLY a canonical JSON object.")
+    return "\n".join(parts)
+
+
+def test_slice_prompt_by_fragments_basic():
+    prompt = _make_sample_prompt(8)
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={3}, neighbor=1)
+    
+    # Preamble and Output must be retained
+    assert "# Task: atomize session" in sliced
+    assert "## Session fragments to atomize" in sliced
+    assert "## Output" in sliced
+    assert "Return ONLY a canonical JSON object." in sliced
+
+    # Targeted fragments (3 +- 1 => 2, 3, 4) must be included
+    assert "[fragment 2]" in sliced
+    assert "[fragment 3]" in sliced
+    assert "[fragment 4]" in sliced
+
+    # Non-targeted fragments must be excluded
+    assert "[fragment 0]" not in sliced
+    assert "[fragment 1]" not in sliced
+    assert "[fragment 5]" not in sliced
+    assert "[fragment 6]" not in sliced
+    assert "[fragment 7]" not in sliced
+
+    # Sliced length must be significantly smaller than original
+    assert len(sliced) < len(prompt) * 0.6
+
+
+def test_slice_prompt_by_fragments_neighbor_zero():
+    prompt = _make_sample_prompt(5)
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={2}, neighbor=0)
+
+    assert "[fragment 2]" in sliced
+    assert "[fragment 1]" not in sliced
+    assert "[fragment 3]" not in sliced
+
+
+def test_slice_prompt_by_fragments_empty_indices_failsafe():
+    prompt = _make_sample_prompt(5)
+    # Empty indices should fail-safe return original prompt
+    sliced = harness.slice_prompt_by_fragments(prompt, indices=set(), neighbor=1)
+    assert sliced == prompt
+
+
+def test_slice_prompt_by_fragments_out_of_bounds_failsafe():
+    prompt = _make_sample_prompt(5)
+    # Indices completely out of bounds should fail-safe return original prompt
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={99, 100}, neighbor=1)
+    assert sliced == prompt
+
+
+def test_slice_prompt_by_fragments_no_fragments_failsafe():
+    prompt = "# Task: simple prompt with no fragment markers\n## Output\nReturn JSON."
+    sliced = harness.slice_prompt_by_fragments(prompt, indices={0}, neighbor=1)
+    assert sliced == prompt

--- a/docs/superpowers/plans/2026-08-04-issue-74-local-harness-input-slicing.md
+++ b/docs/superpowers/plans/2026-08-04-issue-74-local-harness-input-slicing.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+work_item: issue-74-local-harness-input-slicing
+---
+
+# local-harness map-reduce 輸入切分 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development——先寫失敗測試再實作。
+
+**Goal:** `contrib/local-harness` 的 map-reduce 第二階段（per-concept write）不再每次重送全量 payload——依 concept 的 `fragment_indices` 裁切輸入（±1 鄰域），大 session（實測 48 fragments/100KB）的單次呼叫 payload 縮到與 concept 相稱的大小。
+
+**Root cause 位置：** `contrib/local-harness/harness.py` pass 2 write（約 L408-436）只切輸出、不切輸入。
+
+**風險註記：** contrib-only，不進 wheel、不被 package 引用，改壞不影響 core／CI。但 fragment-marker 正則切分要準確（`[fragment N]` 標記），preamble 與 `## Output` 指示區塊必須保留。
+
+**Target branch:** `feature/74-harness-input-slicing`
+
+## Global Constraints
+
+- 語言 zh-tw；TDD 先 RED 再實作。
+- 交付治理：`changelog.d/<slug>.md`、pytest／policy_check／openspec strict 全綠、PR checklist 全勾。body 註 `Refs #74`＋說明：**端到端驗證（真實 local-vllm 對 48-fragment payload 實測不再 `truncated at max_tokens`）屬手動驗證項，merge 後由 operator 在有 local-vllm 端點的環境執行**，故不用 Closes（或如 maintainer 判定可關則改 Closes——由 review 階段決定）。
+- contrib 沒有既有測試檔：新建測試放 `contrib/local-harness/tests/`（若該路徑不被 root pytest 收集，於 PR body 說明執行方式）或依 repo 慣例放 `tests/`。
+- 全套測試在非巢狀 sibling worktree 跑。
+- commit 前 `rm -rf .psc_tmp`；不要 `git add -A`。
+
+## Task 1: 純函式輸入裁切
+
+**檔案**：`contrib/local-harness/harness.py`、新測試檔
+
+- [ ] 先寫測試：新純函式 `slice_prompt_by_fragments(prompt, indices, neighbor=1)`——合成含 8 個 `[fragment N]` 區塊的 prompt，`indices={3}` 時輸出僅含 fragment 2/3/4 與 preamble、`## Output` 區塊；bytes 顯著小於原文。
+- [ ] 先寫測試：indices 越界／空集合／單 fragment prompt 的邊界行為（fail-safe：裁切失敗時退回全量並記 warning，不得讓 write 直接失敗）。
+- [ ] 實作純函式並接進 pass 2 write 呼叫點。
+- [ ] 全套綠；`changelog.d/74-harness-input-slicing.md`（type: fix）。

--- a/docs/superpowers/specs/2026-08-04-issue-74-local-harness-input-slicing-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-74-local-harness-input-slicing-design.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+work_item: issue-74-local-harness-input-slicing
+---
+
+# local-harness map-reduce 輸入切分（issue #74）設計
+
+- 日期：2026-08-04
+- Issue：[#74](https://github.com/hamanpaul/paulsha-hippo/issues/74)
+- 狀態：已核可，待實作
+
+## 背景
+
+證據與根因見 spec。修改點集中在 `contrib/local-harness/harness.py` pass 2 write（約 L408-436）；`prompt` 全文以 `paulsha_hippo/atomizer/prompt.py::build_prompt()` 產出，結構固定為：skill 文字 → `## Known projects` → （可選）`## This session's project` → `## Session fragments to atomize`（逐 fragment 輸出 `[fragment N]` 標記＋內文，多段 fragment 另加 `part X/Y` 後綴）→ `## Output`（輸出指示）。本設計要解的問題是「切輸入的邊界怎麼劃、失敗怎麼收」。
+
+## Decisions
+
+### D1：新增純函式 `slice_prompt_by_fragments(prompt, indices, neighbor=1)`
+
+簽名：`slice_prompt_by_fragments(prompt: str, indices: list[int], neighbor: int = 1) -> str`。
+
+行為：
+- 用正則（比照 issue 中已驗證的 `^\[fragment \d+` 前綴，錨定行首）掃出 `## Session fragments to atomize` 區段內每個 `[fragment N ...]` 標記的起訖位置，切出「該標記行＋其後內容直到下一個標記或區段結尾」作為一個 fragment block；同一 `fragment_index` 若有多個 `part X/Y` 標記（同一 fragment 被拆成多段），視為同一個索引下的連續 block，裁切時整組保留或整組捨棄，不拆散單一 fragment 的分段。
+- 依 `indices` 集合擴張 ±`neighbor`（預設 1）個相鄰 fragment index，再依擴張後的索引集合挑出對應 block，依原順序重新組裝。
+- 保留 `## Session fragments to atomize` 之前的全部 preamble（skill 文字／`## Known projects`／`## This session's project`）與 `## Output` 之後的全部輸出指示區塊——這兩段不受裁切影響，逐字保留。
+- 選純函式（不是 method、不吃 harness 其他狀態）：輸入輸出都是字串／整數集合，最小依賴、最容易寫合成 fixture 測試（8-fragment 合成 prompt），也不需要改動 `paulsha_hippo/atomizer/prompt.py` 的輸出格式。
+
+候選但不選：(a) 讓 `build_prompt()` 直接產生分段結構（如 list of dict）取代目前的純字串 prompt——會改變 prompt 契約，影響到非 local-harness 的呼叫者（其他 profile 走同一份全量 prompt 字串），風險與範圍都超出本 issue；(b) 在 harness 內用 JSON/結構化方式重新序列化 fragment——同樣不必要地擴大改動面。純字串裁切、原地替換是最小改動。
+
+### D2：Fail-safe——裁切失敗一律退回全量 prompt 並記 warning
+
+裁切函式內部任何非預期狀況（正則抓不到任何 `[fragment N]` 標記、`indices` 全部越界、擴張後索引集合為空、單一 fragment 的 prompt 裁完後與全量幾乎等長而失去意義等）一律視為「裁切不可信」，函式回傳原始 `prompt` 全文（不裁切），呼叫方（pass 2 write 迴圈）在偵測到「輸出等於輸入」或函式內部顯式回傳全量旗標時，寫一行 stderr warning（`hippo-local-harness: slice_prompt_by_fragments fallback: <reason>`），繼續照舊送出全量 payload 完成該 concept 的 write。
+
+理由：issue 本文明載「裁切失敗時退回全量並記 warning，不得讓 write 直接失敗」——`local-vllm` 是 tier-3 保底，任何本次新增的裁切邏輯本身造成 write 失敗，都是比「效能未達預期」更嚴重的回歸（從「慢但能跑」變成「跑不了」）。fail-safe 使本次變更在最壞情況下等價於變更前的行為（全量重送），只在裁切可信時才拿到效能收益，不存在「裁切邏輯有 bug 導致核心功能壞掉」的下行風險。
+
+不選「裁切失敗直接拋例外／die()」：會把一個純粹的效能最佳化，變成一個可能讓 write 整段失敗的新故障點，與 issue 的驗收語意（「不得讓 write 直接失敗」）直接衝突。
+
+### D3：Contrib-only 風險邊界——不進 wheel、不被 package 引用
+
+`contrib/local-harness/` 明載於檔案頭註解為「Local-only deployment artifact (NOT part of the paulsha-hippo repo/wheel)」，本次變更全數落在這個目錄內（`harness.py` 本體＋新測試檔），不觸碰 `paulsha_hippo/` 套件程式碼、不改 `paulsha_hippo/atomizer/prompt.py` 的輸出契約、不改其他 external-agent profile 的呼叫路徑。因此：
+- 本次變更改壞不影響 hippo core、其他 tier profile（`claude`/`codex`/`agy`/`cg`）或 CI 的套件測試；爆炸半徑限定在 `local-vllm` 這一條 tier-3 保底路徑。
+- 對應地，本次不要求也不應該去改動 `openspec/specs/stage2-llm-distillation/spec.md` 的既有 base spec 內容（如「Bounded zero-tool distillation」等既有 Requirement）——那些描述的是 hippo 核心的 chunk 打包／context 預算，屬另一層級；本次只在該 scope 下新增一個聚焦 `local-harness` 自身 pass 2 行為的 Requirement（見 openspec change 的 `specs/stage2-llm-distillation/spec.md`）。
+- 若實作時發現裁切需要跨到 `paulsha_hippo/` 才能可靠取得 fragment 邊界資訊（例如需要 `Fragment` 物件而非純文字正則），視為超出本次 contrib-only 範圍，應回頭在 PR/issue 說明並重新評估邊界，而非默默擴大改動面。
+
+## Testing
+
+- 新增：8-fragment 合成 prompt，`indices={3}` 時 `slice_prompt_by_fragments` 輸出僅含 fragment 2/3/4 與 preamble、`## Output` 區塊，bytes 顯著小於原文。
+- 新增：indices 越界／空集合／單 fragment prompt 的邊界行為——裁切失敗時退回全量並記 warning，函式不拋例外，呼叫方 write 不因此失敗。
+- 新增：pass 2 write 呼叫點接上裁切函式後的整合行為（可用 mock/monkeypatch 驗證送出的 payload content 已裁切）。
+- 既有：全套 pytest、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠。
+- 端到端（真實 local-vllm 對 48-fragment payload 實測不再 `truncated at max_tokens`）不在本次自動化測試範圍——屬 merge 後 operator 手動驗證項。

--- a/docs/superpowers/specs/2026-08-04-issue-74-local-harness-input-slicing-spec.md
+++ b/docs/superpowers/specs/2026-08-04-issue-74-local-harness-input-slicing-spec.md
@@ -1,0 +1,39 @@
+---
+status: accepted
+work_item: issue-74-local-harness-input-slicing
+---
+
+# local-harness map-reduce 輸入切分（issue #74）規格
+
+## Problem and Outcome
+
+`contrib/local-harness/harness.py`（tier-3 `local-vllm` 保底）的兩段式 map-reduce 流程只切輸出、不切輸入：pass 1（enumerate）算出每個 concept 的 `fragment_indices`，但 pass 2（write）組 message 時仍把整份 `prompt`（含全部 fragment）逐字重送一遍，只在指令文字裡「告訴」模型該用哪些 index。
+
+實測 `claude-code:e41dbdd3-…`（48 fragments／100,523 bytes）於三個 effort 全部失敗且失敗只是遷移、沒有消失：`low`（203s，`truncated at max_tokens`）、`medium`（357s，`truncated at max_tokens`）、`high`（400s，`vLLM request failed: timed out`）。`medium`／`high` 的耗時已遠超 `FIXED_TIMEOUT_SECONDS = 300` 的 per-agent 上限——在有界設計下，這個 payload 規模任何 effort 都不可能完成。
+
+`ENUM_SCHEMA` 的 `fragment_indices` 是必填欄位（`required` 含之，且 `minItems: 1`），pass 1 已精確算出每個 concept 需要哪些 fragment，這項資訊在 pass 2 被完整丟棄。`paulsha_hippo/atomizer/prompt.py::build_prompt()` 以 `[fragment N]` 標記逐段輸出（`label = f"fragment {fragment.fragment_index}"`，多段 fragment 另加 `part X/Y` 後綴），故 harness 可自行依標記裁切輸入，不需要 hippo 端改動 prompt 契約。
+
+預期結果：pass 2 每次 write 只送該 concept 的 `fragment_indices` 對應的 `[fragment N]` 區塊（含可選 ±1 鄰域）與必要的 preamble／`## Output` 指示區塊，不再重送全量 payload；單次輸入 bytes 顯著小於原文；同一 48-fragment payload 有機會落回 per-agent 300s 上限內完成而不觸發 `truncated at max_tokens`；裁切邏輯失敗時 fail-safe 退回全量重送並記 warning，不得讓 write 直接失敗。
+
+## Goals
+
+- G1：新增純函式 `slice_prompt_by_fragments(prompt, indices, neighbor=1)`，依 `fragment_indices` 從完整 prompt 裁出對應 `[fragment N]` 區塊（±1 鄰域），保留 preamble（skill/known projects/session project 區塊）與 `## Output` 指示區塊。
+- G2：pass 2 write 呼叫點改用裁切後的 prompt 取代目前的全量 `prompt`。
+- G3：裁切失敗（正則抓不到標記、indices 越界、空集合等任何非預期狀況）fail-safe 退回全量 prompt 並記 stderr warning，不得讓該 concept 的 write 直接失敗。
+- G4：新增測試涵蓋正常裁切正確性（含 bytes 顯著縮減）與邊界情境（越界／空集合／單 fragment prompt）。
+
+## Non-goals
+
+- 不改 `paulsha_hippo/atomizer/prompt.py` 的 prompt 契約或 `[fragment N]` 標記格式。
+- 不改 pass 1（enumerate）邏輯或 `ENUM_SCHEMA`。
+- 不解決「token 開銷是否來自 guided decoding 本身」——issue 已誠實列出這點無法只靠切輸入解釋，需另行量測，非本次範圍。
+- 不做端到端「真實 local-vllm 對 48-fragment payload 實測不再 truncated」驗證——此為 merge 後 operator 手動驗證項（見 accepted plan）。
+- 不影響 hippo core／package／CI：`contrib/local-harness/` 不進 wheel、不被 package 引用，僅版控與部署來源。
+
+## Acceptance
+
+- 合成 8 個 `[fragment N]` 區塊的 prompt，`indices={3}` 時 `slice_prompt_by_fragments` 輸出僅含 fragment 2/3/4（±1 鄰域）與 preamble、`## Output` 區塊，bytes 顯著小於原文。
+- indices 越界、空集合、單 fragment prompt 等邊界情境下裁切失敗，函式退回全量 prompt 並記 warning，呼叫方不拋例外。
+- pass 2 write 實際呼叫點使用裁切後的 prompt。
+- 全套 pytest、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠。
+- 端到端 48-fragment 真實 local-vllm 驗證留待 merge 後 operator 於有 local-vllm 端點的環境手動執行（非本次驗收項）。

--- a/openspec/changes/issue-74-local-harness-input-slicing/design.md
+++ b/openspec/changes/issue-74-local-harness-input-slicing/design.md
@@ -1,0 +1,36 @@
+---
+status: accepted
+work_item: issue-74-local-harness-input-slicing
+---
+
+# Issue #74 local-harness map-reduce 輸入切分設計
+
+- 日期：2026-08-04
+- Issue：[#74](https://github.com/hamanpaul/paulsha-hippo/issues/74)
+- 狀態：已核可，待實作
+
+## 背景
+
+證據與根因見 spec（`docs/superpowers/specs/2026-08-04-issue-74-local-harness-input-slicing-spec.md`）與同名 design。`prompt` 全文由 `paulsha_hippo/atomizer/prompt.py::build_prompt()` 產出，結構固定：skill 文字 → `## Known projects` → （可選）`## This session's project` → `## Session fragments to atomize`（逐 fragment 輸出 `[fragment N]` 標記，多段 fragment 另加 `part X/Y` 後綴）→ `## Output`。修改點集中在 `contrib/local-harness/harness.py` pass 2 write（約 L408-436）。
+
+## Decisions
+
+### D1：新增純函式 `slice_prompt_by_fragments(prompt, indices, neighbor=1)`
+
+依 concept 的 `fragment_indices` 從完整 prompt 裁出對應 `[fragment N]` 區塊（±1 鄰域），保留 preamble（skill／known projects／session project 區塊）與 `## Output` 指示區塊。同一 `fragment_index` 若因 `part_count > 1` 而拆成多個 `[fragment N part X/Y]` 標記，整組視為同一索引、整組保留或整組捨棄，不拆散單一 fragment 的分段。純函式（字串輸入輸出、不吃 harness 其他狀態）便於合成 8-fragment fixture 直接單元測試，也不需要改動 `build_prompt()` 的輸出格式或契約。
+
+### D2：Fail-safe——裁切失敗退回全量 prompt 並記 warning
+
+裁切函式偵測到任何不可信狀況（抓不到 `[fragment N]` 標記、`indices` 全部越界、擴張後索引集合為空等）一律回傳原始 `prompt` 全文，呼叫方寫一行 stderr warning 後照舊送出全量 payload，不得讓該 concept 的 write 直接失敗。理由：`local-vllm` 是 tier-3 保底，本次是效能最佳化而非功能新增，任何裁切邏輯的 bug 都不應該把「慢但能跑」變成「跑不了」；fail-safe 使最壞情況等價於變更前行為。
+
+### D3：Contrib-only 風險邊界，不進 wheel
+
+本次變更全數落在 `contrib/local-harness/`（`harness.py` 本體＋新測試檔），不觸碰 `paulsha_hippo/` 套件程式碼、不改 `paulsha_hippo/atomizer/prompt.py` 的輸出契約、不改其他 tier profile 的呼叫路徑。`contrib/local-harness/` 明載為「NOT part of the paulsha-hippo repo/wheel」，改壞不影響 hippo core、其他 profile 或 CI 的套件測試，爆炸半徑限定在 `local-vllm` 這一條 tier-3 保底路徑。若實作時發現裁切需要跨到 `paulsha_hippo/` 才能可靠取得 fragment 邊界（例如需要 `Fragment` 物件而非純文字正則），視為超出本次範圍，應於 PR/issue 說明並重新評估邊界。
+
+## Testing
+
+- 新增：8-fragment 合成 prompt，`indices={3}` 時輸出僅含 fragment 2/3/4 與 preamble、`## Output` 區塊，bytes 顯著小於原文。
+- 新增：indices 越界／空集合／單 fragment prompt 的邊界行為——裁切失敗退回全量並記 warning，不拋例外。
+- 新增：pass 2 write 呼叫點整合行為（送出的 payload content 已裁切）。
+- 既有：全套 pytest、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠。
+- 端到端（真實 local-vllm 48-fragment 實測）留待 merge 後 operator 手動驗證，非本次自動化範圍。

--- a/openspec/changes/issue-74-local-harness-input-slicing/proposal.md
+++ b/openspec/changes/issue-74-local-harness-input-slicing/proposal.md
@@ -1,0 +1,27 @@
+---
+status: accepted
+work_item: issue-74-local-harness-input-slicing
+---
+
+# Issue #74 local-harness map-reduce 輸入切分提案
+
+## Why
+
+`contrib/local-harness/harness.py`（tier-3 `local-vllm` 保底）的兩段式 map-reduce 只切輸出、不切輸入：pass 2（write）每次都把整份 prompt（含全部 fragment）重送一遍，只在指令文字裡「告訴」模型該用哪些 `fragment_indices`。實測 48-fragment／100,523 bytes 的 session 於三個 effort 全部失敗（`low`/`medium` `truncated at max_tokens`、`high` `vLLM request failed: timed out`），`medium`/`high` 耗時已遠超 `FIXED_TIMEOUT_SECONDS = 300` 的 per-agent 上限——在有界設計下，這個 payload 規模任何 effort 都不可能完成。
+
+裁切輸入所需的資訊早已存在且被丟棄：pass 1 的 `ENUM_SCHEMA` 中 `fragment_indices` 為必填欄位，且 `paulsha_hippo/atomizer/prompt.py::build_prompt()` 已以 `[fragment N]` 標記逐段輸出，harness 可自行依標記裁切輸入，不需要 hippo 端改動 prompt 契約。
+
+## What Changes
+
+- 新增純函式 `slice_prompt_by_fragments(prompt, indices, neighbor=1)`：依 concept 的 `fragment_indices` 從完整 prompt 裁出對應 `[fragment N]` 區塊（±1 鄰域），保留 preamble 與 `## Output` 指示區塊。
+- pass 2 write 呼叫點（`contrib/local-harness/harness.py` 約 L408-436）接上此函式，取代目前每次重送的全量 `prompt`。
+- Fail-safe：裁切失敗（正則抓不到標記、indices 越界、空集合等）退回全量 prompt 並記 stderr warning，不得讓 write 直接失敗。
+- 新增測試：合成 8-fragment fixture 驗證裁切正確性與 bytes 顯著縮減；邊界情境（越界／空集合／單 fragment prompt）。
+- 新增 `changelog.d/74-harness-input-slicing.md`（type: fix，於實作 PR 提交，非本 define 套件範圍）。
+
+## Impact
+
+- 影響範圍：僅 `contrib/local-harness/harness.py` 與其新測試檔；不改 `paulsha_hippo/` 套件程式碼、不改 `paulsha_hippo/atomizer/prompt.py` 的輸出契約、不改其他 tier profile（`claude`/`codex`/`agy`/`cg`）的呼叫路徑。
+- 風險：`contrib/local-harness/` 不進 wheel、不被 package 引用（僅版控與部署來源），改壞不影響 hippo core／CI；唯一風險是 `[fragment N]` 正則切分不準確或把 preamble／`## Output` 區塊誤裁掉，已以 fail-safe（D2）與合成 fixture 測試（D1）收斂。
+- 端到端驗證（真實 local-vllm 對 48-fragment payload 實測不再 `truncated at max_tokens`）屬 merge 後 operator 手動驗證項，於有 local-vllm 端點的環境執行，非本次自動化驗收範圍。
+- Authority：`docs/superpowers/plans/2026-08-04-issue-74-local-harness-input-slicing.md`、spec/design 同名對。

--- a/openspec/changes/issue-74-local-harness-input-slicing/specs/stage2-llm-distillation/spec.md
+++ b/openspec/changes/issue-74-local-harness-input-slicing/specs/stage2-llm-distillation/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Local-harness pass-2 input slicing by fragment indices
+
+The contrib local-vllm harness's second map-reduce pass (per-concept write) SHALL slice the rendered prompt down to the fragment blocks named by the concept's `fragment_indices`, expanded by a ±1 neighbor window, and SHALL preserve the prompt preamble and the `## Output` instruction block verbatim, instead of resending the full fragment payload for every concept. Slicing SHALL be a pure string transformation over the existing `[fragment N]` markers and MUST NOT require any change to the prompt contract produced by the atomizer prompt builder.
+
+When slicing cannot be trusted — no fragment markers are found, the index set is empty, or every index is out of range — the harness SHALL fall back to the unmodified full prompt and SHALL emit a warning; a slicing failure MUST NOT cause the concept write itself to fail.
+
+#### Scenario: Concept write sends only its fragment neighborhood
+- **WHEN** pass 2 writes a concept whose `fragment_indices` cover a strict subset of the session's fragments
+- **THEN** the request payload SHALL contain only the selected fragment blocks (±1 neighbor) plus the preamble and the `## Output` block, and SHALL be smaller than the full prompt
+
+#### Scenario: Untrusted slicing falls back to the full prompt
+- **WHEN** slicing finds no `[fragment N]` markers, or the concept's index set is empty or entirely out of range
+- **THEN** the harness SHALL send the unmodified full prompt, SHALL log a warning, and the concept write SHALL proceed without failing

--- a/openspec/changes/issue-74-local-harness-input-slicing/tasks.md
+++ b/openspec/changes/issue-74-local-harness-input-slicing/tasks.md
@@ -11,5 +11,5 @@ work_item: issue-74-local-harness-input-slicing
 
 - [x] 1.1 先寫測試：新純函式 `slice_prompt_by_fragments(prompt, indices, neighbor=1)`——合成含 8 個 `[fragment N]` 區塊的 prompt，`indices={3}` 時輸出僅含 fragment 2/3/4 與 preamble、`## Output` 區塊；bytes 顯著小於原文。
 - [x] 1.2 先寫測試：indices 越界／空集合／單 fragment prompt 的邊界行為（fail-safe：裁切失敗時退回全量並記 warning，不得讓 write 直接失敗）。
-- [ ] 1.3 實作純函式 `slice_prompt_by_fragments` 並接進 pass 2 write 呼叫點。
-- [ ] 1.4 全套綠；`changelog.d/74-harness-input-slicing.md`（type: fix）。
+- [x] 1.3 實作純函式 `slice_prompt_by_fragments` 並接進 pass 2 write 呼叫點。
+- [x] 1.4 全套綠；`changelog.d/74-harness-input-slicing.md`（type: fix）。

--- a/openspec/changes/issue-74-local-harness-input-slicing/tasks.md
+++ b/openspec/changes/issue-74-local-harness-input-slicing/tasks.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+work_item: issue-74-local-harness-input-slicing
+---
+
+# local-harness map-reduce 輸入切分 Tasks
+
+依 TDD：先寫失敗測試再實作。測試置於 `contrib/local-harness/tests/test_harness_slicing.py`。
+
+## Task 1: 純函式輸入裁切
+
+- [x] 1.1 先寫測試：新純函式 `slice_prompt_by_fragments(prompt, indices, neighbor=1)`——合成含 8 個 `[fragment N]` 區塊的 prompt，`indices={3}` 時輸出僅含 fragment 2/3/4 與 preamble、`## Output` 區塊；bytes 顯著小於原文。
+- [x] 1.2 先寫測試：indices 越界／空集合／單 fragment prompt 的邊界行為（fail-safe：裁切失敗時退回全量並記 warning，不得讓 write 直接失敗）。
+- [ ] 1.3 實作純函式 `slice_prompt_by_fragments` 並接進 pass 2 write 呼叫點。
+- [ ] 1.4 全套綠；`changelog.d/74-harness-input-slicing.md`（type: fix）。

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -14,7 +14,8 @@ def test_ci_does_not_false_green_test_detection_or_install_failure():
     assert "|| true" not in install_block
     assert "python -m pip install \".[test]\"" in install_block
     assert "python -m pytest --collect-only -q" in text
-    assert "python -m pytest tests/ -q" in text
+    # CI must run both the package suite and the contrib harness suite (R-19)
+    assert "python -m pytest tests/ contrib/local-harness/tests/ -q" in text
 
 
 def test_ci_clean_install_smoke_runs_outside_checkout():


### PR DESCRIPTION
## 摘要

local-vllm harness 的 map-reduce 第二階段（per-concept write）原本每個 concept 都重複發送全量 session payload，大 session（48 fragments 級）下 prompt 過長導致 max_tokens 截斷、write 品質劣化。本 PR 讓 per-concept write 依 map 階段回報的 concept `fragment_indices` 裁切輸入（`slice_prompt_by_fragments`，含 ±1 鄰域保留上下文）：

- fragment 標記正則逐字對齊 `build_prompt` 實際輸出格式（行首、小寫、閉合括號、可選 `part X/Y` 後綴），body 內引用的假標記不再造成誤切
- 三種裁切不可信情況（prompt 無標記／concept 索引集合為空／全部索引越界）皆安全退回全量輸入並記 stderr warning
- 每個 concept write 記錄 indices 與 sliced/full bytes，供事後稽核裁切效果
- CI `tests.yml` 納入 contrib/local-harness 測試，`tests/test_ci_workflow_contract.py` 同步更新契約

驗證證據：

- 全套測試 `python3 -m pytest -q`：1752 passed, 4 skipped, 184 subtests passed（worktree 內直接跑，無環境假失敗）
- 新增 slicing regression 測試 `contrib/local-harness/tests/test_harness_slicing.py`：12 passed
- `openspec validate --all --strict`：15 passed, 0 failed
- `python3 -m policy_check --repo .`：0 failure（R-22 為本地無 diff context 的預期 WARN）

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用（contrib harness 內部行為，無 CLI help 面；openspec change + planning artifacts 已隨 PR 附上）

## 風險與回復

- 無資料遷移、無 live deployment 變更；僅影響 contrib/local-harness 的 prompt 組裝路徑。
- 裁切邏輯有三重 fallback（無標記／空索引／全越界皆退回全量），最壞情況行為等同變更前。
- Rollback：revert 本 squash commit 即可，無外部狀態依賴。
- 尚未完成的 acceptance：真實 local-vllm 48-fragment 端到端實測屬 merge 後 operator 手動項，本 PR 不含（故以 Refs 引用而非關閉 issue）。

Refs #74
