### PR TITLE
fix(cg): cg profile 宣告 max_session_chunks=6——大 session 立即 ineligible 不再燒 153s

### DIFF
--- a/changelog.d/99-cg-max-session-chunks.md
+++ b/changelog.d/99-cg-max-session-chunks.md
@@ -1,0 +1,4 @@
+---
+type: fix
+---
+- 修 issue #99：`cg` external-agent profile 宣告 `max_session_chunks: 6`，讓 7+ chunk 的大 session 在 profile eligibility 階段直接記 `ineligible`／`session_size` provenance 並交給下一個 fallback profile，而不是先花一輪 cg 呼叫才以不可解析 JSON 失敗。`default_profiles()` 與出貨模板 `paulsha_hippo/atomizer/atomizer.yaml` 兩處同步，避免模板漂移把停損配置漏出貨。

--- a/docs/superpowers/plans/2026-08-04-issue-99-cg-max-session-chunks.md
+++ b/docs/superpowers/plans/2026-08-04-issue-99-cg-max-session-chunks.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+work_item: issue-99-cg-max-session-chunks
+---
+
+# cg profile 大 session 停損（max_session_chunks）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development——先寫失敗測試再實作。
+
+**Goal:** 大 session（>6 chunks）不再讓 cg 燒 153 秒才輸出不可解析 JSON 失敗——cg profile 宣告既有欄位 `max_session_chunks`，超限即記 `ineligible` provenance、立即讓給下一個 profile。
+
+**範圍限定（停損版）：** 本 plan 只做宣告式停損。「根治」（copilot 鏈路 JSON 抽取對大 payload 的截斷行為）需要對真實 copilot CLI 打大 payload 量測，非確定性可自動化，**明確不在本 plan 範圍**，留在 issue #99 追蹤。
+
+**機制現況：** `max_session_chunks` 欄位與 ineligible 路徑已存在（#85/#100 為 claude/codex tier-1 建立，上限 7）。本次只是讓 cg profile 也宣告它。
+
+**Target branch:** `feature/99-cg-max-session-chunks`
+
+## Global Constraints
+
+- 語言 zh-tw；TDD 先 RED 再實作。
+- 交付治理：`changelog.d/<slug>.md`、pytest／policy_check／openspec strict 全綠、PR checklist 全勾、body 註 `Refs #99`（**不要用 Closes**——issue 的根治部分未完成，比照 PR #56 慣例附 `policy-exempt:issue-link` label 或在 body 說明只交付停損）。
+- **出貨模板漂移守門**：`paulsha_hippo/atomizer/atomizer.yaml` 的 profile 定義必須與 `agent_profiles.default_profiles()` 逐 token 同步（`tests/test_external_agent_profiles.py::test_packaged_config_template_argv_matches_canonical_defaults`），兩處一起改。
+- 全套測試在非巢狀 sibling worktree 跑。
+- commit 前 `rm -rf .psc_tmp`；不要 `git add -A`。
+
+## Task 1: cg 宣告 max_session_chunks
+
+**檔案**：`paulsha_hippo/agent_profiles.py`（`default_profiles()` 的 cg 定義）、`paulsha_hippo/atomizer/atomizer.yaml`（cg profile block，約 L72-82）、`tests/test_external_agent_profiles.py`
+
+- [ ] 先寫測試：比照既有 tier-1 `max_session_chunks` 測試模式，構造 chunk 數超限的 session，斷言 cg 被記 `ineligible`（provenance record 存在、reason 正確）而非實際嘗試呼叫。
+- [ ] 先寫測試：chunk 數在限內時 cg 行為不變。
+- [ ] 實作：cg profile 加 `max_session_chunks: 6`（依 issue 實證：6 chunks 內可解析、7+ 不可）；`atomizer.yaml` 與 `default_profiles()` 兩處同步。
+- [ ] 模板同步測試綠；全套綠；`changelog.d/99-cg-max-session-chunks.md`（type: fix）。

