### PR TITLE
fix(atomize): proposal 未知欄位降級 soft-repair——單一 proposal 的 tags2 不再拖垮整份回應

### DIFF
--- a/changelog.d/105-proposal-soft-repair.md
+++ b/changelog.d/105-proposal-soft-repair.md
@@ -1,2 +1,6 @@
-- type: fix
-  description: proposal unknown fields soft-repaired and dropped instead of failing response
+---
+type: fix
+---
+- 修 issue #105：LLM 回應中單一 proposal 帶 schema 不認得的未知欄位（如 `tags2`）時，`atomizer/llm_output.py::_build_proposal` 原將其併入 hard violation 拋 `LlmOutputError`，整份回應（其餘 N 個合法 proposals）一起判死，fallback 鏈全滅 → session park。未知欄位改降級為 soft violation：決定性丟棄該欄位並記 warning（含 proposal 序號與被丟棄的欄位名，可觀測），其餘 proposal 正常產出。
+- Hard violation 判死語意一條未鬆：缺 `title`、非法 `artifact_kind`、空 `body`、空 `source_fragment_indices` 等仍讓整份回應拋 `LlmOutputError`（防 retry 非決定性遺失 findings 的設計不變量），`_parse_proposals` 的不變量註解同步更新，明示 hard/soft 分界理由——未知欄位丟棄是決定性操作、不產生 retry。
+- 測試補齊三面：soft-repair 後合法 proposals 存活、warning 內容可觀測（欄位名＋序號）、hard violation 逐條列舉仍整份判死。

--- a/changelog.d/105-proposal-soft-repair.md
+++ b/changelog.d/105-proposal-soft-repair.md
@@ -1,0 +1,2 @@
+- type: fix
+  description: proposal unknown fields soft-repaired and dropped instead of failing response

--- a/docs/superpowers/plans/2026-08-04-issue-105-proposal-soft-repair.md
+++ b/docs/superpowers/plans/2026-08-04-issue-105-proposal-soft-repair.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+work_item: issue-105-proposal-soft-repair
+---
+
+# Proposal 未知欄位 soft-repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development——先寫失敗測試再實作。**本檔案守著一條明文設計不變量，修法必須顯式處理它。**
+
+**Goal:** LLM 回應中單一 proposal 帶 schema 不認得的「未知欄位」（如 `tags2`）時，不再讓整份回應（其他 N 個合法 proposal）一起判死——未知欄位屬可安全丟棄的 soft violation，丟棄該欄位（或僅剔除該 proposal）並記 warning；真正的 hard violation 維持整份判死。
+
+**Root cause 位置：** `paulsha_hippo/atomizer/llm_output.py::_build_proposal`（約 L211-267）把 unknown fields 併入 hard-field violation，`_parse_proposals`（L270-283）因而 raise `LlmOutputError` 使整份失效，fallback 鏈全滅 → session park。
+
+**設計不變量（程式碼內明文註解）：** 「一個 proposal 拖垮整份回應」是刻意設計——防止 retry 非決定性遺失 findings。**修法必須二選一：更新該註解並論證縮小失效範圍為何不違反其目的（未知欄位丟棄是決定性操作、不產生 retry），或證明修法沒動到該不變量。不得默默繞過。**
+
+**Target branch:** `feature/105-proposal-soft-repair`
+
+## Global Constraints
+
+- 語言 zh-tw；TDD 先 RED 再實作。
+- 交付治理：`changelog.d/<slug>.md`、pytest／policy_check／openspec strict 全綠、PR checklist 全勾、body `Closes #105`。
+- 這是每輪 dream cycle 必經路徑：**hard violation 的判死語意一條都不能鬆**——缺 title、非法 artifact_kind、型別錯誤等仍須整份 `LlmOutputError`。
+- 全套測試在非巢狀 sibling worktree 跑。
+- commit 前 `rm -rf .psc_tmp`；不要 `git add -A`。
+
+## Task 1: 未知欄位降級為 soft violation
+
+**檔案**：`paulsha_hippo/atomizer/llm_output.py`、`tests/test_llm_output.py`（或既有對應測試檔）
+
+- [ ] 先寫測試：N 個合法 proposal + 1 個帶未知欄位 `tags2` 的回應——修復後不拋 `LlmOutputError`，未知欄位被丟棄（或該 proposal 被剔除並記 warning），其餘 proposal 正常產出。
+- [ ] 先寫測試（不變量保護）：缺 `title`／非法 `artifact_kind` 等 hard violation 仍讓**整份**回應判死——逐一列舉既有 hard 條件為測試案例。
+- [ ] 先寫測試：warning 內容含被丟棄的欄位名與 proposal 序號（可觀測）。
+- [ ] 實作：`_build_proposal` 把 unknown-field 從 hard 清單分離為 soft 處理；更新該設計註解說明分界理由。
+- [ ] 全套綠；`changelog.d/105-proposal-soft-repair.md`（type: fix）。

