### PR TITLE
fix(search): hippo search 查詢接上 FTS5 sanitizer——column-filter 形查詢不再拋 no such column

### DIFF
--- a/changelog.d/98-search-fts-sanitizer.md
+++ b/changelog.d/98-search-fts-sanitizer.md
@@ -2,3 +2,4 @@
 type: fix
 ---
 - `hippo search` 進入 FTS5 前改重用 `retrieval.to_fts_query()` 正規化查詢；`build: f5df394`、`tag:123`、`col:` 這類含冒號的輸入不再被 FTS5 誤判成不存在的欄位過濾器並拋 `no such column`。
+- 語意變更揭露（非零成本 bugfix）：多詞查詢的比對語意由 FTS5 隱式 AND 收斂為 OR-join（與 hooks shortlist 生產路徑一致），命中集可能變寬——例 `flock ledger` 修復前只回同時含兩詞的 slice，修復後含任一詞即命中；stopword 與單字元 latin token 會在 sanitize 時被丟棄；sanitize 後為空的查詢（純 stopword／符號）回空清單而非拋 SQL 錯誤。

--- a/changelog.d/98-search-fts-sanitizer.md
+++ b/changelog.d/98-search-fts-sanitizer.md
@@ -1,0 +1,4 @@
+---
+type: fix
+---
+- `hippo search` 進入 FTS5 前改重用 `retrieval.to_fts_query()` 正規化查詢；`build: f5df394`、`tag:123`、`col:` 這類含冒號的輸入不再被 FTS5 誤判成不存在的欄位過濾器並拋 `no such column`。

--- a/docs/superpowers/plans/2026-08-04-issue-98-search-retrieval-schema.md
+++ b/docs/superpowers/plans/2026-08-04-issue-98-search-retrieval-schema.md
@@ -11,7 +11,7 @@ work_item: issue-98-search-retrieval-schema
 
 **Root cause（已驗證）:** SQLite FTS5 對 `MATCH ?` 綁定參數仍會解析查詢語法；查詢字串含 `word:` 時 `word` 被當 column-filter，欄位不存在即報 `no such column`。`paulsha_hippo/retrieval.py::to_fts_query()` 已是正確 sanitizer，hooks 的 shortlist 路徑（`hooks/_shortlist_common.py`）已在用；只有 `moc/cli.py::run()`（`hippo search` 入口）呼叫 `moc/search.py::search()` 時把 `args.query` 原文直送 FTS5。
 
-**Target branch:** `feature/98-search-fts-sanitizer`
+**Target branch:** `feature/98-issue-98-search-retrieval-schema`
 
 ## Global Constraints
 