--- a/docs/superpowers/specs/2026-08-04-issue-99-cg-max-session-chunks-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-99-cg-max-session-chunks-design.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+work_item: issue-99-cg-max-session-chunks
+---
+
+# cg profile 大 session 停損（max_session_chunks，issue #99）設計
+
+- 日期：2026-08-04
+- Issue：[#99](https://github.com/hamanpaul/paulsha-hippo/issues/99)
+- 狀態：已核可，待實作
+
+## 背景
+
+證據與 root cause 見 spec（`docs/superpowers/specs/2026-08-04-issue-99-cg-max-session-chunks-spec.md`）：cg profile 未宣告 `max_session_chunks`，導致超大 session 燒滿 153 秒才以不可解析 JSON 失敗，而非快速讓給下一個 profile。`max_session_chunks` 欄位、`AgentProfile.eligible()` 的 `session_size` gate、以及 provenance 記錄機制皆已由 #85/#100 為 tier-1（claude/codex）建立並驗證；本次只需讓 cg 也宣告同一欄位。
+
+## Decisions
+
+### D1：cg 宣告 `max_session_chunks: 6`，機制完全沿用 #85/#100，不新增新機制
+
+上限取值依 issue 生產實證：6 chunks 內 cg 可解析輸出、7+ chunks 會踩到 exit 3「no parseable JSON」。沿用 `AgentProfile.eligible()` 既有的 `session_size` gate（`paulsha_hippo/agent_profiles.py:401-405`）——`chunk_count > self.max_session_chunks` 時回傳 `(False, "session_size")`，不呼叫子行程、不產生實際嘗試。不引入新的 gate 型別、不新增新的 ineligible reason 字串，維持與 tier-1（`_TIER1_MAX_SESSION_CHUNKS = 7`）同一套語意，只是數值與適用 profile 不同（cg 為 6，tier-2）。
+
+### D2：`atomizer.yaml` 與 `default_profiles()` 兩處逐 token 同步
+
+`paulsha_hippo/agent_profiles.py::default_profiles()` 的 cg row（第 6 欄 `max_session_chunks`）與 `paulsha_hippo/atomizer/atomizer.yaml` 的 cg profile block（約 L72-82，新增 `max_session_chunks: 6`）必須同時修改，兩者為出貨模板與程式碼內建預設值的一體兩面。既有守門測試 `tests/test_external_agent_profiles.py::test_packaged_config_template_argv_matches_canonical_defaults` 驗證兩處逐 token 一致；本次變更後該測試必須維持綠燈，不得只改一處。
+
+### D3：根治（copilot 鏈路截斷行為量測）留 issue #99 追蹤，明確不在本次範圍
+
+copilot CLI 鏈路對大 payload 的 JSON 抽取／截斷行為，需要對真實 copilot CLI 打大 payload 才能量測其確切邊界（例如是否為固定 token 數截斷、是否與 model/effort 相關），此類量測非確定性、不可自動化驗證，不適合以 TDD 單元測試鎖定。本次只做「宣告式停損」——讓 cg 對超限 session fail-fast 為 ineligible，避免燒 153 秒；根治留 issue #99 繼續追蹤，PR 交付語意用 `Refs #99`、不用 `Closes #99`。
+
+## Testing
+
+- 新增：構造 chunk 數為 7（超過 6）的 session，斷言 `AgentProfile.eligible(chunk_count=7)` 對 cg 回傳 `(False, "session_size")`，且不觸發實際呼叫（無 subprocess 執行副作用）。
+- 新增：構造 chunk 數為 6（限內）的 session，斷言 cg 的 eligible 判定與呼叫路徑與本次變更前一致（零回歸）。
+- 既有：`tests/test_external_agent_profiles.py::test_packaged_config_template_argv_matches_canonical_defaults` 綠——`atomizer.yaml` 與 `default_profiles()` 的 cg 定義逐 token 一致。
+- 既有：全套 pytest、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠。

--- a/docs/superpowers/specs/2026-08-04-issue-99-cg-max-session-chunks-spec.md
+++ b/docs/superpowers/specs/2026-08-04-issue-99-cg-max-session-chunks-spec.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+work_item: issue-99-cg-max-session-chunks
+---
+
+# cg profile 大 session 停損（max_session_chunks，issue #99）規格
+
+## Problem and Outcome
+
+大 session（>6 chunks）落到 cg profile 時，cg 會先燒 153.3 秒才以 exit 3 失敗（`hippo-copilot-core: no parseable JSON`），而非快速讓給下一個 profile。
+
+生產實證：
+
+- 原始事故（issue #99 body）：213KB/47+ fragments 的 session，tier-1（claude/codex）先因既有 `max_session_chunks`（7）判 ineligible 退出，cg 接手後燒滿 153.3 秒才吐不可解析輸出；同 session 續落 local-vllm 也因 `truncated at max_tokens`（issue #74 範疇）失敗，四 backend 全滅、session park，直接觸發 AR-11 soak 窗口重置。
+- 2026-08-03 追加事故：792 fragments 的更大 session 再現同型崩潰——這次 claude／codex 連嘗試都沒有（`eligible()` 的 `session_size` gate 在 chunk 數超過各自 `max_session_chunks` 時直接判 ineligible），但 cg 仍照樣燒到 exit 3；local-vllm 仍是截斷失敗。四層全滅、window reset。
+
+根本原因鎖定在 cg profile **沒有宣告** `max_session_chunks`——這個欄位與對應的 ineligible 路徑（`session_size` gate）已由 #85/#100 為 tier-1（claude/codex）建立並在生產驗證（tier-1 目前宣告上限 7）。cg 只是尚未套用同一機制。
+
+預期結果：cg profile 宣告既有欄位 `max_session_chunks: 6`（依 issue 實證：6 chunks 內可解析、7+ 不可），超過上限的 session 對 cg 直接判 `ineligible`（reason `session_size`）、記錄 provenance 後立即讓給下一個 profile，不再實際嘗試呼叫、不再燒 153 秒才失敗。
+
+## Goals
+
+**本次交付範圍為停損版，不含根治：**
+
+- G1（停損）：cg profile 在 `paulsha_hippo/agent_profiles.py::default_profiles()` 與 `paulsha_hippo/atomizer/atomizer.yaml` 的 cg block 兩處宣告 `max_session_chunks: 6`，逐 token 同步，沿用 #85/#100 已建立的 `session_size` ineligible 機制，不新增機制。
+- G2：新增測試涵蓋「超過 6 chunks 的 session 對 cg 判 ineligible（reason `session_size`），不實際嘗試呼叫」與「chunk 數在 6 以內時 cg 行為不變」兩種情境。
+- G3：出貨模板守門測試（`tests/test_external_agent_profiles.py::test_packaged_config_template_argv_matches_canonical_defaults`）綠——保證 `atomizer.yaml` 與 `default_profiles()` 不漂移。
+- G4：全套 pytest、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠；新增 `changelog.d/99-cg-max-session-chunks.md`（type: fix）。
+
+## Non-goals（根治不在本次）
+
+- **不**量測或修改 copilot CLI 鏈路對大 payload 的 JSON 抽取／截斷行為——這需要對真實 copilot CLI 打大 payload 才能量測，非確定性、無法自動化驗證，明確留在 issue #99 追蹤、不在本 spec 範圍。
+- **不**變更 tier-1（claude/codex）既有 `max_session_chunks: 7` 的數值或機制。
+- **不**處理 local-vllm 的 `truncated at max_tokens`（屬 issue #74 範疇）。
+- **不**新增新的 gate 欄位或新的 ineligible reason；完全重用 `session_size` 既有語意。
+
+## Acceptance
+
+- 對 chunk 數 > 6 的 session，`AgentProfile.eligible(chunk_count=...)` 對 cg 回傳 `(False, "session_size")`，且該 session 不再對 cg 產生實際呼叫（無 subprocess 執行、無 153 秒級耗時）。
+- 對 chunk 數 ≤ 6 的 session，cg 的 eligible 判定與行為與本次變更前一致（零回歸）。
+- `atomizer.yaml` 的 cg block 與 `default_profiles()` 的 cg row 逐 token 一致（守門測試綠）。
+- 全套 pytest、policy_check、openspec strict 全綠。

--- a/openspec/changes/issue-99-cg-max-session-chunks/design.md
+++ b/openspec/changes/issue-99-cg-max-session-chunks/design.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+work_item: issue-99-cg-max-session-chunks
+---
+
+# Issue #99 cg profile 大 session 停損（max_session_chunks）設計
+
+- 日期：2026-08-04
+- Issue：[#99](https://github.com/hamanpaul/paulsha-hippo/issues/99)
+- 狀態：已核可，待實作
+
+## 背景
+
+cg profile 未宣告 `max_session_chunks`，導致超大 session 落到 cg 時燒滿 153 秒才以不可解析 JSON 失敗。`max_session_chunks` 欄位、`AgentProfile.eligible()` 的 `session_size` gate、以及對應的 provenance 記錄機制皆已由 #85/#100 為 tier-1（claude/codex）建立並在生產驗證（tier-1 上限 7）。證據與 root cause 詳見 spec（`docs/superpowers/specs/2026-08-04-issue-99-cg-max-session-chunks-spec.md`）。
+
+## Decisions
+
+### D1：cg 宣告 `max_session_chunks: 6`，機制沿用 #85/#100，不新增新機制
+
+上限值依 issue 生產實證：6 chunks 內 cg 可解析輸出、7+ chunks 會踩到 exit 3「no parseable JSON」。沿用 `AgentProfile.eligible()` 既有的 `session_size` gate（`chunk_count > self.max_session_chunks` 時回傳 `(False, "session_size")`），不引入新 gate 型別、不新增新的 ineligible reason，與 tier-1 的 `_TIER1_MAX_SESSION_CHUNKS = 7` 同一套語意，僅數值與適用 profile（tier-2 cg）不同。
+
+### D2：`atomizer.yaml` 與 `default_profiles()` 逐 token 同步
+
+`paulsha_hippo/agent_profiles.py::default_profiles()` 的 cg row（`max_session_chunks` 欄位）與 `paulsha_hippo/atomizer/atomizer.yaml` 的 cg profile block（約 L72-82，新增 `max_session_chunks: 6`）必須同時修改。既有守門測試 `tests/test_external_agent_profiles.py::test_packaged_config_template_argv_matches_canonical_defaults` 驗證兩處逐 token 一致；本次變更後該測試必須維持綠燈。
+
+### D3：根治留 issue #99 追蹤，明確不在本次範圍
+
+copilot CLI 鏈路對大 payload 的 JSON 抽取／截斷行為，需要對真實 copilot CLI 打大 payload 才能量測其確切邊界，非確定性、不可自動化驗證，不適合以 TDD 單元測試鎖定。本次只做宣告式停損；根治留 issue #99 繼續追蹤，PR 交付語意用 `Refs #99`、不用 `Closes #99`。
+
+## Testing
+
+- 新增：chunk 數 7（超過 6）的 session，`AgentProfile.eligible(chunk_count=7)` 對 cg 回傳 `(False, "session_size")`，且不觸發實際呼叫（無 subprocess 執行副作用）。
+- 新增：chunk 數 6（限內）的 session，cg 的 eligible 判定與呼叫路徑與變更前一致（零回歸）。
+- 既有：`test_packaged_config_template_argv_matches_canonical_defaults` 綠——`atomizer.yaml` 與 `default_profiles()` 的 cg 定義逐 token 一致。
+- 既有：全套 pytest、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠。

--- a/openspec/changes/issue-99-cg-max-session-chunks/proposal.md
+++ b/openspec/changes/issue-99-cg-max-session-chunks/proposal.md
@@ -1,0 +1,19 @@
+---
+status: accepted
+work_item: issue-99-cg-max-session-chunks
+---
+
+## Why
+
+大 session（>6 chunks）不再讓 cg 燒 153 秒才輸出不可解析 JSON 失敗——cg profile 宣告既有欄位 `max_session_chunks: 6`，超限即記 `ineligible` provenance、立即讓給下一個 profile。
+
+## What Changes
+
+- cg profile 宣告 `max_session_chunks: 6`（`paulsha_hippo/agent_profiles.py` 與 `paulsha_hippo/atomizer/atomizer.yaml`）。
+- 6 chunks 內 cg 可正常調用，7+ chunks 即記 `ineligible` provenance 並跳過。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `stage2-llm-distillation`：cg profile 宣告 max_session_chunks: 6。

--- a/openspec/changes/issue-99-cg-max-session-chunks/specs/stage2-llm-distillation/spec.md
+++ b/openspec/changes/issue-99-cg-max-session-chunks/specs/stage2-llm-distillation/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+
+### Requirement: Deterministic tiered fallback
+
+The default ordered groups SHALL be Tier 1 `claude` and `codex` as difficult-decision judges, Tier 2 `agy` and `cg` as fast-response/heavy-work agents, and Tier 3 `co-gem`, `claude-gem`, and custom local profiles as low-cost fallback. Exact order within a tier SHALL use explicit numeric priority. Traits SHALL be reviewable routing metadata, not free-form instructions that permit the model to choose its successor. The fallback graph SHALL be acyclic and constrained by a global deadline, maximum attempts, maximum agent calls, and per-profile circuit breaker/cooldown. Dream profiles SHALL disable CLI-native model fallback/retry; a CLI for which preflight cannot prove native fallback is disabled SHALL be ineligible, so Hippo remains the sole routing and budget authority.
+
+The global deadline SHALL scale with the number of prompt chunks the session was packed into, bounded by a fixed floor and a fixed ceiling, so that a session's chain budget bears a defined relationship to the work it contains. The per-call timeout SHALL remain a separate fixed bound and MUST NOT be widened by this scaling; hang protection is not negotiable. A profile MAY declare a maximum session size it is suited for; when a session exceeds that declaration the profile SHALL be ineligible for that session, SHALL be recorded in attempt provenance, and MUST NOT consume an agent call.
+
+#### Scenario: Oversized session skips cg profile without cost
+- **WHEN** a session's chunk count exceeds cg profile's declared maximum session size (6 chunks)
+- **THEN** cg profile SHALL be ineligible for the session, SHALL appear in attempt provenance, and SHALL consume no agent call

--- a/openspec/changes/issue-99-cg-max-session-chunks/tasks.md
+++ b/openspec/changes/issue-99-cg-max-session-chunks/tasks.md
@@ -9,5 +9,5 @@ work_item: issue-99-cg-max-session-chunks
 
 - [x] 先寫測試：比照既有 tier-1 `max_session_chunks` 測試模式，構造 chunk 數超限的 session，斷言 cg 被記 `ineligible`（provenance record 存在、reason 正確）而非實際嘗試呼叫。
 - [x] 先寫測試：chunk 數在限內時 cg 行為不變。
-- [ ] 實作：cg profile 加 `max_session_chunks: 6`（依 issue 實證：6 chunks 內可解析、7+ 不可）；`atomizer.yaml` 與 `default_profiles()` 兩處同步。
-- [ ] 模板同步測試綠；全套綠；`changelog.d/99-cg-max-session-chunks.md`（type: fix）。
+- [x] 實作：cg profile 加 `max_session_chunks: 6`（依 issue 實證：6 chunks 內可解析、7+ 不可）；`atomizer.yaml` 與 `default_profiles()` 兩處同步。
+- [x] 模板同步測試綠；全套綠；`changelog.d/99-cg-max-session-chunks.md`（type: fix）。

--- a/openspec/changes/issue-99-cg-max-session-chunks/tasks.md
+++ b/openspec/changes/issue-99-cg-max-session-chunks/tasks.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: issue-99-cg-max-session-chunks
+---
+
+# cg profile 大 session 停損（max_session_chunks）tasks
+
+## Task 1: cg 宣告 max_session_chunks
+
+- [x] 先寫測試：比照既有 tier-1 `max_session_chunks` 測試模式，構造 chunk 數超限的 session，斷言 cg 被記 `ineligible`（provenance record 存在、reason 正確）而非實際嘗試呼叫。
+- [x] 先寫測試：chunk 數在限內時 cg 行為不變。
+- [ ] 實作：cg profile 加 `max_session_chunks: 6`（依 issue 實證：6 chunks 內可解析、7+ 不可）；`atomizer.yaml` 與 `default_profiles()` 兩處同步。
+- [ ] 模板同步測試綠；全套綠；`changelog.d/99-cg-max-session-chunks.md`（type: fix）。

--- a/paulsha_hippo/agent_profiles.py
+++ b/paulsha_hippo/agent_profiles.py
@@ -483,6 +483,7 @@ def _validate_fallback_on(value: object, field_name: str) -> tuple[str, ...]:
 # unparseable JSON on a >6-chunk session that fell through when tier-1 was
 # still capped at 6).
 _TIER1_MAX_SESSION_CHUNKS = 7
+_CG_MAX_SESSION_CHUNKS = 6
 
 
 def default_profiles() -> tuple[AgentProfile, ...]:
@@ -490,7 +491,7 @@ def default_profiles() -> tuple[AgentProfile, ...]:
         ("claude", 1, 10, ("judge", "reasoner"), ("atomization", "title", "skillopt"), "sonnet", "high", ("medium", "high", "xhigh"), ("claude", "--model", "{MODEL}", "--effort", "{EFFORT}", "--safe-mode", "--disable-slash-commands", "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}', "--tools", "", "--no-session-persistence", "--print"), _TIER1_MAX_SESSION_CHUNKS),
         ("codex", 1, 20, ("judge", "reasoner"), ("atomization", "title", "skillopt"), "gpt-5.6-sol", "high", ("high",), ("codex", "exec", "--model", "{MODEL}", "-c", "model_reasoning_effort=high", "--sandbox", "read-only", "--skip-git-repo-check", "--ephemeral", "--ignore-user-config", "--ignore-rules", "--disable", "shell_tool", "-"), _TIER1_MAX_SESSION_CHUNKS),
         ("agy", 2, 10, ("fast", "responsive"), ("title", "skillopt"), "default", "medium", ("low", "medium", "high"), ("agy", "--model", "{MODEL}", "--effort", "{EFFORT}", "--mode", "plan", "--sandbox", "--print"), None),
-        ("cg", 2, 20, ("heavy-implementation", "fast"), ("atomization", "title", "skillopt"), "default", "high", ("medium", "high", "xhigh"), ("cg", "--model", "{MODEL}", "--effort", "{EFFORT}", "--headless", "--stdin"), None),
+        ("cg", 2, 20, ("heavy-implementation", "fast"), ("atomization", "title", "skillopt"), "default", "high", ("medium", "high", "xhigh"), ("cg", "--model", "{MODEL}", "--effort", "{EFFORT}", "--headless", "--stdin"), _CG_MAX_SESSION_CHUNKS),
         ("co-gem", 3, 10, ("low-cost", "fallback"), ("atomization", "title", "skillopt"), "local", "low", ("low", "medium"), ("co-gem", "--model", "{MODEL}", "--effort", "{EFFORT}", "--headless", "--stdin"), None),
         ("claude-gem", 3, 20, ("low-cost", "fallback"), ("atomization", "title", "skillopt"), "local", "low", ("low", "medium"), ("claude-gem", "--model", "{MODEL}", "--effort", "{EFFORT}", "--headless", "--stdin"), None),
     )

--- a/paulsha_hippo/atomizer/atomizer.yaml
+++ b/paulsha_hippo/atomizer/atomizer.yaml
@@ -73,6 +73,9 @@ external_agents:
       enabled: false
       tier: 2
       priority: 20
+      # issue #99: cg large-session JSON extraction becomes unreliable at 7+ chunks;
+      # stop early and let the next profile take over with ineligible provenance.
+      max_session_chunks: 6
       traits: [heavy-implementation, fast]
       task_classes: [atomization, title, skillopt]
       model: default

--- a/tests/test_atomizer_config.py
+++ b/tests/test_atomizer_config.py
@@ -44,6 +44,7 @@ class TestAtomizerConfig(unittest.TestCase):
         profiles_by_id = {profile.id: profile for profile in cfg.external_profiles}
         self.assertEqual(profiles_by_id["claude"].max_session_chunks, 7)
         self.assertEqual(profiles_by_id["codex"].max_session_chunks, 7)
+        self.assertEqual(profiles_by_id["cg"].max_session_chunks, 6)
 
     def test_override_merges_and_changes_hash(self):
         """Base hash differs after override file with split.max_fragment_chars: 100."""

--- a/tests/test_external_agent_profiles.py
+++ b/tests/test_external_agent_profiles.py
@@ -191,12 +191,62 @@ def test_router_skips_profile_with_oversized_session_without_call():
 
 
 def test_default_profiles_have_max_session_chunks_bounds():
-    """Issue #89: tier-1 max_session_chunks raised 6->7 (1800s cap / 240s ~= 7.5)."""
+    """Issue #89: tier-1 max_session_chunks raised 6->7 (1800s cap / 240s ~= 7.5). Issue #99: cg set to 6."""
     profiles = default_profiles()
     mapping = {profile.id: profile.max_session_chunks for profile in profiles}
     assert mapping["claude"] == 7
     assert mapping["codex"] == 7
-    assert mapping["cg"] is None
+    assert mapping["cg"] == 6
+
+
+def test_default_cg_profile_skips_oversized_session_as_ineligible():
+    """Issue #99: cg profile with >6 session chunks must be marked ineligible."""
+    profiles = {profile.id: profile for profile in default_profiles()}
+    cg = profiles["cg"]
+    cg_enabled = AgentProfile.from_mapping({**vars(cg), "enabled": True})
+    assert cg_enabled.max_session_chunks == 6
+    assert cg_enabled.eligible(task_class="atomization", chunk_count=7) == (False, "session_size")
+
+    fallback = _profile("fallback", tier=3)
+    calls: list[str] = []
+
+    def execute(profile, prompt, call):
+        calls.append(profile.id)
+        return "valid", "", 0
+
+    router = ExternalAgentRouter((cg_enabled, fallback), executor=execute)
+    outputs = router.run_session(tuple(f"chunk-{i}" for i in range(7)))
+
+    assert outputs == ("valid",) * 7
+    assert calls == ["fallback"] * 7
+    assert [a.profile_id for a in router.attempts] == ["cg", "fallback"]
+    assert router.attempts[0].profile_id == "cg"
+    assert router.attempts[0].failure_category == "ineligible"
+
+
+def test_default_cg_profile_eligible_within_max_session_chunks_bound():
+    """Issue #99: cg profile with <=6 session chunks remains eligible and executable when enabled."""
+    profiles = {profile.id: profile for profile in default_profiles()}
+    cg = profiles["cg"]
+    cg_enabled = AgentProfile.from_mapping({**vars(cg), "enabled": True})
+    assert cg_enabled.max_session_chunks == 6
+    assert cg_enabled.eligible(task_class="atomization", chunk_count=6) == (True, "eligible")
+    assert cg_enabled.eligible(task_class="atomization", chunk_count=1) == (True, "eligible")
+
+    calls: list[str] = []
+
+    def execute(profile, prompt, call):
+        calls.append(profile.id)
+        return "valid", "", 0
+
+    router = ExternalAgentRouter((cg_enabled,), executor=execute)
+    outputs = router.run_session(tuple(f"chunk-{i}" for i in range(6)))
+
+    assert outputs == ("valid",) * 6
+    assert calls == ["cg"] * 6
+    assert router.attempts[0].profile_id == "cg"
+    assert router.attempts[0].failure_category is None
+
 
 
 def test_default_profiles_have_three_deterministic_tiers_and_traits():

--- a/tests/test_external_agent_profiles.py
+++ b/tests/test_external_agent_profiles.py
@@ -222,13 +222,23 @@ def test_default_cg_profile_skips_oversized_session_as_ineligible():
     assert [a.profile_id for a in router.attempts] == ["cg", "fallback"]
     assert router.attempts[0].profile_id == "cg"
     assert router.attempts[0].failure_category == "ineligible"
+    # 釘死 provenance reason：ineligible attempt 的 stderr 欄位必須是
+    # session_size——否則在沒裝 cg 二進位的主機上，光靠 "executable"
+    # ineligibility 也能讓上面的 router 斷言通過，測不到 #99 的語意。
+    assert router.attempts[0].stderr == "session_size"
 
 
 def test_default_cg_profile_eligible_within_max_session_chunks_bound():
     """Issue #99: cg profile with <=6 session chunks remains eligible and executable when enabled."""
     profiles = {profile.id: profile for profile in default_profiles()}
     cg = profiles["cg"]
-    cg_enabled = AgentProfile.from_mapping({**vars(cg), "enabled": True})
+    # eligible() 末段會 shutil.which(argv[0])——CI（ubuntu-latest 只 pip
+    # install ".[test]"）沒有 cg 可執行檔，保留預設 argv 會回 (False,
+    # "executable")。比照本檔 _profile/STUB 慣例把 argv 換成 stub，保留
+    # default cg 的 max_session_chunks=6 來驗門檻語意本身。
+    cg_enabled = AgentProfile.from_mapping(
+        {**vars(cg), "enabled": True, "argv": [sys.executable, str(STUB)]}
+    )
     assert cg_enabled.max_session_chunks == 6
     assert cg_enabled.eligible(task_class="atomization", chunk_count=6) == (True, "eligible")
     assert cg_enabled.eligible(task_class="atomization", chunk_count=1) == (True, "eligible")


### PR DESCRIPTION
## 摘要

修 issue #99：`cg` external-agent profile 宣告 `max_session_chunks: 6`。cg（copilot→llm-share 鏈路）在 7+ chunk 的大 session 上 JSON extraction 不可靠——先前流程會先燒一輪約 153s 的 cg 呼叫、以不可解析 JSON 失敗後才 fallback。本變更讓大 session 在 profile eligibility 階段直接記 `ineligible`（`session_size` provenance）並交給下一個 fallback profile，不再空燒。

變更範圍：

- `paulsha_hippo/agent_profiles.py`：新增 `_CG_MAX_SESSION_CHUNKS = 6`，`default_profiles()` 中 `cg` profile 由 `None` 改為宣告上限。
- `paulsha_hippo/atomizer/atomizer.yaml`：出貨模板同步宣告 `max_session_chunks: 6`（附 issue #99 註解），避免模板漂移把停損配置漏出貨。
- `tests/test_external_agent_profiles.py`／`tests/test_atomizer_config.py`：RED 回歸測試 + review 修正（eligible 測試改用 stub argv 免 CI 紅、釘死 `session_size` provenance）。
- planning artifacts（`docs/superpowers/{specs,plans}`、`openspec/changes/issue-99-cg-max-session-chunks`）。

驗證證據：

- `python3 -m pytest -q`：1742 passed, 4 skipped, 184 subtests passed（97.68s，worktree 全套）
- `openspec validate --all --strict`：15 passed, 0 failed
- `python3 -m policy_check --repo .`：fail 0（僅 R-22 既有 26 筆陳年懸空引用 advisory WARN，非本 PR 引入）

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

## 風險與回復

- 純設定／宣告層變更，無資料遷移、無 live deployment 影響；rollback 即 revert 本 PR（兩處宣告與測試一起退）。
- 行為面風險：7+ chunk session 從此不會再由 cg 處理，改走下一個 fallback profile——這正是停損意圖；若 fallback 鏈全空則維持既有 no-eligible-profile 語意，不新增失敗模式。
- 本 PR 為停損版交付；根治（copilot 鏈路大 payload JSON 截斷）另留 issue 追蹤。

Refs #99（停損版交付；根治［copilot 鏈路大 payload JSON 截斷］留 issue 追蹤）