--- a/docs/superpowers/specs/2026-08-04-issue-105-proposal-soft-repair-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-105-proposal-soft-repair-design.md
@@ -1,0 +1,69 @@
+---
+status: accepted
+work_item: issue-105-proposal-soft-repair
+---
+
+# Proposal 未知欄位 soft-repair（issue #105）設計
+
+- 日期：2026-08-04
+- Issue：[#105](https://github.com/hamanpaul/paulsha-hippo/issues/105)
+- 狀態：已核可，待實作
+
+## 背景
+
+證據與 root cause 見 spec（`docs/superpowers/specs/2026-08-04-issue-105-proposal-soft-repair-spec.md`）。本設計要回答兩個問題：(1) 未知欄位該怎麼分級處理，(2) 既有的「一個 proposal 拖垮整份回應」設計不變量註解要不要動、怎麼動。
+
+`paulsha_hippo/atomizer/llm_output.py::_build_proposal` 目前的分工（docstring 原文）：
+
+> Build one proposal. Hard-field violations fail the whole response; soft issues (unknown project, malformed relation) are repaired in place.
+
+`project`（L240-247）與 `relations`（L249-256）已經是 soft：不合法時 coerce 成 `_unknown` 或丟棄該筆 relation 並記 `_LOG.warning`，不影響整份回應。唯獨 unknown-field 檢查（L218-220）發生在最前面、且直接 raise，尚未納入這個 soft 分工。
+
+`_parse_proposals`（L280-281）內的既有註解：
+
+```python
+# A canonical response is one transaction.  Publishing only the valid
+# subset would make retries non-deterministic and silently lose findings.
+proposals.append(_build_proposal(item, index, allowed_projects, seen_titles))
+```
+
+## Decisions
+
+### D1：未知欄位降級為 soft violation——丟棄該欄位，記 warning，不整份判死
+
+`_build_proposal` 把 unknown-key 檢查從「直接 raise」改為「丟棄該欄位（或剔除該筆 proposal，實作時二擇一並在 PR 說明取捨），記 `_LOG.warning`，繼續驗證該 proposal 其餘欄位」。判斷依據：未知欄位是模型多產出的雜訊（如打錯欄位名、多寫一個 schema 沒有的欄位），與 `project`／`relations` 既有的 soft-repair 性質相同——都是「這一小塊不認得，丟掉即可，不影響其餘欄位語意」，不像缺 `title`／型別錯誤那樣代表整筆 proposal 的核心資料不可信。
+
+實作路徑：在 unknown-key 檢查處，不再 `raise`，而是對 `unknown_keys` 逐一 `_LOG.warning`（含欄位名與 proposal 序號），並在後續欄位存取前先從 `item` 的有效鍵集合中剔除這些未知鍵（或等價地忽略，因為既有欄位存取本就用 `item.get(...)`／`_require_field` 只讀認得的 key，未知鍵本來就不會被讀取——真正需要動的只有「不 raise」與「加 warning」這兩步）。
+
+### D2：既有 hard violation 清單逐條保留，整份判死語意不變
+
+以下情形維持現狀，任一命中仍讓 `_parse_proposals` 對整份回應 raise `LlmOutputError`，不得降級：
+
+- `item` 本身不是 dict（`proposal {index} is not an object`）。
+- `artifact_kind` 不在 `ARTIFACT_KINDS`。
+- `title` 缺漏／空字串／重複。
+- `body` 缺漏／非字串／空字串。
+- `tags` 缺漏／非 list／元素非字串。
+- `source_fragment_indices` 缺漏／非 list／元素非 int／空 list。
+- `relations` 欄位本身缺漏或非 list（注意：這是「`relations` 這個欄位存在與否、型別對不對」的檢查，跟 D1 的「單筆 relation 內容是否合法」是兩層——後者本來就是 soft，前者仍是 hard）。
+
+這條清單直接對應 spec 的 G3／Acceptance，且是 tasks.md 「不變量保護」測試要逐一覆蓋的案例集。
+
+### D3：不變量註解的更新論證——未知欄位丟棄是決定性操作、不產生 retry 非決定性
+
+`_parse_proposals` 現有註解主張「只發佈有效子集會讓 retry 變得非決定性、悄悄遺失 findings」，因此設計為一個 proposal 壞掉、整份回應失效、觸發 retry（由外層 fallback/重跑機制決定下一步）。這條不變量的真正目的是：**不要在同一份回應裡「選擇性發佈」，因為選誰、不選誰若涉及重跑會產生不同結果，讓同一輸入在不同次執行下產出不同的已發佈集合。**
+
+未知欄位丟棄不觸碰這個目的，理由：
+
+1. **丟棄未知欄位是對單一 proposal 內部欄位集合的裁剪，不是「選擇性發佈哪些 proposal」。** 該 proposal 本身仍然完整產出並計入本次回應的 `findings`；被丟棄的只是它裡面一個 schema 不認得的欄位，等同 `project`／`relations` 既有的 soft-repair——兩者都已經在裁剪欄位內容而不影響「這個 proposal 算不算被發佈」。
+2. **這是決定性操作，不觸發 retry。** 同一組輸入（含 `tags2`）每次跑都會被同樣丟棄、同樣記 warning、同樣的其餘欄位驗證結果，不存在「這次選了 A 沒選 B、下次選了 B 沒選 A」的分歧——不變量要防的是「retry 導致不同次選擇不同子集」，而丟棄行為本身是純函數、與 retry 無關。
+3. **N 個合法 proposal 仍然一個不少地整批發佈或整批不發佈**——soft-repair 只改變「單一 proposal 內部欄位集合」，不改變「本次回應的 proposal 集合是否整批成立」。真正的 hard violation（D2 清單）一旦命中，仍然是整份回應失效、交由外層 retry/fallback 處理，不變量在這條路徑上完全未動。
+
+結論：不變量的保護範圍（「不得對回應本身做選擇性子集發佈」）維持不變，本次修法只是把「未知欄位」從誤放的 hard 分類移回它本該屬於的 soft 分類，與既有 `project`／`relations` soft-repair 同層級。`_build_proposal` docstring 與 `_parse_proposals` 註解需同步更新，明文寫出這個分界理由，避免未來讀者誤以為修法繞過了不變量。
+
+## Testing
+
+- 新增：N 合法 + 1 帶未知欄位（如 `tags2`）不再整份 `LlmOutputError`，其餘 proposal 正常產出。
+- 新增（不變量保護）：D2 清單逐條測試，仍整份判死。
+- 新增：warning 內容含欄位名與 proposal 序號，可觀測。
+- 既有：`tests/test_llm_output.py` 全套綠，`project`／`relations` 既有 soft-repair 行為零回歸。

--- a/docs/superpowers/specs/2026-08-04-issue-105-proposal-soft-repair-spec.md
+++ b/docs/superpowers/specs/2026-08-04-issue-105-proposal-soft-repair-spec.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+work_item: issue-105-proposal-soft-repair
+---
+
+# Proposal 未知欄位 soft-repair（issue #105）規格
+
+## Problem and Outcome
+
+`claude-code:805cf9bf-2def-4d50-b643-00762079346c` 這輪（56 fragments，正常量級）claude 有實際跑完並回傳，但 proposal 13 帶了一個 schema 不認得的欄位 `tags2`。`_build_proposal`（`paulsha_hippo/atomizer/llm_output.py:218-220`）目前把「未知欄位」歸類為 hard-field violation：
+
+```python
+unknown_keys = sorted(set(item) - _PROPOSAL_KEYS)
+if unknown_keys:
+    raise LlmOutputError(f"proposal {index} has unknown fields: {', '.join(unknown_keys)}")
+```
+
+這個 raise 發生在 `_parse_proposals`（L270-283）的迴圈裡，一個 proposal 觸發即整份 `LlmOutputError`，導致同一回應裡其他 N 個合法 proposal 全部陪葬；往下四層 fallback（claude → codex → …）跟著耗盡，整輪 session park。
+
+2026-07-31T10:00:33Z 生產實證（`~/.agents/memory/runtime/ledger/processing.jsonl`）：
+
+```
+error: llm promote failed after session attempt(s): external agent fallback exhausted
+(process, exit 4): claude proposal 13 has unknown fields: tags2 | codex exit 1 ...
+```
+
+此輪 park 直接觸發 AR-11 soak 窗口重置（reset 前已累積 1/3 合格輪）。與 #99／#74 同屬「單一 session 打穿四層 fallback、觸發 AR-11 soak 窗口重置」症狀族，但本 issue 根因層在 claude 輸出驗證的容錯設計，不是 payload 過大。
+
+`tags2` 究竟是模型把 `tags` 打錯欄位名、還是在 `tags` 之外多產生一個欄位，現有程式碼路徑無法區分：unknown-key 檢查（L218）發生在其他欄位驗證之前，一撞到就直接 raise，不會繼續往下看 `tags` 本身是否合法存在。是否與同日落地的 #103（tags 正規化）有 prompt/schema 不同步的關聯，目前只是時間點巧合觀察，未證實因果，本次修法不依賴此假設。
+
+預期結果：proposal 帶未知欄位時，該欄位被丟棄（或該 proposal 被剔除）並記可觀測 warning（含欄位名與 proposal 序號），其餘合法 proposal 正常產出、不再整份判死；已存在的 hard violation（缺 `title`、非法 `artifact_kind`、型別錯誤等）語意一條不能鬆——仍整份 `LlmOutputError`。
+
+## Goals
+
+- G1：`_build_proposal` 把「未知欄位」從 hard-field 清單分離為 soft violation——丟棄該欄位（或剔除該 proposal），不再讓 `_parse_proposals` 對整份回應 raise `LlmOutputError`。
+- G2：Soft-repair 產生可觀測 warning，內容含被丟棄的欄位名與 proposal 序號（呼應既有 `project`／`relations` soft-repair 的 log 慣例）。
+- G3：既有 hard violation 語意零回歸——`_require_field`／`_require_non_empty_string`／`_require_list`／`_require_string_list`／`_require_int_list`、`artifact_kind` 檢查、`title` 重複檢查、`body` 空值檢查等仍整份判死，逐一列舉為測試案例。
+- G4：更新 `_build_proposal` docstring 與 `_parse_proposals` 內「一個 proposal 拖垮整份回應」的設計不變量註解，顯式論證縮小失效範圍（未知欄位丟棄）為何不違反其原始目的（見 design.md D3）。
+
+## Non-goals
+
+- 不放寬既有 hard violation 判定範圍（缺 `title`、非法 `artifact_kind`、型別錯誤、重複 `title`、空 `body`、空 `source_fragment_indices` 等）。
+- 不改動 `project`／`relations` 既有的 soft-repair 行為（保持現狀，僅新增 unknown-field 分支）。
+- 不改 canonical response 頂層 schema（`schema_version`／`disposition`／`reason`／`findings`）驗證，本次僅限單一 proposal 內部的欄位驗證分界。
+
+## Acceptance
+
+- N 個合法 proposal + 1 個帶未知欄位（如 `tags2`）的回應：`_parse_proposals` 不拋 `LlmOutputError`，未知欄位被丟棄（或該 proposal 被剔除），其餘 N 個 proposal 正常產出。
+- 既有 hard violation 測試（缺 `title`、非法 `artifact_kind`、型別錯誤等）逐一列舉，仍整份判死。
+- Warning 內容含被丟棄的欄位名與 proposal 序號，可在測試中以 caplog／mock logger 觀測到。
+- 全套 `python3 -m pytest tests/ -q`、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠。

--- a/openspec/changes/issue-105-proposal-soft-repair/design.md
+++ b/openspec/changes/issue-105-proposal-soft-repair/design.md
@@ -1,0 +1,61 @@
+---
+status: accepted
+work_item: issue-105-proposal-soft-repair
+---
+
+# Issue #105 Proposal 未知欄位 soft-repair 設計
+
+- 日期：2026-08-04
+- Issue：[#105](https://github.com/hamanpaul/paulsha-hippo/issues/105)
+- 狀態：已核可，待實作
+
+## 背景
+
+證據與 root cause 見 spec（`docs/superpowers/specs/2026-08-04-issue-105-proposal-soft-repair-spec.md`）。`paulsha_hippo/atomizer/llm_output.py::_build_proposal`（L211-267）目前把未知欄位檢查（L218-220）放在 hard-field 陣營，一撞到就 `raise LlmOutputError`，使 `_parse_proposals`（L270-283）對整份回應失效。既有 `project`（L240-247）與 `relations`（L249-256）已是 soft-repair：不合法時 coerce/丟棄並記 `_LOG.warning`，不影響整份回應。
+
+`_parse_proposals` 內既有設計不變量註解：
+
+```python
+# A canonical response is one transaction.  Publishing only the valid
+# subset would make retries non-deterministic and silently lose findings.
+proposals.append(_build_proposal(item, index, allowed_projects, seen_titles))
+```
+
+## Decisions
+
+### D1：未知欄位降級為 soft violation——丟棄該欄位，記 warning，不判死整份回應
+
+`_build_proposal` 把 unknown-key 檢查從「直接 raise」改為：對每個未知鍵 `_LOG.warning`（含被丟棄的欄位名與 proposal 序號），丟棄後繼續驗證該 proposal 其餘（認得的）欄位。理由：未知欄位是模型多產出的雜訊（打錯欄位名／多寫一個 schema 沒有的欄位），性質與 `project`／`relations` 既有 soft-repair 相同——都是「這一小塊不認得，丟掉即可」，不像缺 `title`／型別錯誤那樣代表整筆 proposal 的核心資料不可信。既有欄位存取（`_require_field`／`item.get(...)`）本就只讀認得的 key，未知鍵原本就不會被讀取，因此本項變更的最小範圍是「不 raise + 加 warning」。
+
+### D2：hard violation 清單逐條保留，整份判死語意不變
+
+以下情形維持現狀，任一命中仍讓 `_parse_proposals` 對整份回應 raise `LlmOutputError`：
+
+- `item` 本身不是 dict。
+- `artifact_kind` 不在 `ARTIFACT_KINDS`。
+- `title` 缺漏／空字串／與既有 `seen_titles` 重複。
+- `body` 缺漏／非字串／空字串。
+- `tags` 缺漏／非 list／元素非字串。
+- `source_fragment_indices` 缺漏／非 list／元素非 int／空 list。
+- `relations` 欄位本身缺漏或非 list（欄位存在性與型別檢查，區別於 D1／既有 soft-repair 處理的「單筆 relation 內容是否合法」）。
+
+這條清單即 tasks.md 「不變量保護」測試要逐一覆蓋的案例集，也是 spec G3／Acceptance 對應的驗收基準。
+
+### D3：不變量註解的更新論證——未知欄位丟棄是決定性操作、不產生 retry 非決定性
+
+`_parse_proposals` 現有註解要防的是「只發佈有效子集會讓 retry 變得非決定性、悄悄遺失 findings」——即不得對回應本身做選擇性子集發佈，因為選誰、不選誰若牽涉重跑會讓同一輸入在不同次執行下產出不同的已發佈集合。
+
+未知欄位丟棄不觸碰這個目的：
+
+1. **這是對單一 proposal 內部欄位集合的裁剪，不是「選擇性發佈哪些 proposal」。** 該 proposal 仍完整計入本次回應的 `findings`，只是裡面一個 schema 不認得的欄位被丟棄——與 `project`／`relations` 既有 soft-repair 同層級，兩者都已在裁剪欄位內容而不影響「這個 proposal 算不算被發佈」。
+2. **這是決定性操作，不觸發 retry。** 同一組輸入（含未知欄位）每次執行都會被同樣丟棄、同樣記 warning、其餘欄位驗證結果同樣穩定——不存在「這次選了 A、下次選了 B」的分歧。不變量要防的是 retry 導致不同次選擇不同子集，丟棄行為本身是純函數、與 retry 無關。
+3. **N 個合法 proposal 仍整批發佈或整批不發佈**——soft-repair 只改變單一 proposal 內部欄位集合，不改變「本次回應的 proposal 集合是否整批成立」。D2 清單命中時仍整份回應失效、交由外層 retry/fallback 處理，不變量在這條路徑上完全未動。
+
+結論：不變量保護的範圍（不得對回應做選擇性子集發佈）維持不變，本次修法只是把「未知欄位」從誤放的 hard 分類移回它本該屬於的 soft 分類。實作時需同步更新 `_build_proposal` docstring 與 `_parse_proposals` 註解，明文寫出這個分界理由。
+
+## Testing
+
+- 新增：N 合法 + 1 帶未知欄位（如 `tags2`）不再整份 `LlmOutputError`，其餘 proposal 正常產出。
+- 新增（不變量保護）：D2 清單逐條測試，仍整份判死。
+- 新增：warning 內容含欄位名與 proposal 序號，可觀測（caplog／mock logger）。
+- 既有：`tests/test_llm_output.py` 全套綠，`project`／`relations` 既有 soft-repair 行為零回歸；`python3 -m pytest tests/ -q`、`python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠。

--- a/openspec/changes/issue-105-proposal-soft-repair/design.md
+++ b/openspec/changes/issue-105-proposal-soft-repair/design.md
@@ -27,6 +27,8 @@ proposals.append(_build_proposal(item, index, allowed_projects, seen_titles))
 
 `_build_proposal` 把 unknown-key 檢查從「直接 raise」改為：對每個未知鍵 `_LOG.warning`（含被丟棄的欄位名與 proposal 序號），丟棄後繼續驗證該 proposal 其餘（認得的）欄位。理由：未知欄位是模型多產出的雜訊（打錯欄位名／多寫一個 schema 沒有的欄位），性質與 `project`／`relations` 既有 soft-repair 相同——都是「這一小塊不認得，丟掉即可」，不像缺 `title`／型別錯誤那樣代表整筆 proposal 的核心資料不可信。既有欄位存取（`_require_field`／`item.get(...)`）本就只讀認得的 key，未知鍵原本就不會被讀取，因此本項變更的最小範圍是「不 raise + 加 warning」。
 
+**邊界記載（legacy `parse()` 多陣列掃描路徑的候選鑑別力放寬）**：`parse()` 會掃描 raw 中所有候選 JSON 陣列並以 `_parse_proposals` 鑑別。未知欄位降級後，「proposal 形狀＋多餘欄位」的陣列不再被 unknown-field raise 淘汰而成為合法競爭者——若 raw 同時含真 proposal 陣列與一個帶額外欄位的 proposal 形狀陣列，結果會從「正常解析前者」變為 `multiple valid JSON arrays found` 整份失敗；掃描淘汰非 proposal 陣列（如 `[{"note": ...}]`）時，也可能先記一筆 unknown-field warning 再因 hard violation（如 `artifact_kind`）被淘汰。此變化僅及 legacy／測試面：生產路徑只走 `parse_response`（`llm_promoter.py` 經嚴格單一 JSON value 解析），不存在多候選競爭，故接受此邊界變化、不另設路徑開關。
+
 ### D2：hard violation 清單逐條保留，整份判死語意不變
 
 以下情形維持現狀，任一命中仍讓 `_parse_proposals` 對整份回應 raise `LlmOutputError`：

--- a/openspec/changes/issue-105-proposal-soft-repair/proposal.md
+++ b/openspec/changes/issue-105-proposal-soft-repair/proposal.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: issue-105-proposal-soft-repair
+---
+
+# Issue #105 Proposal 未知欄位 soft-repair 提案
+
+## Why
+
+`claude-code:805cf9bf-2def-4d50-b643-00762079346c` 這輪（56 fragments，正常量級）claude 有實際跑完並回傳，但 proposal 13 帶了一個 schema 不認得的欄位 `tags2`。`_build_proposal`（`paulsha_hippo/atomizer/llm_output.py:218-220`）目前把「未知欄位」判定為 hard-field violation，直接讓**整份回應**（含其餘 N 個合法 proposal）一起 `LlmOutputError` 失效；往下 fallback 到 codex 也 exit 1 失敗，整輪 session park，並觸發 AR-11 soak 窗口重置（issue #105 comment 佐證：`~/.agents/memory/runtime/ledger/processing.jsonl` 2026-07-31T10:00:33Z）。
+
+`_build_proposal` 既有設計哲學（docstring）：「hard-field 違規讓整份回應失效；soft issue（unknown project、malformed relation）原地修復」。未知欄位目前誤放在 hard 分類，應與 `project`／`relations` 同層級歸為 soft。
+
+程式碼內明文有一條設計不變量註解（`_parse_proposals`，L280-281）：「一個 proposal 拖垮整份回應」是刻意設計，防止 retry 非決定性遺失 findings。本提案必須顯式處理這條不變量，論證未知欄位丟棄為何不違反其目的（見 design.md D3），不得默默繞過。
+
+## What Changes
+
+- `paulsha_hippo/atomizer/llm_output.py::_build_proposal`：把未知欄位（unknown-key）檢查從 hard-field 清單分離為 soft violation——丟棄該欄位，記可觀測 warning（含欄位名與 proposal 序號），不再對 `_parse_proposals` raise `LlmOutputError`。
+- 既有 hard violation 清單（缺 `title`、非法 `artifact_kind`、型別錯誤、重複 `title`、空 `body`、空 `source_fragment_indices` 等）維持整份判死，逐一列舉為回歸測試案例，語意一條不鬆。
+- 更新 `_build_proposal` docstring 與 `_parse_proposals` 內設計不變量註解，顯式論證「未知欄位丟棄是決定性操作、不觸發 retry」為何不違反該不變量原始目的。
+- 新增 `changelog.d/105-proposal-soft-repair.md`（type: fix）。
+
+## Impact
+
+- 影響範圍：`paulsha_hippo/atomizer/llm_output.py` 的 proposal 解析路徑（`_build_proposal`／`_parse_proposals`）；不影響頂層 canonical response schema（`schema_version`／`disposition`／`reason`）驗證，不影響 `project`／`relations` 既有 soft-repair 行為。
+- 風險：低——只新增一個 soft 分支並收斂哪些欄位可被裁剪，既有 hard violation 判定範圍不變、有逐條回歸測試鎖定。
+- 生產效益：避免單一 proposal 的一次幻覺欄位拖垮同一回應裡其他所有 proposal，減少 session park 與 AR-11 soak 窗口重置的誤觸發。
+- Authority：`docs/superpowers/plans/2026-08-04-issue-105-proposal-soft-repair.md`、spec/design 同名對（`docs/superpowers/specs/2026-08-04-issue-105-proposal-soft-repair-{spec,design}.md`）、issue #105。

--- a/openspec/changes/issue-105-proposal-soft-repair/proposal.md
+++ b/openspec/changes/issue-105-proposal-soft-repair/proposal.md
@@ -23,6 +23,7 @@ work_item: issue-105-proposal-soft-repair
 ## Impact
 
 - 影響範圍：`paulsha_hippo/atomizer/llm_output.py` 的 proposal 解析路徑（`_build_proposal`／`_parse_proposals`）；不影響頂層 canonical response schema（`schema_version`／`disposition`／`reason`）驗證，不影響 `project`／`relations` 既有 soft-repair 行為。
+- 邊界（legacy `parse()` 多陣列掃描路徑）：「proposal 形狀＋多餘欄位」的陣列不再被 unknown-field raise 淘汰而成為合法競爭者，raw 同時含真 proposal 陣列與此類陣列時會改判 `multiple valid JSON arrays found`；掃描淘汰非 proposal 陣列時也可能先記一筆 unknown-field warning。僅及 legacy／測試面，生產路徑只走 `parse_response`（嚴格單一 JSON value）不受影響——詳見 design.md D1 邊界記載。
 - 風險：低——只新增一個 soft 分支並收斂哪些欄位可被裁剪，既有 hard violation 判定範圍不變、有逐條回歸測試鎖定。
 - 生產效益：避免單一 proposal 的一次幻覺欄位拖垮同一回應裡其他所有 proposal，減少 session park 與 AR-11 soak 窗口重置的誤觸發。
 - Authority：`docs/superpowers/plans/2026-08-04-issue-105-proposal-soft-repair.md`、spec/design 同名對（`docs/superpowers/specs/2026-08-04-issue-105-proposal-soft-repair-{spec,design}.md`）、issue #105。

--- a/openspec/changes/issue-105-proposal-soft-repair/specs/stage2-llm-distillation/spec.md
+++ b/openspec/changes/issue-105-proposal-soft-repair/specs/stage2-llm-distillation/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Explicit canonical LLM disposition
+
+The canonical response SHALL be exactly an object with fields `schema_version`, `disposition`, `reason`, and `findings`. `schema_version` SHALL equal `1`; `disposition` SHALL be either `findings` or `no_findings`; unknown fields on the canonical wrapper object and surrounding non-whitespace noise SHALL be invalid. `findings` SHALL contain one or more valid proposals and use `reason=null`. A proposal with a hard schema violation — missing or blank `title`, invalid `artifact_kind`, wrong field type, empty `body`, or empty `source_fragment_indices` — SHALL invalidate the entire response rather than publish a salvageable subset, because retrying a partially published response would non-deterministically lose findings. An unknown field on an individual proposal SHALL instead be a soft violation: the field SHALL be dropped deterministically, a warning naming the proposal index and the dropped field names SHALL be recorded for observability, the remaining fields of that proposal and every other proposal SHALL still be validated and produced, and the drop MUST NOT consume a retry or trigger fallback. When the source session has a known project, that pinned source project SHALL override model re-homing. `no_findings` SHALL contain an empty findings list and a non-empty reason. During one compatibility version, a non-empty legacy proposal array MAY be accepted. A legacy empty array, empty wrapper, empty stdout, malformed type, or unknown wrapper field SHALL be invalid and MUST NOT produce `promoted`.
+
+`promoted` SHALL require `accepted_slices >= 1`. Only explicit successful `no_findings` responses from every chunk MAY terminate with zero slices, using the distinct terminal state `no-findings` and retaining the reasons.
+
+Parked evidence SHALL retain only structured failure metadata plus the byte count and SHA-256 of invalid model stdout; it MUST NOT persist the stdout text because a backend can echo private prompt content. Each chunk attempt SHALL clear any previous chunk's in-memory stdout before execution.
+
+#### Scenario: Empty legacy array is invalid
+- **WHEN** the backend returns `[]` or a wrapper containing an empty findings array without an explicit `no_findings` disposition and reason
+- **THEN** the attempt SHALL consume the bounded invalid-output retry path and MUST NOT record `promoted`
+
+#### Scenario: Explicit no-findings terminates without a slice
+- **WHEN** every chunk returns a valid `no_findings` response with a non-empty reason
+- **THEN** the session SHALL enter terminal `no-findings`, archive its fragments, and never create a zero-slice promoted record
+
+#### Scenario: Unknown proposal field is soft-repaired without killing the response
+- **WHEN** a response contains valid proposals plus one proposal that carries a schema-unknown field such as `tags2`
+- **THEN** the unknown field SHALL be dropped deterministically with a warning naming the proposal index and the dropped field names, and every proposal — including the repaired one — SHALL be produced without invalidating the response
+
+#### Scenario: Hard proposal violation still invalidates the entire response
+- **WHEN** any proposal in a response is missing `title`, has an invalid `artifact_kind`, an empty `body`, or an empty `source_fragment_indices`
+- **THEN** the entire response SHALL be invalid, no proposal from that response SHALL be published, and the attempt SHALL follow the bounded retry/park path

--- a/openspec/changes/issue-105-proposal-soft-repair/tasks.md
+++ b/openspec/changes/issue-105-proposal-soft-repair/tasks.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+work_item: issue-105-proposal-soft-repair
+---
+
+# Proposal 未知欄位 soft-repair tasks
+
+依 TDD：每個實作任務前先落紅燈測試。測試置於 `tests/test_llm_output.py`。
+
+## Task 1: 未知欄位降級為 soft violation
+
+- [x] 先寫測試：N 個合法 proposal + 1 個帶未知欄位 `tags2` 的回應——修復後不拋 `LlmOutputError`，未知欄位被丟棄（或該 proposal 被剔除並記 warning），其餘 proposal 正常產出。
+- [x] 先寫測試（不變量保護）：缺 `title`／非法 `artifact_kind` 等 hard violation 仍讓**整份**回應判死——逐一列舉既有 hard 條件為測試案例。
+- [x] 先寫測試：warning 內容含被丟棄的欄位名與 proposal 序號（可觀測）。
+- [ ] 實作：`_build_proposal` 把 unknown-field 從 hard 清單分離為 soft 處理；更新該設計註解說明分界理由。
+- [ ] 全套綠；`changelog.d/105-proposal-soft-repair.md`（type: fix）。

--- a/openspec/changes/issue-105-proposal-soft-repair/tasks.md
+++ b/openspec/changes/issue-105-proposal-soft-repair/tasks.md
@@ -12,5 +12,5 @@ work_item: issue-105-proposal-soft-repair
 - [x] 先寫測試：N 個合法 proposal + 1 個帶未知欄位 `tags2` 的回應——修復後不拋 `LlmOutputError`，未知欄位被丟棄（或該 proposal 被剔除並記 warning），其餘 proposal 正常產出。
 - [x] 先寫測試（不變量保護）：缺 `title`／非法 `artifact_kind` 等 hard violation 仍讓**整份**回應判死——逐一列舉既有 hard 條件為測試案例。
 - [x] 先寫測試：warning 內容含被丟棄的欄位名與 proposal 序號（可觀測）。
-- [ ] 實作：`_build_proposal` 把 unknown-field 從 hard 清單分離為 soft 處理；更新該設計註解說明分界理由。
-- [ ] 全套綠；`changelog.d/105-proposal-soft-repair.md`（type: fix）。
+- [x] 實作：`_build_proposal` 把 unknown-field 從 hard 清單分離為 soft 處理；更新該設計註解說明分界理由。
+- [x] 全套綠；`changelog.d/105-proposal-soft-repair.md`（type: fix）。

--- a/paulsha_hippo/atomizer/llm_output.py
+++ b/paulsha_hippo/atomizer/llm_output.py
@@ -212,13 +212,14 @@ def _build_proposal(
     item: Any, index: int, allowed_projects: set[str], seen_titles: set[str]
 ) -> SliceProposal:
     """Build one proposal. Hard-field violations fail the whole response;
-    soft issues (unknown project, malformed relation) are repaired in place."""
+    soft issues (unknown top-level fields, unknown project, malformed
+    relations) are repaired/dropped in place deterministically."""
     if not isinstance(item, dict):
         raise LlmOutputError(f"proposal {index} is not an object")
     unknown_keys = sorted(set(item) - _PROPOSAL_KEYS)
     if unknown_keys:
         _LOG.warning(
-            "atomizer: proposal %s dropped unknown field(s): %s",
+            "atomize: proposal %s dropped unknown field(s): %s",
             index,
             ", ".join(unknown_keys),
         )

--- a/paulsha_hippo/atomizer/llm_output.py
+++ b/paulsha_hippo/atomizer/llm_output.py
@@ -217,7 +217,11 @@ def _build_proposal(
         raise LlmOutputError(f"proposal {index} is not an object")
     unknown_keys = sorted(set(item) - _PROPOSAL_KEYS)
     if unknown_keys:
-        raise LlmOutputError(f"proposal {index} has unknown fields: {', '.join(unknown_keys)}")
+        _LOG.warning(
+            "atomizer: proposal %s dropped unknown field(s): %s",
+            index,
+            ", ".join(unknown_keys),
+        )
 
     artifact_kind = item.get("artifact_kind")
     if artifact_kind not in ARTIFACT_KINDS:
@@ -277,8 +281,11 @@ def _parse_proposals(data: Any, known_projects: list[str]) -> list[SliceProposal
     proposals: list[SliceProposal] = []
     seen_titles: set[str] = set()
     for index, item in enumerate(data):
-        # A canonical response is one transaction.  Publishing only the valid
-        # subset would make retries non-deterministic and silently lose findings.
+        # A canonical response is one transaction for hard schema violations.
+        # Hard violations (missing title, invalid artifact_kind, bad type) fail
+        # the whole response to avoid non-deterministic retry and silent loss of findings.
+        # Soft issues (unknown top-level fields, unknown project, malformed relations)
+        # are safely repaired/dropped deterministically without triggering retries.
         proposals.append(_build_proposal(item, index, allowed_projects, seen_titles))
     return proposals
 

--- a/tests/test_llm_output.py
+++ b/tests/test_llm_output.py
@@ -274,7 +274,7 @@ class LlmOutputTests(unittest.TestCase):
         log_output = "\n".join(cm.output)
         self.assertIn("tags2", log_output)
         self.assertIn("unknown_field", log_output)
-        self.assertIn("1", log_output)
+        self.assertIn("proposal 1", log_output)
 
     def test_hard_field_violations_fail_entire_response_as_a_whole(self):
         hard_cases = [

--- a/tests/test_llm_output.py
+++ b/tests/test_llm_output.py
@@ -242,13 +242,99 @@ class LlmOutputTests(unittest.TestCase):
         with self.assertRaises(llm_output.LlmOutputError):
             llm_output.parse(raw, PROJECTS)
 
-    def test_unknown_top_level_fields_raise(self):
+    def test_unknown_top_level_fields_soft_repaired_and_dropped(self):
         raw = (
             '[{"title":"a","artifact_kind":"report","project":"paulshaclaw","tags":[],"body":"b",'
             '"source_fragment_indices":[0],"relations":[],"extra":"x"}]'
         )
-        with self.assertRaises(llm_output.LlmOutputError):
-            llm_output.parse(raw, PROJECTS)
+        proposals = llm_output.parse(raw, PROJECTS)
+        self.assertEqual(len(proposals), 1)
+        self.assertEqual(proposals[0].title, "a")
+
+    def test_unknown_top_level_field_dropped_with_warning_and_proposals_survive(self):
+        raw = json.dumps(
+            [
+                _proposal_payload("valid1"),
+                {
+                    "title": "valid2",
+                    "artifact_kind": "report",
+                    "project": "paulshaclaw",
+                    "tags": ["t"],
+                    "body": "body-valid2",
+                    "source_fragment_indices": [1],
+                    "relations": [],
+                    "tags2": ["extra_tag"],
+                    "unknown_field": 123,
+                },
+            ]
+        )
+        with self.assertLogs("paulsha_hippo.atomizer", level="WARNING") as cm:
+            proposals = llm_output.parse(raw, PROJECTS)
+        self.assertEqual([p.title for p in proposals], ["valid1", "valid2"])
+        log_output = "\n".join(cm.output)
+        self.assertIn("tags2", log_output)
+        self.assertIn("unknown_field", log_output)
+        self.assertIn("1", log_output)
+
+    def test_hard_field_violations_fail_entire_response_as_a_whole(self):
+        hard_cases = [
+            # missing title
+            [
+                _proposal_payload("valid"),
+                {
+                    "artifact_kind": "report",
+                    "project": "paulshaclaw",
+                    "tags": [],
+                    "body": "b",
+                    "source_fragment_indices": [1],
+                    "relations": [],
+                },
+            ],
+            # invalid artifact_kind
+            [
+                _proposal_payload("valid"),
+                {
+                    "title": "bad_kind",
+                    "artifact_kind": "invalid_kind",
+                    "project": "paulshaclaw",
+                    "tags": [],
+                    "body": "b",
+                    "source_fragment_indices": [1],
+                    "relations": [],
+                },
+            ],
+            # empty body
+            [
+                _proposal_payload("valid"),
+                {
+                    "title": "bad_body",
+                    "artifact_kind": "report",
+                    "project": "paulshaclaw",
+                    "tags": [],
+                    "body": "   ",
+                    "source_fragment_indices": [1],
+                    "relations": [],
+                },
+            ],
+            # empty source_fragment_indices
+            [
+                _proposal_payload("valid"),
+                {
+                    "title": "bad_indices",
+                    "artifact_kind": "report",
+                    "project": "paulshaclaw",
+                    "tags": [],
+                    "body": "b",
+                    "source_fragment_indices": [],
+                    "relations": [],
+                },
+            ],
+        ]
+        for idx, payload in enumerate(hard_cases):
+            with self.subTest(case=idx):
+                raw = json.dumps(payload)
+                with self.assertRaises(llm_output.LlmOutputError):
+                    llm_output.parse(raw, PROJECTS)
 
     def test_non_object_relation_is_dropped(self):
         raw = (


### PR DESCRIPTION
## 摘要

修 issue #105：LLM 回應中單一 proposal 帶 schema 不認得的未知欄位（如 `tags2`）時，`atomizer/llm_output.py::_build_proposal` 原本將其併入 hard violation 拋 `LlmOutputError`，導致整份回應（其餘 N 個合法 proposals）一起判死、fallback 鏈全滅 → session park。本 PR 將未知欄位降級為 soft violation：決定性丟棄該欄位並記 warning（含 proposal 序號與被丟棄的欄位名，可觀測），其餘 proposals 正常產出。

Hard violation 判死語意一條未鬆：缺 `title`、非法 `artifact_kind`、空 `body`、空 `source_fragment_indices` 等仍讓整份回應拋 `LlmOutputError`（防 retry 非決定性遺失 findings 的設計不變量）。`_parse_proposals` 的不變量註解同步更新，明示 hard/soft 分界理由。隨附 openspec change（`issue-105-proposal-soft-repair`）補 `stage2-llm-distillation` spec delta，拆分 proposal 層 unknown-field soft violation 與 hard violation 整份判死語意。

驗證證據（worktree 本機實跑）：
- `python3 -m pytest -q`：**1742 passed, 4 skipped, 188 subtests passed**（96.75s），無任何失敗
- `openspec validate --all --strict`：**15 passed, 0 failed**
- `python3 -m policy_check --repo .`：**fail 0**（唯一 warn 為 R-22 陳年懸空引用 advisory，26 筆皆 pre-existing，與本 PR 無關）
- 測試補齊三面：soft-repair 後合法 proposals 存活、warning 內容可觀測（欄位名＋序號）、hard violation 逐條列舉仍整份判死

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

## 風險與回復

- 無資料遷移、無 live deployment 影響：變更侷限於 `atomizer/llm_output.py` 的 proposal 解析路徑，行為變化僅「未知欄位從整份判死改為決定性丟棄＋warning」。
- Rollback：revert 本 squash commit 即回復原 hard violation 行為，無殘留狀態。
- 已知邊界：legacy `parse()` 路徑不在本次 soft-repair 範圍，已於 docstring 記載（review 修正 commit e380f6b）。

Closes #105