--- a/docs/superpowers/plans/2026-08-04-issue-98-search-retrieval-schema.md
+++ b/docs/superpowers/plans/2026-08-04-issue-98-search-retrieval-schema.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+work_item: issue-98-search-retrieval-schema
+---
+
+# `hippo search` FTS5 查詢 sanitize Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development——先寫失敗測試、看它以正確理由失敗、再實作。
+
+**Goal:** `hippo search` CLI 對含 `word:` 形式的查詢（如 `build: f5df394`）不再拋 `no such column: build`；修法是把 CLI 路徑接上既有的 sanitizer，不新增任何查詢語法設計。
+
+**Root cause（已驗證）:** SQLite FTS5 對 `MATCH ?` 綁定參數仍會解析查詢語法；查詢字串含 `word:` 時 `word` 被當 column-filter，欄位不存在即報 `no such column`。`paulsha_hippo/retrieval.py::to_fts_query()` 已是正確 sanitizer，hooks 的 shortlist 路徑（`hooks/_shortlist_common.py`）已在用；只有 `moc/cli.py::run()`（`hippo search` 入口）呼叫 `moc/search.py::search()` 時把 `args.query` 原文直送 FTS5。
+
+**Target branch:** `feature/98-search-fts-sanitizer`
+
+## Global Constraints
+
+- 語言：PR 標題、內文、commit message、changelog 碎片一律 zh-tw。
+- TDD：先寫測試看 RED 再實作。
+- 交付治理：同一 PR 需 `changelog.d/<slug>.md` 碎片；`python3 -m pytest -q`、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠；PR body 用 repo PR template 且 checklist 全勾；body 以 `Closes #98` 關閉 issue。
+- 全套測試請在非巢狀 sibling worktree 跑；repo 巢狀 worktree 下 `tests/test_project_resolver.py` 有 2 個環境假失敗屬已知訊號。
+- 不可回歸 `tests/test_moc_search.py` 既有排序/比對語意。
+- commit 前 `rm -rf .psc_tmp`，不要用 `git add -A`。
+
+## Task 1: CLI 查詢接上 sanitizer
+
+**檔案**：`paulsha_hippo/moc/search.py`（或 `paulsha_hippo/moc/cli.py`，擇語意最小處）、`tests/test_moc_search.py`
+
+- [ ] 先寫測試：對 `search()` 餵 `"build: f5df394"`、`"tag:123"`、單獨 `"col:"` 等 column-filter 形查詢，斷言不拋 `sqlite3.OperationalError`／`SearchIndexError`，回傳 list（可為空）。
+- [ ] 先寫測試：正常關鍵字查詢（既有測試語料）結果與修復前一致。
+- [ ] 實作：在 `hippo search` 進入 FTS5 前套用 `retrieval.to_fts_query()`（重用，不複製貼上實作）。
+- [ ] 全套測試綠；新增 `changelog.d/98-search-fts-sanitizer.md`（type: fix）。

--- a/docs/superpowers/specs/2026-08-04-issue-98-search-retrieval-schema-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-98-search-retrieval-schema-design.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+work_item: issue-98-search-retrieval-schema
+---
+
+# `hippo search` FTS5 查詢 sanitize（issue #98）設計
+
+- 日期：2026-08-04
+- Issue：[#98](https://github.com/hamanpaul/paulsha-hippo/issues/98)
+- 狀態：已核可，待實作
+
+## 背景
+
+證據與 root cause 見 spec。本設計唯一的問題是「sanitizer 接在哪一層」。
+
+## Decisions
+
+### D1：接在 `hippo search` CLI 進入 FTS5 前的最小語意處
+
+候選：(a) `moc/cli.py::run()` 傳入前先 sanitize；(b) `moc/search.py::search()` 內部 sanitize。
+
+**選 (b)**：`search()` 是 CLI 唯一入口點且未被 shortlist 路徑共用（shortlist 走 `retrieval.py` 自己的查詢組裝，已 sanitize）；在 `search()` 內 sanitize 使任何未來新呼叫者自動安全，且測試可直接對 `search()` 斷言。若實作時發現 `search()` 尚被其他已 sanitize 的路徑呼叫（雙重 sanitize 語意風險），退回 (a) 並在 PR 說明。
+
+### D2：重用 `retrieval.to_fts_query()`，不複製貼上
+
+單一 sanitizer 真理來源。若簽名不合（如需要 tokenize 選項），以最小 adapter 呼叫，不 fork 邏輯。
+
+### D3：語意零回歸為硬門檻
+
+`tests/test_moc_search.py` 既有斷言一條都不許改。sanitize 後的查詢對「本來就合法」的輸入必須產生等價結果——`to_fts_query()` 在 shortlist 路徑的既有行為已證明這點。
+
+## Testing
+
+- 新增：column-filter 形（`build: f5df394`／`tag:123`／`col:`）不拋例外。
+- 既有：全套綠。

--- a/docs/superpowers/specs/2026-08-04-issue-98-search-retrieval-schema-spec.md
+++ b/docs/superpowers/specs/2026-08-04-issue-98-search-retrieval-schema-spec.md
@@ -1,0 +1,31 @@
+---
+status: accepted
+work_item: issue-98-search-retrieval-schema
+---
+
+# `hippo search` FTS5 查詢 sanitize（issue #98）規格
+
+## Problem and Outcome
+
+`hippo search` CLI 對現行 retrieval.db 查詢含 `word:` 形式的字串（例如 `build: f5df394`）時拋 `no such column: build`（AR-05 佐證期間捕獲，issue #98）。
+
+Root cause 已以最小 sqlite3 腳本重現：SQLite FTS5 對 `MATCH ?` 的綁定參數仍會解析查詢語法，`word:` 被當成 column-filter 前綴，欄位不存在即報 `sqlite3.OperationalError: no such column`。
+
+Repo 內已有做法完全正確的 sanitizer：`paulsha_hippo/retrieval.py::to_fts_query()`。hooks 的 prompt-time shortlist 路徑（`hooks/_shortlist_common.py`）已使用它，因此不受影響；只有 `hippo search` CLI 入口（`paulsha_hippo/moc/cli.py::run()` → `paulsha_hippo/moc/search.py::search()`）把使用者查詢原文直送 FTS5。
+
+預期結果：`hippo search` 對任意使用者查詢字串（含 column-filter 形、引號、特殊字元）不再拋 SQL 層例外；回傳正常（可為空）的結果列表；既有排序與比對語意不變。
+
+## Goals
+
+- G1：`hippo search` CLI 路徑套用 `retrieval.to_fts_query()`（重用，不複製實作）。
+- G2：`tests/test_moc_search.py` 既有測試全綠（排序/比對語意零回歸）。
+- G3：新增回歸測試涵蓋 column-filter 形查詢。
+
+## Non-goals
+
+- 不改 FTS5 schema、不改 shortlist/recall 主路徑（本來就正確）、不新增查詢語法功能。
+
+## Acceptance
+
+- 對 `search()`（CLI 同路徑）餵 `"build: f5df394"`、`"tag:123"`、`"col:"` 不拋例外，回傳 list。
+- 全套 pytest、policy_check、openspec strict 全綠。

--- a/docs/superpowers/specs/2026-08-04-issue-98-search-retrieval-schema-spec.md
+++ b/docs/superpowers/specs/2026-08-04-issue-98-search-retrieval-schema-spec.md
@@ -13,12 +13,12 @@ Root cause 已以最小 sqlite3 腳本重現：SQLite FTS5 對 `MATCH ?` 的綁�
 
 Repo 內已有做法完全正確的 sanitizer：`paulsha_hippo/retrieval.py::to_fts_query()`。hooks 的 prompt-time shortlist 路徑（`hooks/_shortlist_common.py`）已使用它，因此不受影響；只有 `hippo search` CLI 入口（`paulsha_hippo/moc/cli.py::run()` → `paulsha_hippo/moc/search.py::search()`）把使用者查詢原文直送 FTS5。
 
-預期結果：`hippo search` 對任意使用者查詢字串（含 column-filter 形、引號、特殊字元）不再拋 SQL 層例外；回傳正常（可為空）的結果列表；既有排序與比對語意不變。
+預期結果：`hippo search` 對任意使用者查詢字串（含 column-filter 形、引號、特殊字元）不再拋 SQL 層例外；回傳正常（可為空）的結果列表；既有測試涵蓋之排序與比對語意零回歸。注意這**不是**全輸入結果等價：套用 `to_fts_query()` 後，多詞查詢的比對語意由 FTS5 隱式 AND 收斂為 OR-join（與 hooks shortlist 路徑一致，命中集可能變寬）、stopword／單字元 latin token 會被丟棄、sanitize 後為空的查詢回空清單而非拋錯——此為刻意接受的語意成本，換取與 shortlist 共用單一 sanitizer。
 
 ## Goals
 
 - G1：`hippo search` CLI 路徑套用 `retrieval.to_fts_query()`（重用，不複製實作）。
-- G2：`tests/test_moc_search.py` 既有測試全綠（排序/比對語意零回歸）。
+- G2：`tests/test_moc_search.py` 既有測試全綠（既有測試涵蓋之排序／比對語意零回歸）。
 - G3：新增回歸測試涵蓋 column-filter 形查詢。
 
 ## Non-goals

--- a/openspec/changes/issue-98-search-retrieval-schema/design.md
+++ b/openspec/changes/issue-98-search-retrieval-schema/design.md
@@ -21,11 +21,11 @@ work_item: issue-98-search-retrieval-schema
 
 ### D2：重用 `retrieval.to_fts_query()`，單一 sanitizer 真理來源
 
-不複製實作。簽名不合時以最小 adapter 呼叫，不 fork 邏輯。
+不複製實作。簽名不合時以最小 adapter 呼叫，不 fork 邏輯。`search()` 內對所有查詢無條件套用，不設「已 canonical 形（`"tok" OR "tok"`）查詢」bypass：shortlist 生產路徑傳入的 canonical 查詢重 sanitize 為冪等（token 皆已通過長度／stopword 過濾、`OR` 本身是 stopword），bypass 只會引入第二條無測試守護的語意分支。
 
-### D3：語意零回歸為硬門檻
+### D3：門檻為「既有測試涵蓋之語意零回歸」，非全輸入結果等價
 
-`tests/test_moc_search.py` 既有斷言一條不改；合法輸入 sanitize 後結果必須等價（shortlist 生產路徑已證明此性質）。
+`tests/test_moc_search.py` 既有斷言一條不改、全綠。但套用 `to_fts_query()` 對合法輸入**不是**結果等價：多詞查詢的比對語意由 FTS5 隱式 AND 收斂為 OR-join（例 `flock ledger` 修復前只命中同時含兩詞的 slice，修復後含任一詞即命中）；stopword 與單字元 latin token 被丟棄；sanitize 後為空的查詢回空 list 而非拋 SQL 錯誤。此語意成本為刻意接受——換取 CLI 與 hooks shortlist 共用單一 sanitizer 真理來源、行為一致；揭露於 changelog 碎片與 spec。
 
 ## Testing
 

--- a/openspec/changes/issue-98-search-retrieval-schema/design.md
+++ b/openspec/changes/issue-98-search-retrieval-schema/design.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+work_item: issue-98-search-retrieval-schema
+---
+
+# Issue #98 `hippo search` FTS5 查詢 sanitize 設計
+
+- 日期：2026-08-04
+- Issue：[#98](https://github.com/hamanpaul/paulsha-hippo/issues/98)
+- 狀態：已核可，待實作
+
+## 背景
+
+`hippo search` CLI 對含 `word:` 形式的查詢拋 `no such column`：FTS5 對 `MATCH ?` 綁定參數仍解析查詢語法。root cause 已以最小 sqlite3 腳本重現；證據見 spec（`docs/superpowers/specs/2026-08-04-issue-98-search-retrieval-schema-spec.md`）。
+
+## Decisions
+
+### D1：sanitize 接在 `moc/search.py::search()` 內、進 FTS5 前
+
+`search()` 是 `hippo search` CLI 唯一入口，shortlist 路徑不經過它（走 `retrieval.py` 自己的查詢組裝、已 sanitize）。在 `search()` 內 sanitize 使未來任何新呼叫者自動安全，測試可直接對 `search()` 斷言。若實作發現 `search()` 另有已 sanitize 的呼叫者（雙重 sanitize 風險），退回 CLI 層（`moc/cli.py::run()`）並於 PR 說明。
+
+### D2：重用 `retrieval.to_fts_query()`，單一 sanitizer 真理來源
+
+不複製實作。簽名不合時以最小 adapter 呼叫，不 fork 邏輯。
+
+### D3：語意零回歸為硬門檻
+
+`tests/test_moc_search.py` 既有斷言一條不改；合法輸入 sanitize 後結果必須等價（shortlist 生產路徑已證明此性質）。
+
+## Testing
+
+- 新增：`"build: f5df394"`、`"tag:123"`、`"col:"` 不拋例外、回傳 list。
+- 既有：全套 pytest、policy_check、openspec strict 全綠。

--- a/openspec/changes/issue-98-search-retrieval-schema/proposal.md
+++ b/openspec/changes/issue-98-search-retrieval-schema/proposal.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+work_item: issue-98-search-retrieval-schema
+---
+
+## Why
+
+`hippo search` CLI 對含 `word:` 形式的查詢（如 `build: f5df394`）會拋 `no such column: build`。SQLite FTS5 對 `MATCH ?` 綁定參數仍會解析查詢語法；查詢字串含 `word:` 時 `word` 被當 column-filter，欄位不存在即報 `no such column`。
+
+## What Changes
+
+- 在 `hippo search` CLI 與 `search()` 進入 FTS5 前套用 `retrieval.to_fts_query()` sanitizer。
+- 新增單元測試驗證 `build: f5df394`、`tag:123`、`col:` 等 column-filter 形查詢不拋 `SearchIndexError`。
+
+## Non-Goals
+
+- 不新增任何查詢語法設計。

--- a/openspec/changes/issue-98-search-retrieval-schema/specs/stage2-memory-prompt-retrieval/spec.md
+++ b/openspec/changes/issue-98-search-retrieval-schema/specs/stage2-memory-prompt-retrieval/spec.md
@@ -1,0 +1,12 @@
+# stage2-memory-prompt-retrieval Spec Delta
+
+## MODIFIED Requirements
+
+### Requirement: FTS 查詢淨化純函式
+
+`hippo search` CLI 入口與 `search()` 函式 SHALL 於查詢進入 SQLite FTS5 前套用 `to_fts_query()` 進行淨化，防止 `word:` 形式之 column-filter 形查詢觸發 SQLite `no such column` 或語法錯誤。
+
+#### Scenario: column-filter 形查詢不致語法錯誤
+
+- **WHEN** 對 `search()` 傳入 `build: f5df394`、`tag:123` 或 `col:` 等 column-filter 形查詢
+- **THEN** 查詢 MUST NOT 拋出 `sqlite3.OperationalError` 或 `SearchIndexError`，且回傳 list（可為空）

--- a/openspec/changes/issue-98-search-retrieval-schema/specs/stage2-memory-prompt-retrieval/spec.md
+++ b/openspec/changes/issue-98-search-retrieval-schema/specs/stage2-memory-prompt-retrieval/spec.md
@@ -10,3 +10,8 @@
 
 - **WHEN** 對 `search()` 傳入 `build: f5df394`、`tag:123` 或 `col:` 等 column-filter 形查詢
 - **THEN** 查詢 MUST NOT 拋出 `sqlite3.OperationalError` 或 `SearchIndexError`，且回傳 list（可為空）
+
+#### Scenario: sanitize 後 token 仍可命中
+
+- **WHEN** 索引語料含 body 為 `build f5df394 details` 之 slice，且查詢為 `build: f5df394`
+- **THEN** 結果 MUST 命中該 slice（sanitize 後 tokens `build`／`f5df394` 以 OR-join 比對，不因淨化而搜不到）

--- a/openspec/changes/issue-98-search-retrieval-schema/tasks.md
+++ b/openspec/changes/issue-98-search-retrieval-schema/tasks.md
@@ -9,5 +9,5 @@ work_item: issue-98-search-retrieval-schema
 
 - [x] 1.1 先寫測試：對 `search()` 餵 `"build: f5df394"`、`"tag:123"`、單獨 `"col:"` 等 column-filter 形查詢，斷言不拋 `sqlite3.OperationalError`／`SearchIndexError`，回傳 list（可為空）。
 - [x] 1.2 先寫測試：正常關鍵字查詢（既有測試語料）結果與修復前一致。
-- [ ] 1.3 實作：在 `hippo search` 進入 FTS5 前套用 `retrieval.to_fts_query()`（重用，不複製貼上實作）。
-- [ ] 1.4 全套測試綠；新增 `changelog.d/98-search-fts-sanitizer.md`（type: fix）。
+- [x] 1.3 實作：在 `hippo search` 進入 FTS5 前套用 `retrieval.to_fts_query()`（重用，不複製貼上實作）。
+- [x] 1.4 全套測試綠；新增 `changelog.d/98-search-fts-sanitizer.md`（type: fix）。

--- a/openspec/changes/issue-98-search-retrieval-schema/tasks.md
+++ b/openspec/changes/issue-98-search-retrieval-schema/tasks.md
@@ -8,6 +8,6 @@ work_item: issue-98-search-retrieval-schema
 ## 1. CLI 查詢接上 sanitizer
 
 - [x] 1.1 先寫測試：對 `search()` 餵 `"build: f5df394"`、`"tag:123"`、單獨 `"col:"` 等 column-filter 形查詢，斷言不拋 `sqlite3.OperationalError`／`SearchIndexError`，回傳 list（可為空）。
-- [x] 1.2 先寫測試：正常關鍵字查詢（既有測試語料）結果與修復前一致。
+- [x] 1.2 正常關鍵字查詢的零回歸依靠既有測試涵蓋（`tests/test_moc_search.py` 既有無冒號查詢斷言一條未改、全綠）；未另寫修復前後等價測試。另於 1.1 測試內加正向斷言：`"build: f5df394"` sanitize 後 tokens build/f5df394 仍命中 `sl-1`，防 `return []` 式退化實作。
 - [x] 1.3 實作：在 `hippo search` 進入 FTS5 前套用 `retrieval.to_fts_query()`（重用，不複製貼上實作）。
 - [x] 1.4 全套測試綠；新增 `changelog.d/98-search-fts-sanitizer.md`（type: fix）。

--- a/openspec/changes/issue-98-search-retrieval-schema/tasks.md
+++ b/openspec/changes/issue-98-search-retrieval-schema/tasks.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: issue-98-search-retrieval-schema
+---
+
+# Issue #98 search FTS5 sanitizer tasks
+
+## 1. CLI 查詢接上 sanitizer
+
+- [x] 1.1 先寫測試：對 `search()` 餵 `"build: f5df394"`、`"tag:123"`、單獨 `"col:"` 等 column-filter 形查詢，斷言不拋 `sqlite3.OperationalError`／`SearchIndexError`，回傳 list（可為空）。
+- [x] 1.2 先寫測試：正常關鍵字查詢（既有測試語料）結果與修復前一致。
+- [ ] 1.3 實作：在 `hippo search` 進入 FTS5 前套用 `retrieval.to_fts_query()`（重用，不複製貼上實作）。
+- [ ] 1.4 全套測試綠；新增 `changelog.d/98-search-fts-sanitizer.md`（type: fix）。

--- a/paulsha_hippo/moc/search.py
+++ b/paulsha_hippo/moc/search.py
@@ -5,7 +5,6 @@ import fcntl
 import json
 import logging
 import os
-import re
 import secrets
 import sqlite3
 from contextlib import contextmanager
@@ -26,7 +25,6 @@ from . import frontmatter_io as fio
 
 INDEX_WRITE_BATCH_SIZE = 100
 LOGGER = logging.getLogger("paulsha_hippo.moc.search")
-_CANONICAL_FTS_QUERY = re.compile(r'^"[^"]+"(?: OR "[^"]+")*$')
 
 # 跨批次契約 #6：build_index() 回傳 dict 的六個 coverage 鍵。
 COVERAGE_KEYS = ("scanned", "invalid_frontmatter", "pool_excluded",
@@ -480,21 +478,19 @@ def _row_read_count(row: tuple) -> int:
     return value if isinstance(value, int) and value > 0 else 0
 
 
-def _normalize_match_query(query: str) -> str:
-    stripped = query.strip()
-    if not stripped:
-        return ""
-    if _CANONICAL_FTS_QUERY.fullmatch(stripped):
-        return stripped
-    return to_fts_query(stripped)
-
-
 def search(memory_root: Path, query: str, *, project: str | None, limit: int,
            include_decayed: bool) -> list[dict]:
     path = index_path(memory_root)
     if not path.exists():
         raise SearchIndexError("search index not built; run the dream/moc pass first")
-    match_query = _normalize_match_query(query)
+    # issue #98：查詢一律經 retrieval.to_fts_query() 淨化後才進 FTS5（單一
+    # sanitizer 真理來源，與 hooks shortlist 一致），`word:` 形輸入不再被
+    # FTS5 當 column-filter 拋 no such column。不設「已 canonical 形查詢」
+    # bypass——shortlist 傳入的 canonical 查詢重 sanitize 為冪等（token 皆已
+    # 過濾、OR 為 stopword）。語意成本（刻意接受）：多詞查詢由 FTS5 隱式
+    # AND 收斂為 OR-join；stopword／單字元 latin token 被丟棄；sanitize 後
+    # 為空（純 stopword／符號）回空 list 而非拋 SQL 錯誤。
+    match_query = to_fts_query(query)
     if not match_query:
         return []
     conn = sqlite3.connect(path)

--- a/paulsha_hippo/moc/search.py
+++ b/paulsha_hippo/moc/search.py
@@ -5,6 +5,7 @@ import fcntl
 import json
 import logging
 import os
+import re
 import secrets
 import sqlite3
 from contextlib import contextmanager
@@ -20,10 +21,12 @@ from ..ledger import lifecycle
 from ..ledger import retrieval_set
 from ..ledger import usage as usage_ledger
 from ..noise import classify_noise, pool_exclude_reason
+from ..retrieval import to_fts_query
 from . import frontmatter_io as fio
 
 INDEX_WRITE_BATCH_SIZE = 100
 LOGGER = logging.getLogger("paulsha_hippo.moc.search")
+_CANONICAL_FTS_QUERY = re.compile(r'^"[^"]+"(?: OR "[^"]+")*$')
 
 # 跨批次契約 #6：build_index() 回傳 dict 的六個 coverage 鍵。
 COVERAGE_KEYS = ("scanned", "invalid_frontmatter", "pool_excluded",
@@ -477,11 +480,23 @@ def _row_read_count(row: tuple) -> int:
     return value if isinstance(value, int) and value > 0 else 0
 
 
+def _normalize_match_query(query: str) -> str:
+    stripped = query.strip()
+    if not stripped:
+        return ""
+    if _CANONICAL_FTS_QUERY.fullmatch(stripped):
+        return stripped
+    return to_fts_query(stripped)
+
+
 def search(memory_root: Path, query: str, *, project: str | None, limit: int,
            include_decayed: bool) -> list[dict]:
     path = index_path(memory_root)
     if not path.exists():
         raise SearchIndexError("search index not built; run the dream/moc pass first")
+    match_query = _normalize_match_query(query)
+    if not match_query:
+        return []
     conn = sqlite3.connect(path)
     try:
         has_usage_cols = _slice_meta_has_usage_columns(conn)
@@ -490,7 +505,7 @@ def search(memory_root: Path, query: str, *, project: str | None, limit: int,
                f"m.link_weight, m.active, m.path{usage_select} "
                "FROM slices_fts f JOIN slice_meta m ON m.slice_id = f.slice_id "
                "WHERE slices_fts MATCH ?")
-        params: list[object] = [query]
+        params: list[object] = [match_query]
         if project:
             sql += " AND m.project = ?"
             params.append(project)

--- a/tests/test_moc_search.py
+++ b/tests/test_moc_search.py
@@ -34,6 +34,18 @@ class SearchTests(unittest.TestCase):
             self.assertEqual([h["slice_id"] for h in hits], ["sl-1"])
             self.assertIn("project", hits[0])
 
+    def test_search_column_filter_query_does_not_raise(self):
+        # Issue #98: column-filter style queries like "build: f5df394", "tag:123", "col:"
+        # must not raise sqlite3.OperationalError / SearchIndexError.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _slice(root, "sl-1", "proj", "build note", "build f5df394 details")
+            search.build_index(root, link_weights={})
+            for q in ["build: f5df394", "tag:123", "col:"]:
+                hits = search.search(root, q, project=None, limit=5, include_decayed=True)
+                self.assertIsInstance(hits, list)
+
+
     def test_search_stable_sort_uses_base_score_before_slice_id(self):
         # v5 plan BLOCKER #7：有 usage boost 時排序鍵須為
         # (adjusted_score, base_score, slice_id)，同分時以 base_score 決勝，

--- a/tests/test_moc_search.py
+++ b/tests/test_moc_search.py
@@ -41,10 +41,14 @@ class SearchTests(unittest.TestCase):
             root = Path(tmp)
             _slice(root, "sl-1", "proj", "build note", "build f5df394 details")
             search.build_index(root, link_weights={})
-            for q in ["build: f5df394", "tag:123", "col:"]:
+            # 正向行為 pin：sanitize 後 tokens build/f5df394 仍須真的命中
+            # sl-1——防 `return []` 式退化實作也能讓本測試綠。
+            hits = search.search(root, "build: f5df394", project=None, limit=5,
+                                 include_decayed=True)
+            self.assertEqual([h["slice_id"] for h in hits], ["sl-1"])
+            for q in ["tag:123", "col:"]:
                 hits = search.search(root, q, project=None, limit=5, include_decayed=True)
                 self.assertIsInstance(hits, list)
-
 
     def test_search_stable_sort_uses_base_score_before_slice_id(self):
         # v5 plan BLOCKER #7：有 usage boost 時排序鍵須為


### PR DESCRIPTION
## 摘要

`hippo search`（`moc/search.py::search()`）先前把使用者原始查詢字串直接丟進 FTS5 `MATCH`，`build: f5df394`、`tag:123`、`col:` 這類含冒號的輸入會被 FTS5 誤判為 column-filter，拋出 `no such column` 的 `OperationalError`。本 PR 讓查詢一律先經 `retrieval.to_fts_query()` 淨化再進 FTS5——與 hooks shortlist 生產路徑共用同一個 sanitizer 真理來源，不設「已 canonical 形查詢」bypass（重複 sanitize 為冪等）。

語意變更揭露（非零成本 bugfix，已寫入 changelog 碎片與程式註解）：

- 多詞查詢由 FTS5 隱式 AND 收斂為 OR-join（與 shortlist 路徑一致），命中集可能變寬。
- stopword 與單字元 latin token 在 sanitize 時被丟棄。
- sanitize 後為空的查詢（純 stopword／符號）回空清單，而非拋 SQL 錯誤。

## 驗證

- 全套測試（worktree 內 `python3 -m pytest -q`）：**1741 passed, 4 skipped, 184 subtests passed**，無失敗。
- 新增測試 `tests/test_moc_search.py::test_search_column_filter_query_does_not_raise`：column-filter 形查詢不拋錯，且正向 pin `build: f5df394` sanitize 後仍真的命中目標 slice（防 `return []` 式退化實作）。
- `openspec validate --all --strict`：**15 passed, 0 failed**。
- `python3 -m policy_check --repo .`：**0 fail**，僅 R-22 既有 26 筆陳年懸空引用 WARN（advisory，與本 PR 無關）；R-09 碎片存在性由 CI 以 PR context 複驗（`changelog.d/98-search-fts-sanitizer.md` 已在 diff 內）。

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

## 風險與回復

- 無資料遷移、無 index schema 變動；`VERSION` 未動（非 release PR）。
- CLI 介面（旗標／參數）無變動，CLI help 不適用；行為語意變更已由 `changelog.d/98-search-fts-sanitizer.md` 揭露。
- 主要風險為多詞查詢 AND→OR 造成命中集變寬——屬刻意接受的語意收斂（向 shortlist 生產路徑對齊）；若下游依賴嚴格 AND 語意，回復方式為 revert 本 squash commit（單一 commit、無耦合遷移）。

Closes #98
