### PR TITLE
fix(router): deadline 提前 break 時對被跳過 profile 補記 skipped provenance

### DIFF
--- a/changelog.d/106-router-skip-provenance.md
+++ b/changelog.d/106-router-skip-provenance.md
@@ -1,4 +1,5 @@
 ---
 type: fix
 ---
-- RouterState 主迴圈因 session_deadline 提前 break 時，剩餘 enabled 且 task_class 匹配的 profiles 補記 skipped/ineligible provenance 記錄，attempts_detail 不再憑空遺漏 profiles。
+- RouterState 主迴圈因鏈預算耗盡提前 break 時（pre-attempt deadline check 補 `session_deadline`、attempt 中途 deadline/call-budget 耗盡補 `session_budget`），剩餘 enabled 且 task_class 匹配的 profiles 補記 skipped/ineligible provenance 記錄，attempts_detail 不再憑空遺漏 profiles；circuit-open 的剩餘 profile 維持無聲跳過不補記。
+- exhausted raise 的 category/profile_id/exit_code/stderr 錨定最後一筆真實 attempt（不受合成 skip 記錄影響），park 行為與修復前完全一致；skip 補記可使 attempts 長度超過 max_attempts，屬明文預期語意。

--- a/changelog.d/106-router-skip-provenance.md
+++ b/changelog.d/106-router-skip-provenance.md
@@ -1,0 +1,4 @@
+---
+type: fix
+---
+- RouterState 主迴圈因 session_deadline 提前 break 時，剩餘 enable 且 task_class 匹配的 profiles 補記 skipped/ineligible provenance 記錄，避免 attempts_detail 不再憑空遺漏 profiles。

--- a/changelog.d/106-router-skip-provenance.md
+++ b/changelog.d/106-router-skip-provenance.md
@@ -1,4 +1,4 @@
 ---
 type: fix
 ---
-- RouterState 主迴圈因 session_deadline 提前 break 時，剩餘 enable 且 task_class 匹配的 profiles 補記 skipped/ineligible provenance 記錄，避免 attempts_detail 不再憑空遺漏 profiles。
+- RouterState 主迴圈因 session_deadline 提前 break 時，剩餘 enabled 且 task_class 匹配的 profiles 補記 skipped/ineligible provenance 記錄，attempts_detail 不再憑空遺漏 profiles。

--- a/docs/superpowers/plans/2026-08-04-issue-106-router-skipped-profile-provenance.md
+++ b/docs/superpowers/plans/2026-08-04-issue-106-router-skipped-profile-provenance.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+work_item: issue-106-router-skipped-profile-provenance
+---
+
+# Router deadline 提前 break 的 profile provenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development——先寫失敗測試再實作。**本檔案是全 repo dispatch 熱路徑，改動範圍必須最小。**
+
+**Goal:** session 鏈預算被慢速 tier-1 吃掉、`RouterState` 主迴圈提前 `break` 時，被跳過的後段 profile 仍留下一筆 provenance 記錄（比照既有 `eligible=False` 記錄樣式），`attempts_detail` 不再「憑空少 profile」。
+
+**Root cause 位置：** `paulsha_hippo/agent_profiles.py::RouterState` 主迴圈（約 L888-905）`time.monotonic() - started >= session_deadline` 判斷在進入下一個 profile 之前先 `break`，未記任何 ineligible/skipped 記錄。
+
+**Target branch:** `feature/106-router-skip-provenance`
+
+## Global Constraints
+
+- 語言 zh-tw；TDD 先 RED 再實作。
+- 交付治理：`changelog.d/<slug>.md`、pytest／policy_check／openspec strict 全綠、PR checklist 全勾、body `Closes #106`。
+- **絕對最小 diff**：只補 provenance 記錄，**不得改變** dispatch 順序、deadline 算式、fallback 語意、park 行為。`FALLBACK_ON` allowlist 不可動。任何行為面（而非觀測面）的改變即為超範圍。
+- 不得放寬 `FIXED_TIMEOUT_SECONDS`。
+- 全套測試在非巢狀 sibling worktree 跑。
+- commit 前 `rm -rf .psc_tmp`；不要 `git add -A`。
+
+## Task 1: 提前 break 時補記 skipped provenance
+
+**檔案**：`paulsha_hippo/agent_profiles.py`、`tests/test_external_agent_profiles.py`
+
+- [ ] 先寫測試：stub executor 構造 profile 鏈 [claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]，斷言 break 後 attempts/provenance 含所有 enabled 且 task_class 匹配的 profile——被跳過者各有一筆記錄（建議 reason 沿用既有 ineligible 分類體系，如 `session_deadline`；不新增 fallback category）。
+- [ ] 先寫測試：預算充足時記錄行為與現行完全一致（回歸保護）。
+- [ ] 實作：break 前對剩餘 eligible profiles 逐一 append 一筆 skipped/ineligible 記錄，樣式比照緊鄰的 `eligible=False` pattern。
+- [ ] 全套綠；`changelog.d/106-router-skip-provenance.md`（type: fix）。

--- a/docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-design.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+work_item: issue-106-router-skipped-profile-provenance
+---
+
+# Router deadline 提前 break 遺失 profile provenance（issue #106）設計
+
+- 日期：2026-08-04
+- Issue：[#106](https://github.com/hamanpaul/paulsha-hippo/issues/106)
+- 狀態：已核可，待實作
+
+## 背景
+
+證據與 root cause 見 spec（`docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-spec.md`）。本設計唯一要決定的是：break 前要補記什麼樣的 provenance、reason 怎麼分類、以及如何確保零行為回歸。
+
+## Decisions
+
+### D1：break 前，比照緊鄰的 `eligible=False` pattern，逐一為剩餘 profile 補一筆 skipped provenance
+
+`RouterState` 主迴圈既有的 `eligible=False` 分支（約 L906-924）已經示範了正確樣式：對「enabled 且 task_class 相符，但無法執行」的 profile 追加一筆 `AgentRunResult(..., model_verification="unavailable", failure_category="ineligible", stderr=sanitize_stderr(reason), ...)`，`elapsed_seconds=0.0`、不消耗 agent call。`time.monotonic() - started >= session_deadline` 觸發 `break` 時，改為先對 `self.profiles` 中尚未走到、且 `profile.enabled and self.task_class in profile.task_classes` 為真的每一個 profile，依同一 `AgentRunResult` 建構樣式各 append 一筆記錄，再執行原本的 `break`。已經因為 circuit breaker（`_circuit_open_until`）而被 `continue` 跳過的 profile 維持原樣不受影響——本決策只處理「deadline 提前 break」這一種消失路徑。
+
+### D2：reason 沿用既有 ineligible 分類體系，不新增 fallback category
+
+`profile.eligible()` 已有 `session_size` / `context_budget` / `disabled` / `task_class` 等 reason 字串，`failure_category` 統一是 `"ineligible"`（不是 `classify_failure()` 的 `FALLBACK_ON` 分類）。新記錄比照這個既有體系，補一個新的 reason 字串（例如 `"session_deadline"`）標示「因鏈預算耗盡而未被嘗試」，`failure_category` 仍填 `"ineligible"`。**不**把這個 reason 加進 `FALLBACK_ON` / `ALLOWED_FALLBACK_CATEGORIES`——它不是一個可以觸發 fallback 判斷的失敗分類，只是 provenance 上的一個標記值，`classify_failure()` 的邏輯與 allowlist 維持零改動。
+
+### D3：行為面零改變，只補觀測
+
+本次修復不得改變：dispatch 順序（`for profile in self.profiles` 迭代順序不變）、`session_deadline_seconds()` / `effective_max_agent_calls()` 算式、`FIXED_TIMEOUT_SECONDS` / `FIXED_SESSION_DEADLINE_SECONDS`、fallback 語意（`FALLBACK_ON` allowlist 不動）、park 行為（`_raise_exhausted` 的觸發條件與內容不變，只是 `attempts` 列表在傳入前多了幾筆 skipped 記錄）。新增的 provenance 記錄消耗 `elapsed_seconds=0.0` 且不遞增 `calls`，因此不影響 `len(attempts) >= self.max_attempts` 或 `calls >= session_call_budget` 的既有判斷時序——這些記錄是在迴圈即將 `break` 之後、函式返回之前一次性補齊，不會讓迴圈多繞一圈。預算充足、迴圈正常走到最後一個 profile 而不觸發 deadline break 的既有情境，程式路徑完全不經過這段新增程式碼，因此零回歸。
+
+## Testing
+
+- 新增：模擬鏈 `[claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]`，斷言 break 後 `attempts` 對應所有 enabled+task_class 相符 profile，被跳過者各有一筆 `failure_category="ineligible"` 記錄。
+- 新增：預算充足時記錄行為與現行完全一致（回歸保護鎖）。
+- 既有：`tests/test_external_agent_profiles.py` 全套綠；全套 pytest、`policy_check`、`openspec validate --all --strict` 綠。

--- a/docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-design.md
@@ -15,20 +15,35 @@ work_item: issue-106-router-skipped-profile-provenance
 
 ## Decisions
 
-### D1：break 前，比照緊鄰的 `eligible=False` pattern，逐一為剩餘 profile 補一筆 skipped provenance
+### D1：兩條 break 路徑都比照緊鄰的 `eligible=False` pattern，逐一為剩餘 profile 補一筆 skipped provenance；circuit-open 的剩餘 profile 不補記
 
-`RouterState` 主迴圈既有的 `eligible=False` 分支（約 L906-924）已經示範了正確樣式：對「enabled 且 task_class 相符，但無法執行」的 profile 追加一筆 `AgentRunResult(..., model_verification="unavailable", failure_category="ineligible", stderr=sanitize_stderr(reason), ...)`，`elapsed_seconds=0.0`、不消耗 agent call。`time.monotonic() - started >= session_deadline` 觸發 `break` 時，改為先對 `self.profiles` 中尚未走到、且 `profile.enabled and self.task_class in profile.task_classes` 為真的每一個 profile，依同一 `AgentRunResult` 建構樣式各 append 一筆記錄，再執行原本的 `break`。已經因為 circuit breaker（`_circuit_open_until`）而被 `continue` 跳過的 profile 維持原樣不受影響——本決策只處理「deadline 提前 break」這一種消失路徑。
+`RouterState` 主迴圈既有的 `eligible=False` 分支已經示範了正確樣式：對「enabled 且 task_class 相符，但無法執行」的 profile 追加一筆 `AgentRunResult(..., model_verification="unavailable", failure_category="ineligible", stderr=sanitize_stderr(reason), ...)`，`elapsed_seconds=0.0`、不消耗 agent call。補記邏輯抽成 `_record_skipped_profiles()` helper，覆蓋兩條「鏈預算耗盡致 profile 消失」的路徑：
+
+1. **Top-of-loop deadline break**：`time.monotonic() - started >= session_deadline` 成立時，先對 `self.profiles` 中尚未走到的剩餘 profile 補記（reason `session_deadline`），再執行原本的 `break`。
+2. **Bottom break on `budget`**：deadline 或 call budget 在 attempt 中途耗盡時，chunk 迴圈 raise `category="budget"`（NON_FALLBACK → 底部 break）——多 chunk session 為生產常態，此路徑真實可達。此時同樣對剩餘 profile 補記（reason `session_budget`）。其他 non-fallback category（如 `policy`）是 per-profile 的鏈終止決策，不屬於「鏈預算耗盡」，維持原樣不補記。
+
+**circuit-open 這一格的明確決策**：補記時逐一檢查 `_circuit_open_until`——circuit 尚開著的剩餘 profile **不補記**。主迴圈對 circuit-open profile 本來就是無聲 `continue`（零記錄），該 profile 就算預算充足也不會被嘗試；補一筆 `session_deadline` 會造成同一狀態在兩條路徑下 provenance 不一致、且記錄語意失真。已經因 circuit breaker 被 `continue` 跳過（在迴圈行進中）的 profile 同樣維持原樣不受影響。
 
 ### D2：reason 沿用既有 ineligible 分類體系，不新增 fallback category
 
-`profile.eligible()` 已有 `session_size` / `context_budget` / `disabled` / `task_class` 等 reason 字串，`failure_category` 統一是 `"ineligible"`（不是 `classify_failure()` 的 `FALLBACK_ON` 分類）。新記錄比照這個既有體系，補一個新的 reason 字串（例如 `"session_deadline"`）標示「因鏈預算耗盡而未被嘗試」，`failure_category` 仍填 `"ineligible"`。**不**把這個 reason 加進 `FALLBACK_ON` / `ALLOWED_FALLBACK_CATEGORIES`——它不是一個可以觸發 fallback 判斷的失敗分類，只是 provenance 上的一個標記值，`classify_failure()` 的邏輯與 allowlist 維持零改動。
+`profile.eligible()` 已有 `session_size` / `context_budget` / `disabled` / `task_class` 等 reason 字串，`failure_category` 統一是 `"ineligible"`（不是 `classify_failure()` 的 `FALLBACK_ON` 分類）。新記錄比照這個既有體系，補兩個新的 reason 字串：`"session_deadline"`（pre-attempt deadline check 觸發）與 `"session_budget"`（attempt 中途 deadline / call budget 耗盡觸發），標示「因鏈預算耗盡而未被嘗試」，`failure_category` 仍填 `"ineligible"`。**不**把這些 reason 加進 `FALLBACK_ON` / `ALLOWED_FALLBACK_CATEGORIES`——它們不是可以觸發 fallback 判斷的失敗分類，只是 provenance 上的標記值，`classify_failure()` 的邏輯與 allowlist 維持零改動。
 
-### D3：行為面零改變，只補觀測
+### D3：行為面零改變，只補觀測——raise 內容錨定 terminal 真實 attempt
 
-本次修復不得改變：dispatch 順序（`for profile in self.profiles` 迭代順序不變）、`session_deadline_seconds()` / `effective_max_agent_calls()` 算式、`FIXED_TIMEOUT_SECONDS` / `FIXED_SESSION_DEADLINE_SECONDS`、fallback 語意（`FALLBACK_ON` allowlist 不動）、park 行為（`_raise_exhausted` 的觸發條件與內容不變，只是 `attempts` 列表在傳入前多了幾筆 skipped 記錄）。新增的 provenance 記錄消耗 `elapsed_seconds=0.0` 且不遞增 `calls`，因此不影響 `len(attempts) >= self.max_attempts` 或 `calls >= session_call_budget` 的既有判斷時序——這些記錄是在迴圈即將 `break` 之後、函式返回之前一次性補齊，不會讓迴圈多繞一圈。預算充足、迴圈正常走到最後一個 profile 而不觸發 deadline break 的既有情境，程式路徑完全不經過這段新增程式碼，因此零回歸。
+本次修復不得改變：dispatch 順序（`for profile in self.profiles` 迭代順序不變）、`session_deadline_seconds()` / `effective_max_agent_calls()` 算式、`FIXED_TIMEOUT_SECONDS` / `FIXED_SESSION_DEADLINE_SECONDS`、fallback 語意（`FALLBACK_ON` allowlist 不動）、park 行為。
+
+**park 行為不變的機制**：`_raise_exhausted` 原本從 `attempts[-1]` 取 raise 的 `category` / `profile_id` / `exit_code` / `stderr`，但補記後列表尾端可能是合成的 skip 記錄——若直接沿用，timeout 會被翻成 ineligible，下游 `llm_promoter` 的 category 映射（transient ↔ backend_unavailable）與 park 落盤的 failure_category 全部跟著翻。因此 `run_session` 全程追蹤 `terminal`（最後一筆**真實** attempt 記錄：實際執行過的 attempt 或既有 `eligible=False` ineligible 記錄），並顯式傳入 `_raise_exhausted(attempts, terminal)`；`_raise_exhausted` 未收到顯式參數時預設仍取 `attempts[-1]`（pre-#106 呼叫形狀）。`self.attempts` 保留含 skip 的完整列表供 provenance，raise 的內容一律取自 terminal——provenance 變多，錯誤本身不變。
+
+**max_attempts 上限的明文語意**：skip 記錄是在迴圈已決定 `break` 之後一次性補齊，不經過 top-of-loop 的 `len(attempts) >= self.max_attempts` 判斷，因此 **`attempts` 列表長度可以超過 `max_attempts`**（例：max_attempts=3、4-profile 鏈在第 1 筆後 deadline break → 1 真實 + 3 skip = 4 筆）。這是預期語意，非 bug：skip 記錄純屬 provenance，不消耗 agent call；park 訊息「after N bounded chunk attempt(s)」的 N 因此把未曾執行的 profile 也計入——這是「attempt chain 必須含所有 enabled+task_class 相符 profile」這個需求的直接後果。序列化端由既有 `_MAX_PROVENANCE_ATTEMPTS`（6）截斷，不會無界膨脹。
+
+新增的 provenance 記錄消耗 `elapsed_seconds=0.0` 且不遞增 `calls`，因此不影響 `len(attempts) >= self.max_attempts` 或 `calls >= session_call_budget` 的既有判斷時序——這些記錄不會讓迴圈多繞一圈。預算充足、迴圈正常走到最後一個 profile 而不觸發 break 的既有情境，程式路徑完全不經過補記程式碼，因此零回歸。
 
 ## Testing
 
-- 新增：模擬鏈 `[claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]`，斷言 break 後 `attempts` 對應所有 enabled+task_class 相符 profile，被跳過者各有一筆 `failure_category="ineligible"` 記錄。
+- 新增：模擬鏈 `[claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]`，斷言 break 後 `attempts` 對應所有 enabled+task_class 相符 profile，被跳過者各有一筆 `failure_category="ineligible"` 記錄，且 raise 的 `category` / `profile_id` / `stderr` 取自 terminal 真實 attempt（park exactly as before 的回歸鎖）。
+- 新增：生產事故形狀（claude timeout → codex timeout → deadline break），斷言 raise 報 `category="timeout"`、`profile_id="codex"`，不受 skip 尾端影響。
+- 新增：attempt 中途 budget 耗盡（2-chunk session、chunk-0 吃光 deadline）→ 底部 break 同樣補記剩餘 profile（reason `session_budget`），raise 報 terminal 真實 attempt（`category="budget"`）。
+- 新增：circuit-open 的剩餘 profile 在 deadline break 時不被補記。
+- 新增：skip 補記可使 `len(attempts)` 超過 `max_attempts`（明文語意鎖）。
 - 新增：預算充足時記錄行為與現行完全一致（回歸保護鎖）。
 - 既有：`tests/test_external_agent_profiles.py` 全套綠；全套 pytest、`policy_check`、`openspec validate --all --strict` 綠。

--- a/docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-spec.md
+++ b/docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-spec.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+work_item: issue-106-router-skipped-profile-provenance
+---
+
+# Router deadline 提前 break 遺失 profile provenance（issue #106）規格
+
+## Problem and Outcome
+
+`RouterState` 主迴圈（`paulsha_hippo/agent_profiles.py::RouterState`，約 L888-905）在每個 profile 開始前檢查 `time.monotonic() - started >= session_deadline`；一旦成立就直接 `break`，不會為剩下尚未嘗試、但本來 enabled 且 task_class 相符的 profile 留下任何 `attempts` 記錄。
+
+生產實證（2026-08-04T02:00:33Z，session `claude-code:749f862e-0296-41f6-b7e5-79719075a32a`）：claude 跑到單次呼叫 300s 上限（`FIXED_TIMEOUT_SECONDS`）逼近後才判 timeout，codex 接著也失敗，兩者合計吃掉大半 600s 鏈預算（`FIXED_SESSION_DEADLINE_SECONDS`）。整輪理論上有 claude/codex/cg/local-vllm 4 個 enabled profile，但 `attempts` 只記到 3 筆——第 4 個 profile（local-vllm）連「ineligible」記錄都沒有，直接從證據鏈消失。此次 park 把 AR-11 soak 窗口從 2/3 直接打回 0/3，是目前三個已知 reset 事故中唯一發生在窗口即將達標前一步的。
+
+Root cause 與既有修復（issue #89 系列：把單次呼叫 timeout 與整鏈預算拆開為 `FIXED_SESSION_DEADLINE_SECONDS`）解決的是不同子情境：#89 修的是「快速失敗的 profile 們互相排擠彼此的呼叫次數／時間」；本案是「**第一個 profile 本身就跑到接近單次上限**，加上第二個 profile 也吃掉一部分時間，兩者相加即可吃光整條鏈預算」，導致迴圈甚至沒機會走到第 3、4 個 profile 的 `eligible()` 判斷。
+
+預期結果：`RouterState` 因 `session_deadline` 提前 `break` 時，對所有本應被嘗試、但因鏈預算耗盡而未嘗試的 enabled+task_class 相符 profile，比照緊鄰的 `eligible=False` pattern 各補一筆 provenance 記錄，使 `attempts_detail` 不再「憑空少 profile」；下游只能靠 attempts 數量倒推、不利除錯與稽核的現況因此消除。此修復**只補觀測**，不改變 dispatch 順序、deadline 算式、fallback 語意或 park 行為——這是全 repo 唯一每個 task_class、每個 session 都會經過的 dispatch 熱路徑，任何行為面改變都超出本次修復範圍。
+
+## Goals
+
+- G1：`RouterState` 因 `session_deadline` 提前 `break` 時，為每一個原本 enabled 且 `task_class` 相符、但因預算耗盡而未被嘗試的 profile，各補一筆 provenance 記錄（樣式比照緊鄰的 `eligible=False` / `failure_category="ineligible"` pattern）。
+- G2：新增記錄的 reason 沿用既有 ineligible 分類體系（例如 `session_deadline`），不新增 `FALLBACK_ON` / `classify_failure` 分類，不擴大 fallback allowlist。
+- G3：預算充足、迴圈正常走完全部 profile 的既有情境，記錄行為與現行完全一致（零回歸）。
+- G4：全套 pytest、`policy_check`、`openspec validate --all --strict` 綠。
+
+## Non-goals
+
+- 不改 dispatch 順序、`session_deadline_seconds()` / `effective_max_agent_calls()` 算式、fallback 語意、park 行為。
+- 不放寬 `FIXED_TIMEOUT_SECONDS`、不動 `FALLBACK_ON` allowlist。
+- 不評估「鏈預算是否該考慮已知 profile 數 × 各自最大耗時」這類演算法層改動（issue 中列為未定調的可能方向，非本次範圍）。
+
+## Acceptance
+
+- 模擬鏈 `[claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]`：斷言 break 後 `attempts`/provenance 含所有 enabled 且 task_class 匹配的 profile，被跳過者各有一筆記錄。
+- 預算充足時的既有測試全綠（回歸保護）。
+- 對應 accepted plan：`docs/superpowers/plans/2026-08-04-issue-106-router-skipped-profile-provenance.md`。

--- a/docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-spec.md
+++ b/docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-spec.md
@@ -17,9 +17,9 @@ Root cause 與既有修復（issue #89 系列：把單次呼叫 timeout 與整�
 
 ## Goals
 
-- G1：`RouterState` 因 `session_deadline` 提前 `break` 時，為每一個原本 enabled 且 `task_class` 相符、但因預算耗盡而未被嘗試的 profile，各補一筆 provenance 記錄（樣式比照緊鄰的 `eligible=False` / `failure_category="ineligible"` pattern）。
-- G2：新增記錄的 reason 沿用既有 ineligible 分類體系（例如 `session_deadline`），不新增 `FALLBACK_ON` / `classify_failure` 分類，不擴大 fallback allowlist。
-- G3：預算充足、迴圈正常走完全部 profile 的既有情境，記錄行為與現行完全一致（零回歸）。
+- G1：`RouterState` 因鏈預算耗盡提前 `break` 時——含 pre-attempt deadline check 與 attempt 中途 deadline / call budget 耗盡（`category="budget"` 底部 break）兩條路徑——為每一個原本 enabled 且 `task_class` 相符、但因預算耗盡而未被嘗試的 profile，各補一筆 provenance 記錄（樣式比照緊鄰的 `eligible=False` / `failure_category="ineligible"` pattern）；circuit-open 的剩餘 profile 維持主迴圈的無聲跳過語意，不補記。
+- G2：新增記錄的 reason 沿用既有 ineligible 分類體系（`session_deadline` / `session_budget`），不新增 `FALLBACK_ON` / `classify_failure` 分類，不擴大 fallback allowlist。
+- G3：預算充足、迴圈正常走完全部 profile 的既有情境，記錄行為與現行完全一致（零回歸）；exhausted raise 的 `category` / `profile_id` / `exit_code` / `stderr` 一律取自 terminal 真實 attempt，park 行為與修復前完全一致（skip 補記可使 `attempts` 長度超過 `max_attempts`，屬明文預期語意）。
 - G4：全套 pytest、`policy_check`、`openspec validate --all --strict` 綠。
 
 ## Non-goals
@@ -30,6 +30,8 @@ Root cause 與既有修復（issue #89 系列：把單次呼叫 timeout 與整�
 
 ## Acceptance
 
-- 模擬鏈 `[claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]`：斷言 break 後 `attempts`/provenance 含所有 enabled 且 task_class 匹配的 profile，被跳過者各有一筆記錄。
+- 模擬鏈 `[claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]`：斷言 break 後 `attempts`/provenance 含所有 enabled 且 task_class 匹配的 profile，被跳過者各有一筆記錄，且 raise 的 `category` / `profile_id` / `stderr` 取自最後一筆真實 attempt。
+- attempt 中途 budget 耗盡（多 chunk session）觸發底部 break 時，剩餘 profile 同樣獲得補記（reason `session_budget`）。
+- circuit-open 的剩餘 profile 在補記時被跳過（與主迴圈無聲 continue 一致）。
 - 預算充足時的既有測試全綠（回歸保護）。
 - 對應 accepted plan：`docs/superpowers/plans/2026-08-04-issue-106-router-skipped-profile-provenance.md`。

--- a/openspec/changes/issue-106-router-skipped-profile-provenance/design.md
+++ b/openspec/changes/issue-106-router-skipped-profile-provenance/design.md
@@ -15,20 +15,35 @@ work_item: issue-106-router-skipped-profile-provenance
 
 ## Decisions
 
-### D1：break 前，比照緊鄰的 `eligible=False` pattern，逐一為剩餘 profile 補一筆 skipped provenance
+### D1：兩條 break 路徑都比照緊鄰的 `eligible=False` pattern，逐一為剩餘 profile 補一筆 skipped provenance；circuit-open 的剩餘 profile 不補記
 
-`RouterState` 主迴圈既有的 `eligible=False` 分支（約 L906-924）已經示範了正確樣式：對「enabled 且 task_class 相符，但無法執行」的 profile 追加一筆 `AgentRunResult(..., model_verification="unavailable", failure_category="ineligible", stderr=sanitize_stderr(reason), ...)`，`elapsed_seconds=0.0`、不消耗 agent call。`time.monotonic() - started >= session_deadline` 觸發 `break` 時，改為先對 `self.profiles` 中尚未走到、且 `profile.enabled and self.task_class in profile.task_classes` 為真的每一個 profile，依同一 `AgentRunResult` 建構樣式各 append 一筆記錄，再執行原本的 `break`。已經因為 circuit breaker（`_circuit_open_until`）而被 `continue` 跳過的 profile 維持原樣不受影響——本決策只處理「deadline 提前 break」這一種消失路徑。
+`RouterState` 主迴圈既有的 `eligible=False` 分支已經示範了正確樣式：對「enabled 且 task_class 相符，但無法執行」的 profile 追加一筆 `AgentRunResult(..., model_verification="unavailable", failure_category="ineligible", stderr=sanitize_stderr(reason), ...)`，`elapsed_seconds=0.0`、不消耗 agent call。補記邏輯抽成 `_record_skipped_profiles()` helper，覆蓋兩條「鏈預算耗盡致 profile 消失」的路徑：
+
+1. **Top-of-loop deadline break**：`time.monotonic() - started >= session_deadline` 成立時，先對 `self.profiles` 中尚未走到的剩餘 profile 補記（reason `session_deadline`），再執行原本的 `break`。
+2. **Bottom break on `budget`**：deadline 或 call budget 在 attempt 中途耗盡時，chunk 迴圈 raise `category="budget"`（NON_FALLBACK → 底部 break）——多 chunk session 為生產常態，此路徑真實可達。此時同樣對剩餘 profile 補記（reason `session_budget`）。其他 non-fallback category（如 `policy`）是 per-profile 的鏈終止決策，不屬於「鏈預算耗盡」，維持原樣不補記。
+
+**circuit-open 這一格的明確決策**：補記時逐一檢查 `_circuit_open_until`——circuit 尚開著的剩餘 profile **不補記**。主迴圈對 circuit-open profile 本來就是無聲 `continue`（零記錄），該 profile 就算預算充足也不會被嘗試；補一筆 `session_deadline` 會造成同一狀態在兩條路徑下 provenance 不一致、且記錄語意失真。已經因 circuit breaker 被 `continue` 跳過（在迴圈行進中）的 profile 同樣維持原樣不受影響。
 
 ### D2：reason 沿用既有 ineligible 分類體系，不新增 fallback category
 
-`profile.eligible()` 已有 `session_size` / `context_budget` / `disabled` / `task_class` 等 reason 字串，`failure_category` 統一是 `"ineligible"`（不是 `classify_failure()` 的 `FALLBACK_ON` 分類）。新記錄比照這個既有體系，補一個新的 reason 字串（例如 `"session_deadline"`）標示「因鏈預算耗盡而未被嘗試」，`failure_category` 仍填 `"ineligible"`。**不**把這個 reason 加進 `FALLBACK_ON` / `ALLOWED_FALLBACK_CATEGORIES`——它不是一個可以觸發 fallback 判斷的失敗分類，只是 provenance 上的一個標記值，`classify_failure()` 的邏輯與 allowlist 維持零改動。
+`profile.eligible()` 已有 `session_size` / `context_budget` / `disabled` / `task_class` 等 reason 字串，`failure_category` 統一是 `"ineligible"`（不是 `classify_failure()` 的 `FALLBACK_ON` 分類）。新記錄比照這個既有體系，補兩個新的 reason 字串：`"session_deadline"`（pre-attempt deadline check 觸發）與 `"session_budget"`（attempt 中途 deadline / call budget 耗盡觸發），標示「因鏈預算耗盡而未被嘗試」，`failure_category` 仍填 `"ineligible"`。**不**把這些 reason 加進 `FALLBACK_ON` / `ALLOWED_FALLBACK_CATEGORIES`——它們不是可以觸發 fallback 判斷的失敗分類，只是 provenance 上的標記值，`classify_failure()` 的邏輯與 allowlist 維持零改動。
 
-### D3：行為面零改變，只補觀測
+### D3：行為面零改變，只補觀測——raise 內容錨定 terminal 真實 attempt
 
-本次修復不得改變：dispatch 順序（`for profile in self.profiles` 迭代順序不變）、`session_deadline_seconds()` / `effective_max_agent_calls()` 算式、`FIXED_TIMEOUT_SECONDS` / `FIXED_SESSION_DEADLINE_SECONDS`、fallback 語意（`FALLBACK_ON` allowlist 不動）、park 行為（`_raise_exhausted` 的觸發條件與內容不變，只是 `attempts` 列表在傳入前多了幾筆 skipped 記錄）。新增的 provenance 記錄消耗 `elapsed_seconds=0.0` 且不遞增 `calls`，因此不影響 `len(attempts) >= self.max_attempts` 或 `calls >= session_call_budget` 的既有判斷時序——這些記錄是在迴圈即將 `break` 之後、函式返回之前一次性補齊，不會讓迴圈多繞一圈。預算充足、迴圈正常走到最後一個 profile 而不觸發 deadline break 的既有情境，程式路徑完全不經過這段新增程式碼，因此零回歸。
+本次修復不得改變：dispatch 順序（`for profile in self.profiles` 迭代順序不變）、`session_deadline_seconds()` / `effective_max_agent_calls()` 算式、`FIXED_TIMEOUT_SECONDS` / `FIXED_SESSION_DEADLINE_SECONDS`、fallback 語意（`FALLBACK_ON` allowlist 不動）、park 行為。
+
+**park 行為不變的機制**：`_raise_exhausted` 原本從 `attempts[-1]` 取 raise 的 `category` / `profile_id` / `exit_code` / `stderr`，但補記後列表尾端可能是合成的 skip 記錄——若直接沿用，timeout 會被翻成 ineligible，下游 `llm_promoter` 的 category 映射（transient ↔ backend_unavailable）與 park 落盤的 failure_category 全部跟著翻。因此 `run_session` 全程追蹤 `terminal`（最後一筆**真實** attempt 記錄：實際執行過的 attempt 或既有 `eligible=False` ineligible 記錄），並顯式傳入 `_raise_exhausted(attempts, terminal)`；`_raise_exhausted` 未收到顯式參數時預設仍取 `attempts[-1]`（pre-#106 呼叫形狀）。`self.attempts` 保留含 skip 的完整列表供 provenance，raise 的內容一律取自 terminal——provenance 變多，錯誤本身不變。
+
+**max_attempts 上限的明文語意**：skip 記錄是在迴圈已決定 `break` 之後一次性補齊，不經過 top-of-loop 的 `len(attempts) >= self.max_attempts` 判斷，因此 **`attempts` 列表長度可以超過 `max_attempts`**（例：max_attempts=3、4-profile 鏈在第 1 筆後 deadline break → 1 真實 + 3 skip = 4 筆）。這是預期語意，非 bug：skip 記錄純屬 provenance，不消耗 agent call；park 訊息「after N bounded chunk attempt(s)」的 N 因此把未曾執行的 profile 也計入——這是「attempt chain 必須含所有 enabled+task_class 相符 profile」這個需求的直接後果。序列化端由既有 `_MAX_PROVENANCE_ATTEMPTS`（6）截斷，不會無界膨脹。
+
+新增的 provenance 記錄消耗 `elapsed_seconds=0.0` 且不遞增 `calls`，因此不影響 `len(attempts) >= self.max_attempts` 或 `calls >= session_call_budget` 的既有判斷時序——這些記錄不會讓迴圈多繞一圈。預算充足、迴圈正常走到最後一個 profile 而不觸發 break 的既有情境，程式路徑完全不經過補記程式碼，因此零回歸。
 
 ## Testing
 
-- 新增：模擬鏈 `[claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]`，斷言 break 後 `attempts` 對應所有 enabled+task_class 相符 profile，被跳過者各有一筆 `failure_category="ineligible"` 記錄。
+- 新增：模擬鏈 `[claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]`，斷言 break 後 `attempts` 對應所有 enabled+task_class 相符 profile，被跳過者各有一筆 `failure_category="ineligible"` 記錄，且 raise 的 `category` / `profile_id` / `stderr` 取自 terminal 真實 attempt（park exactly as before 的回歸鎖）。
+- 新增：生產事故形狀（claude timeout → codex timeout → deadline break），斷言 raise 報 `category="timeout"`、`profile_id="codex"`，不受 skip 尾端影響。
+- 新增：attempt 中途 budget 耗盡（2-chunk session、chunk-0 吃光 deadline）→ 底部 break 同樣補記剩餘 profile（reason `session_budget`），raise 報 terminal 真實 attempt（`category="budget"`）。
+- 新增：circuit-open 的剩餘 profile 在 deadline break 時不被補記。
+- 新增：skip 補記可使 `len(attempts)` 超過 `max_attempts`（明文語意鎖）。
 - 新增：預算充足時記錄行為與現行完全一致（回歸保護鎖）。
 - 既有：`tests/test_external_agent_profiles.py` 全套綠；全套 pytest、`policy_check`、`openspec validate --all --strict` 綠。

--- a/openspec/changes/issue-106-router-skipped-profile-provenance/design.md
+++ b/openspec/changes/issue-106-router-skipped-profile-provenance/design.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+work_item: issue-106-router-skipped-profile-provenance
+---
+
+# Issue #106 router deadline 提前 break 補記 skipped profile provenance 設計
+
+- 日期：2026-08-04
+- Issue：[#106](https://github.com/hamanpaul/paulsha-hippo/issues/106)
+- 狀態：已核可，待實作
+
+## 背景
+
+證據與 root cause 見 spec（`docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-spec.md`）。本設計唯一要決定的是：break 前要補記什麼樣的 provenance、reason 怎麼分類、以及如何確保零行為回歸。
+
+## Decisions
+
+### D1：break 前，比照緊鄰的 `eligible=False` pattern，逐一為剩餘 profile 補一筆 skipped provenance
+
+`RouterState` 主迴圈既有的 `eligible=False` 分支（約 L906-924）已經示範了正確樣式：對「enabled 且 task_class 相符，但無法執行」的 profile 追加一筆 `AgentRunResult(..., model_verification="unavailable", failure_category="ineligible", stderr=sanitize_stderr(reason), ...)`，`elapsed_seconds=0.0`、不消耗 agent call。`time.monotonic() - started >= session_deadline` 觸發 `break` 時，改為先對 `self.profiles` 中尚未走到、且 `profile.enabled and self.task_class in profile.task_classes` 為真的每一個 profile，依同一 `AgentRunResult` 建構樣式各 append 一筆記錄，再執行原本的 `break`。已經因為 circuit breaker（`_circuit_open_until`）而被 `continue` 跳過的 profile 維持原樣不受影響——本決策只處理「deadline 提前 break」這一種消失路徑。
+
+### D2：reason 沿用既有 ineligible 分類體系，不新增 fallback category
+
+`profile.eligible()` 已有 `session_size` / `context_budget` / `disabled` / `task_class` 等 reason 字串，`failure_category` 統一是 `"ineligible"`（不是 `classify_failure()` 的 `FALLBACK_ON` 分類）。新記錄比照這個既有體系，補一個新的 reason 字串（例如 `"session_deadline"`）標示「因鏈預算耗盡而未被嘗試」，`failure_category` 仍填 `"ineligible"`。**不**把這個 reason 加進 `FALLBACK_ON` / `ALLOWED_FALLBACK_CATEGORIES`——它不是一個可以觸發 fallback 判斷的失敗分類，只是 provenance 上的一個標記值，`classify_failure()` 的邏輯與 allowlist 維持零改動。
+
+### D3：行為面零改變，只補觀測
+
+本次修復不得改變：dispatch 順序（`for profile in self.profiles` 迭代順序不變）、`session_deadline_seconds()` / `effective_max_agent_calls()` 算式、`FIXED_TIMEOUT_SECONDS` / `FIXED_SESSION_DEADLINE_SECONDS`、fallback 語意（`FALLBACK_ON` allowlist 不動）、park 行為（`_raise_exhausted` 的觸發條件與內容不變，只是 `attempts` 列表在傳入前多了幾筆 skipped 記錄）。新增的 provenance 記錄消耗 `elapsed_seconds=0.0` 且不遞增 `calls`，因此不影響 `len(attempts) >= self.max_attempts` 或 `calls >= session_call_budget` 的既有判斷時序——這些記錄是在迴圈即將 `break` 之後、函式返回之前一次性補齊，不會讓迴圈多繞一圈。預算充足、迴圈正常走到最後一個 profile 而不觸發 deadline break 的既有情境，程式路徑完全不經過這段新增程式碼，因此零回歸。
+
+## Testing
+
+- 新增：模擬鏈 `[claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]`，斷言 break 後 `attempts` 對應所有 enabled+task_class 相符 profile，被跳過者各有一筆 `failure_category="ineligible"` 記錄。
+- 新增：預算充足時記錄行為與現行完全一致（回歸保護鎖）。
+- 既有：`tests/test_external_agent_profiles.py` 全套綠；全套 pytest、`policy_check`、`openspec validate --all --strict` 綠。

--- a/openspec/changes/issue-106-router-skipped-profile-provenance/proposal.md
+++ b/openspec/changes/issue-106-router-skipped-profile-provenance/proposal.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: issue-106-router-skipped-profile-provenance
+---
+
+# Issue #106 router deadline 提前 break 補記 skipped profile provenance 提案
+
+## Why
+
+`RouterState` 主迴圈（`paulsha_hippo/agent_profiles.py`，約 L888-905）在每個 profile 開始前檢查 `time.monotonic() - started >= session_deadline`；一旦成立就直接 `break`，剩下尚未嘗試、但本來 enabled 且 task_class 相符的 profile 完全不會留下任何 `attempts` 記錄。
+
+生產實證：2026-08-04T02:00:33Z，session `claude-code:749f862e-0296-41f6-b7e5-79719075a32a` 理論上有 4 個 enabled profile（claude/codex/cg/local-vllm），但 `attempts` 只記到 3 筆——第 4 個 profile 連「ineligible」記錄都沒留，直接從證據鏈消失。此輪 park 把 AR-11 soak 窗口從 2/3 打回 0/3，是三個已知 reset 事故中唯一發生在窗口即將達標前一步的。
+
+與 issue #89（呼叫次數預算未隨 chunk 數縮放）系出同源但非同一根因：#89 修的是「快速失敗的 profile 們互相排擠彼此的呼叫次數／時間」；本案是「第一個 profile 本身就跑到接近單次呼叫上限，加上第二個也吃掉部分時間，兩者相加即可吃光整條鏈預算」，導致迴圈甚至沒機會走到後段 profile 的 `eligible()` 判斷。
+
+## What Changes
+
+- `paulsha_hippo/agent_profiles.py::RouterState` 主迴圈因 `session_deadline` 提前 `break` 前，對剩餘 enabled 且 task_class 相符的 profile，逐一比照緊鄰的 `eligible=False` pattern 補一筆 `AgentRunResult`（`failure_category="ineligible"`，reason 沿用既有分類體系，例如 `session_deadline`）。
+- 不新增 `FALLBACK_ON` / `classify_failure` 分類，不改變 dispatch 順序、deadline 算式、fallback 語意、park 行為——本次修復**只補觀測**。
+- 新增模擬慢 tier-1 鏈測試（`tests/test_external_agent_profiles.py`）與預算充足時的回歸保護測試。
+- 新增 `changelog.d/106-router-skip-provenance.md`（type: fix）。
+
+## Impact
+
+- 影響範圍：`paulsha_hippo/agent_profiles.py::RouterState`——全 repo 唯一每個 task_class、每個 session 都會經過的 dispatch 熱路徑。**絕對最小 diff**：只補 provenance 記錄。
+- 風險：中——熱路徑改動，但變更範圍嚴格限定於「break 前補記」這一單點，不觸碰既有判斷式的時序與條件。
+- 不影響：dispatch 順序、`session_deadline_seconds()` / `effective_max_agent_calls()` 算式、`FIXED_TIMEOUT_SECONDS`、`FALLBACK_ON` allowlist、park 觸發條件。
+- Authority：`docs/superpowers/plans/2026-08-04-issue-106-router-skipped-profile-provenance.md`、spec/design 同名對（`docs/superpowers/specs/2026-08-04-issue-106-router-skipped-profile-provenance-{spec,design}.md`）。

--- a/openspec/changes/issue-106-router-skipped-profile-provenance/proposal.md
+++ b/openspec/changes/issue-106-router-skipped-profile-provenance/proposal.md
@@ -15,9 +15,9 @@ work_item: issue-106-router-skipped-profile-provenance
 
 ## What Changes
 
-- `paulsha_hippo/agent_profiles.py::RouterState` 主迴圈因 `session_deadline` 提前 `break` 前，對剩餘 enabled 且 task_class 相符的 profile，逐一比照緊鄰的 `eligible=False` pattern 補一筆 `AgentRunResult`（`failure_category="ineligible"`，reason 沿用既有分類體系，例如 `session_deadline`）。
-- 不新增 `FALLBACK_ON` / `classify_failure` 分類，不改變 dispatch 順序、deadline 算式、fallback 語意、park 行為——本次修復**只補觀測**。
-- 新增模擬慢 tier-1 鏈測試（`tests/test_external_agent_profiles.py`）與預算充足時的回歸保護測試。
+- `paulsha_hippo/agent_profiles.py::RouterState` 主迴圈因鏈預算耗盡提前 `break` 前——含 pre-attempt deadline check（reason `session_deadline`）與 attempt 中途 deadline / call budget 耗盡的 `budget` 底部 break（reason `session_budget`）兩條路徑——對剩餘 enabled 且 task_class 相符、且 circuit 未開路的 profile，逐一比照緊鄰的 `eligible=False` pattern 補一筆 `AgentRunResult`（`failure_category="ineligible"`）。
+- 不新增 `FALLBACK_ON` / `classify_failure` 分類，不改變 dispatch 順序、deadline 算式、fallback 語意、park 行為——本次修復**只補觀測**；exhausted raise 的 `category` / `profile_id` / `exit_code` / `stderr` 錨定最後一筆真實 attempt（terminal 快照），不受合成 skip 記錄影響。
+- 新增模擬慢 tier-1 鏈測試（`tests/test_external_agent_profiles.py`）、raise 內容回歸鎖、mid-attempt budget break 測試、circuit-open 不補記測試、`max_attempts` 溢出語意鎖，與預算充足時的回歸保護測試。
 - 新增 `changelog.d/106-router-skip-provenance.md`（type: fix）。
 
 ## Impact

--- a/openspec/changes/issue-106-router-skipped-profile-provenance/specs/stage2-llm-distillation/spec.md
+++ b/openspec/changes/issue-106-router-skipped-profile-provenance/specs/stage2-llm-distillation/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Skipped-profile provenance on chain-deadline exhaustion
+
+When the session chain deadline expires before the router has reached every enabled profile whose task classes match the session, the router SHALL append one attempt record for each remaining enabled, task-class-matching profile before breaking, using the existing ineligible provenance style: `failure_category="ineligible"`, a `session_deadline` reason, zero elapsed time, and no agent call consumed. Skipped-profile records MUST NOT alter dispatch order, deadline arithmetic, fallback semantics, or park behavior, and the `session_deadline` reason MUST NOT be added to the fallback-category allowlist; profiles already skipped by an open circuit breaker SHALL keep their existing recording behavior unchanged. The ordered attempt chain handed to parking SHALL therefore account for every enabled, task-class-matching profile, so a profile can no longer vanish from provenance because the chain budget was exhausted before its eligibility was evaluated.
+
+#### Scenario: Deadline break records the profiles it skipped
+- **WHEN** earlier profile attempts consume the entire chain deadline before the router reaches later enabled, task-class-matching profiles
+- **THEN** each skipped profile SHALL appear in attempt provenance as `ineligible` with reason `session_deadline`, consuming no agent call, and the session SHALL otherwise park exactly as before
+
+#### Scenario: Sufficient budget leaves provenance unchanged
+- **WHEN** the chain deadline is not exhausted and the router walks the full profile chain
+- **THEN** attempt records SHALL be identical to the pre-change behavior with no skipped-profile records appended

--- a/openspec/changes/issue-106-router-skipped-profile-provenance/specs/stage2-llm-distillation/spec.md
+++ b/openspec/changes/issue-106-router-skipped-profile-provenance/specs/stage2-llm-distillation/spec.md
@@ -1,13 +1,21 @@
 ## ADDED Requirements
 
-### Requirement: Skipped-profile provenance on chain-deadline exhaustion
+### Requirement: Skipped-profile provenance on chain-budget exhaustion
 
-When the session chain deadline expires before the router has reached every enabled profile whose task classes match the session, the router SHALL append one attempt record for each remaining enabled, task-class-matching profile before breaking, using the existing ineligible provenance style: `failure_category="ineligible"`, a `session_deadline` reason, zero elapsed time, and no agent call consumed. Skipped-profile records MUST NOT alter dispatch order, deadline arithmetic, fallback semantics, or park behavior, and the `session_deadline` reason MUST NOT be added to the fallback-category allowlist; profiles already skipped by an open circuit breaker SHALL keep their existing recording behavior unchanged. The ordered attempt chain handed to parking SHALL therefore account for every enabled, task-class-matching profile, so a profile can no longer vanish from provenance because the chain budget was exhausted before its eligibility was evaluated.
+When the session chain budget runs out before the router has reached every enabled profile whose task classes match the session — whether the deadline expires at the pre-attempt check (reason `session_deadline`) or the deadline / agent-call budget is exhausted mid-attempt so the chunk loop raises the non-fallback `budget` category (reason `session_budget`) — the router SHALL append one attempt record for each remaining enabled, task-class-matching profile before breaking, using the existing ineligible provenance style: `failure_category="ineligible"`, the applicable reason string, zero elapsed time, and no agent call consumed. A remaining profile whose circuit breaker is currently open SHALL NOT receive a skip record, because the main loop would have silently skipped it even with budget to spare; recording it as budget-skipped would misstate provenance. Skipped-profile records MUST NOT alter dispatch order, deadline arithmetic, fallback semantics, or park behavior, and neither reason string may be added to the fallback-category allowlist. In particular, the exhausted-chain error raised for parking SHALL take its `category`, `profile_id`, `exit_code`, and `stderr` from the terminal attempt that actually ran (or was recorded by the pre-existing ineligible path), never from an appended skip record. Because skip records are appended only after the loop has already decided to break, the attempts list MAY exceed `max_attempts`; the records are provenance-only, park attempt counts derived from the list length therefore include never-executed profiles, and serialization stays bounded by the existing provenance attempt cap. The ordered attempt chain handed to parking SHALL therefore account for every enabled, task-class-matching, non-circuit-open profile, so a profile can no longer vanish from provenance because the chain budget was exhausted before its eligibility was evaluated.
 
 #### Scenario: Deadline break records the profiles it skipped
 - **WHEN** earlier profile attempts consume the entire chain deadline before the router reaches later enabled, task-class-matching profiles
-- **THEN** each skipped profile SHALL appear in attempt provenance as `ineligible` with reason `session_deadline`, consuming no agent call, and the session SHALL otherwise park exactly as before
+- **THEN** each skipped profile SHALL appear in attempt provenance as `ineligible` with reason `session_deadline`, consuming no agent call, and the session SHALL otherwise park exactly as before — the raised error's `category` / `profile_id` / `stderr` SHALL come from the last profile that actually ran
+
+#### Scenario: Mid-attempt budget exhaustion records the profiles it skipped
+- **WHEN** the deadline or agent-call budget runs out inside an attempt (e.g. a multi-chunk session whose earlier chunks consume the whole budget), so the chunk loop raises the non-fallback `budget` category and the router breaks
+- **THEN** each remaining enabled, task-class-matching profile SHALL appear in attempt provenance as `ineligible` with reason `session_budget`, consuming no agent call, and the raised error SHALL report the terminal real attempt (`category="budget"`, the failing profile's id)
+
+#### Scenario: Circuit-open remaining profiles keep their silent-skip behavior
+- **WHEN** a chain-budget break occurs while a remaining profile's circuit breaker is open
+- **THEN** that profile SHALL NOT receive a skip record, matching the main loop's silent skip of circuit-open profiles
 
 #### Scenario: Sufficient budget leaves provenance unchanged
-- **WHEN** the chain deadline is not exhausted and the router walks the full profile chain
+- **WHEN** the chain budget is not exhausted and the router walks the full profile chain
 - **THEN** attempt records SHALL be identical to the pre-change behavior with no skipped-profile records appended

--- a/openspec/changes/issue-106-router-skipped-profile-provenance/tasks.md
+++ b/openspec/changes/issue-106-router-skipped-profile-provenance/tasks.md
@@ -9,3 +9,7 @@ work_item: issue-106-router-skipped-profile-provenance
 - [x] 1.2 先寫測試：預算充足時記錄行為與現行完全一致（回歸保護）。
 - [x] 1.3 實作：break 前對剩餘 eligible profiles 逐一 append 一筆 skipped/ineligible 記錄，樣式比照緊鄰的 `eligible=False` pattern。
 - [x] 1.4 全套綠；`changelog.d/106-router-skip-provenance.md`（type: fix）。
+- [x] 2.1 Review fix（BLOCKING）：`_raise_exhausted` 錨定 terminal 真實 attempt——`run_session` 全程追蹤最後一筆真實記錄並顯式傳入，raise 的 category/profile_id/exit_code/stderr 不再被合成 skip 尾端改寫；補 raise 內容回歸鎖測試（deadline break 斷言 `category=="timeout"`、`profile_id` 為真實嘗試過的 profile）。
+- [x] 2.2 Review fix（MAJOR）：skip 補記延伸到 attempt 中途 budget 耗盡的底部 break 路徑（reason `session_budget`），多 chunk session 的剩餘 profile 不再零記錄消失；補 2-chunk 測試。
+- [x] 2.3 Review fix（MINOR）：skip 補記檢查 `_circuit_open_until`，circuit-open 剩餘 profile 維持無聲跳過語意；補測試與 design D1 決策。
+- [x] 2.4 Review fix（MINOR）：明文記載 skip 補記可使 `len(attempts)` 超過 `max_attempts`、park attempts 計數含未執行 profile（design D3 + openspec requirement），補語意鎖測試。

--- a/openspec/changes/issue-106-router-skipped-profile-provenance/tasks.md
+++ b/openspec/changes/issue-106-router-skipped-profile-provenance/tasks.md
@@ -7,5 +7,5 @@ work_item: issue-106-router-skipped-profile-provenance
 
 - [x] 1.1 先寫測試：stub executor 構造 profile 鏈 [claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]，斷言 break 後 attempts/provenance 含所有 enabled 且 task_class 匹配的 profile——被跳過者各有一筆記錄（建議 reason 沿用既有 ineligible 分類體系，如 `session_deadline`；不新增 fallback category）。
 - [x] 1.2 先寫測試：預算充足時記錄行為與現行完全一致（回歸保護）。
-- [ ] 1.3 實作：break 前對剩餘 eligible profiles 逐一 append 一筆 skipped/ineligible 記錄，樣式比照緊鄰的 `eligible=False` pattern。
-- [ ] 1.4 全套綠；`changelog.d/106-router-skip-provenance.md`（type: fix）。
+- [x] 1.3 實作：break 前對剩餘 eligible profiles 逐一 append 一筆 skipped/ineligible 記錄，樣式比照緊鄰的 `eligible=False` pattern。
+- [x] 1.4 全套綠；`changelog.d/106-router-skip-provenance.md`（type: fix）。

--- a/openspec/changes/issue-106-router-skipped-profile-provenance/tasks.md
+++ b/openspec/changes/issue-106-router-skipped-profile-provenance/tasks.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+work_item: issue-106-router-skipped-profile-provenance
+---
+
+# Issue #106 Router deadline 提前 break 的 profile provenance tasks
+
+- [x] 1.1 先寫測試：stub executor 構造 profile 鏈 [claude(慢、吃光大半 session_deadline), codex, cg, local-vllm]，斷言 break 後 attempts/provenance 含所有 enabled 且 task_class 匹配的 profile——被跳過者各有一筆記錄（建議 reason 沿用既有 ineligible 分類體系，如 `session_deadline`；不新增 fallback category）。
+- [x] 1.2 先寫測試：預算充足時記錄行為與現行完全一致（回歸保護）。
+- [ ] 1.3 實作：break 前對剩餘 eligible profiles 逐一 append 一筆 skipped/ineligible 記錄，樣式比照緊鄰的 `eligible=False` pattern。
+- [ ] 1.4 全套綠；`changelog.d/106-router-skip-provenance.md`（type: fix）。

--- a/paulsha_hippo/agent_profiles.py
+++ b/paulsha_hippo/agent_profiles.py
@@ -16,7 +16,7 @@ import subprocess
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, ClassVar, Mapping, Sequence
 
 
 ROUTER_CONTRACT_VERSION = "1"
@@ -773,9 +773,77 @@ class ExternalAgentRouter:
             return "policy"
         return category
 
-    def _raise_exhausted(self, attempts: list[AgentRunResult]) -> None:
+    def _record_skipped_profiles(
+        self,
+        attempts: list[AgentRunResult],
+        remaining: Sequence[AgentProfile],
+        reason: str,
+    ) -> None:
+        """Append provenance-only records for profiles the chain budget kept
+        the router from ever reaching (issue #106).
+
+        Each remaining enabled, task-class-matching profile gets one
+        ``failure_category="ineligible"`` record in the existing ineligible
+        style: zero elapsed time, no agent call consumed, ``reason`` as the
+        sanitized stderr. Profiles whose circuit breaker is currently open are
+        *not* recorded -- the main loop silently ``continue``s over an open
+        circuit even with budget to spare, so recording one here as
+        budget-skipped would misstate provenance. These records are appended
+        only after the loop has already decided to break: they never affect
+        dispatch order, deadline/call-budget arithmetic, fallback semantics,
+        or which attempt the exhausted raise reports. Because they land after
+        the loop's own bookkeeping, ``len(attempts)`` may exceed
+        ``max_attempts`` (serialization is bounded downstream by
+        ``_MAX_PROVENANCE_ATTEMPTS``).
+        """
+        now = time.monotonic()
+        for profile in remaining:
+            if not (profile.enabled and self.task_class in profile.task_classes):
+                continue
+            if self._circuit_open_until.get(profile.id, 0.0) > now:
+                continue
+            attempts.append(
+                AgentRunResult(
+                    profile.id,
+                    profile.revision,
+                    profile.tier,
+                    len(attempts) + 1,
+                    profile.model,
+                    profile.effort,
+                    None,
+                    "unavailable",
+                    profile.command_fingerprint(),
+                    0.0,
+                    "ineligible",
+                    sanitize_stderr(reason),
+                    None,
+                    None,
+                    profile.priority,
+                    RESPONSE_SCHEMA_VERSION,
+                )
+            )
+
+    _LAST_FROM_ATTEMPTS: ClassVar[object] = object()
+
+    def _raise_exhausted(
+        self,
+        attempts: list[AgentRunResult],
+        last: AgentRunResult | None | object = _LAST_FROM_ATTEMPTS,
+    ) -> None:
+        """Raise the exhausted-chain error for ``attempts``.
+
+        ``last`` is the terminal *real* attempt the raise reports
+        (category / profile_id / exit_code / stderr). It defaults to
+        ``attempts[-1]`` for the pre-#106 call shape, but ``run_session``
+        passes it explicitly: once deadline/budget skip records are appended
+        (issue #106) the tail of ``attempts`` can be a synthetic skip record,
+        and park behavior must keep reporting the last attempt that actually
+        ran -- provenance grows, the raised error does not change.
+        """
         self.attempts = tuple(attempts)
-        last = attempts[-1] if attempts else None
+        if last is self._LAST_FROM_ATTEMPTS:
+            last = attempts[-1] if attempts else None
+        assert last is None or isinstance(last, AgentRunResult)
         category = last.failure_category if last else "ineligible"
         detail = "external agent fallback exhausted"
         if last is not None:
@@ -882,6 +950,12 @@ class ExternalAgentRouter:
         self._last_error = None
         started = time.monotonic()
         attempts: list[AgentRunResult] = []
+        # The terminal *real* attempt record -- the one `_raise_exhausted`
+        # must report. Tracked separately from `attempts[-1]` because the
+        # issue-#106 skip records appended right before a break would
+        # otherwise become the tail and silently rewrite the raised
+        # category/profile/stderr (and therefore park behavior).
+        terminal: AgentRunResult | None = None
         calls = 0
         validated: dict[int, str] = {}
         chunk_results: dict[int, AgentRunResult] = {}
@@ -889,28 +963,9 @@ class ExternalAgentRouter:
             if len(attempts) >= self.max_attempts or calls >= session_call_budget:
                 break
             if time.monotonic() - started >= session_deadline:
-                for rem_profile in self.profiles[profile_idx:]:
-                    if rem_profile.enabled and self.task_class in rem_profile.task_classes:
-                        attempts.append(
-                            AgentRunResult(
-                                rem_profile.id,
-                                rem_profile.revision,
-                                rem_profile.tier,
-                                len(attempts) + 1,
-                                rem_profile.model,
-                                rem_profile.effort,
-                                None,
-                                "unavailable",
-                                rem_profile.command_fingerprint(),
-                                0.0,
-                                "ineligible",
-                                sanitize_stderr("session_deadline"),
-                                None,
-                                None,
-                                rem_profile.priority,
-                                RESPONSE_SCHEMA_VERSION,
-                            )
-                        )
+                self._record_skipped_profiles(
+                    attempts, self.profiles[profile_idx:], "session_deadline"
+                )
                 break
             if self._circuit_open_until.get(profile.id, 0.0) > time.monotonic():
                 continue
@@ -925,26 +980,26 @@ class ExternalAgentRouter:
                 # is a real fallback transition and must remain in provenance,
                 # while still consuming zero agent calls.
                 if profile.enabled and self.task_class in profile.task_classes:
-                    attempts.append(
-                        AgentRunResult(
-                            profile.id,
-                            profile.revision,
-                            profile.tier,
-                            len(attempts) + 1,
-                            profile.model,
-                            profile.effort,
-                            None,
-                            "unavailable",
-                            profile.command_fingerprint(),
-                            0.0,
-                            "ineligible",
-                            sanitize_stderr(reason),
-                            None,
-                            None,
-                            profile.priority,
-                            RESPONSE_SCHEMA_VERSION,
-                        )
+                    ineligible_result = AgentRunResult(
+                        profile.id,
+                        profile.revision,
+                        profile.tier,
+                        len(attempts) + 1,
+                        profile.model,
+                        profile.effort,
+                        None,
+                        "unavailable",
+                        profile.command_fingerprint(),
+                        0.0,
+                        "ineligible",
+                        sanitize_stderr(reason),
+                        None,
+                        None,
+                        profile.priority,
+                        RESPONSE_SCHEMA_VERSION,
                     )
+                    attempts.append(ineligible_result)
+                    terminal = ineligible_result
                 continue
             attempt_index = len(attempts) + 1
             attempt_started = time.monotonic()
@@ -1072,10 +1127,22 @@ class ExternalAgentRouter:
                     output_bytes=int(getattr(caught, "output_bytes", 0) or 0),
                 )
                 attempts.append(result)
+                terminal = result
                 self._circuit_open_until[profile.id] = time.monotonic() + 60.0
                 if category not in ALLOWED_FALLBACK_CATEGORIES or category not in profile.fallback_on:
+                    if category == "budget":
+                        # The session-wide chain budget (deadline or call
+                        # budget) ran out mid-attempt: the remaining profiles
+                        # vanish for the same reason as a pre-attempt deadline
+                        # break and get the same provenance-only skip records
+                        # (issue #106). Other non-fallback categories end the
+                        # chain as a deliberate per-profile decision and keep
+                        # their pre-existing provenance shape.
+                        self._record_skipped_profiles(
+                            attempts, self.profiles[profile_idx + 1:], "session_budget"
+                        )
                     break
-        self._raise_exhausted(attempts)
+        self._raise_exhausted(attempts, terminal)
 
 
 __all__ = [

--- a/paulsha_hippo/agent_profiles.py
+++ b/paulsha_hippo/agent_profiles.py
@@ -885,10 +885,32 @@ class ExternalAgentRouter:
         calls = 0
         validated: dict[int, str] = {}
         chunk_results: dict[int, AgentRunResult] = {}
-        for profile in self.profiles:
+        for profile_idx, profile in enumerate(self.profiles):
             if len(attempts) >= self.max_attempts or calls >= session_call_budget:
                 break
             if time.monotonic() - started >= session_deadline:
+                for rem_profile in self.profiles[profile_idx:]:
+                    if rem_profile.enabled and self.task_class in rem_profile.task_classes:
+                        attempts.append(
+                            AgentRunResult(
+                                rem_profile.id,
+                                rem_profile.revision,
+                                rem_profile.tier,
+                                len(attempts) + 1,
+                                rem_profile.model,
+                                rem_profile.effort,
+                                None,
+                                "unavailable",
+                                rem_profile.command_fingerprint(),
+                                0.0,
+                                "ineligible",
+                                sanitize_stderr("session_deadline"),
+                                None,
+                                None,
+                                rem_profile.priority,
+                                RESPONSE_SCHEMA_VERSION,
+                            )
+                        )
                 break
             if self._circuit_open_until.get(profile.id, 0.0) > time.monotonic():
                 continue

--- a/tests/test_external_agent_profiles.py
+++ b/tests/test_external_agent_profiles.py
@@ -1087,7 +1087,7 @@ def test_router_session_deadline_break_records_skipped_profile_provenance(monkey
 
     router = ExternalAgentRouter((claude, codex, cg, local_vllm), executor=execute)
 
-    with pytest.raises(AgentRunError, match="fallback exhausted"):
+    with pytest.raises(AgentRunError, match="fallback exhausted") as excinfo:
         router.run("prompt")
 
     attempt_profiles = [attempt.profile_id for attempt in router.attempts]
@@ -1098,6 +1098,161 @@ def test_router_session_deadline_break_records_skipped_profile_provenance(monkey
     for attempt in router.attempts[1:]:
         assert attempt.failure_category == "ineligible"
         assert attempt.stderr == "session_deadline"
+
+    # "the session SHALL otherwise park exactly as before": the raised error
+    # must report the terminal *real* attempt, never a synthetic skip record
+    # -- otherwise llm_promoter maps timeout->transient into
+    # ineligible->backend_unavailable and every parked artifact downstream
+    # (ledger, _failed evidence, dream census, requeue category) flips.
+    assert excinfo.value.category == "timeout"
+    assert excinfo.value.profile_id == "claude"
+    assert excinfo.value.stderr == "claude timeout"
+
+
+def test_router_deadline_break_raise_reports_terminal_real_attempt(monkeypatch):
+    """Production incident shape (issue #106 review finding): claude timeout ->
+    codex timeout -> deadline break. Provenance gains skip records for cg and
+    local-vllm, but the exhausted raise must stay byte-identical to pre-#106
+    behavior: category/profile_id/stderr from the last profile that really ran
+    (codex), not from the appended skip tail (local-vllm/session_deadline)."""
+    import time
+    from paulsha_hippo.agent_profiles import AgentRunError
+
+    claude = _profile("claude", tier=1, priority=1)
+    codex = _profile("codex", tier=1, priority=2)
+    cg = _profile("cg", tier=2, priority=1)
+    local_vllm = _profile("local-vllm", tier=3, priority=1)
+
+    current_time = [100.0]
+    monkeypatch.setattr(time, "monotonic", lambda: current_time[0])
+
+    def execute(profile, prompt, attempt):
+        current_time[0] += 350.0
+        raise AgentRunError(f"{profile.id} timeout", category="timeout")
+
+    router = ExternalAgentRouter((claude, codex, cg, local_vllm), executor=execute)
+
+    with pytest.raises(AgentRunError, match="fallback exhausted") as excinfo:
+        router.run("prompt")
+
+    assert [attempt.profile_id for attempt in router.attempts] == [
+        "claude", "codex", "cg", "local-vllm",
+    ]
+    assert router.attempts[0].failure_category == "timeout"
+    assert router.attempts[1].failure_category == "timeout"
+    assert router.attempts[2].failure_category == "ineligible"
+    assert router.attempts[3].failure_category == "ineligible"
+
+    assert excinfo.value.category == "timeout"
+    assert excinfo.value.profile_id == "codex"
+    assert excinfo.value.stderr == "codex timeout"
+
+
+def test_router_mid_attempt_budget_break_records_skipped_profile_provenance(monkeypatch):
+    """The chain deadline can also expire *inside* an attempt (multi-chunk
+    session): the chunk loop raises category="budget", which is not a fallback
+    category, so the router breaks at the bottom of the loop. The remaining
+    profiles must get the same provenance-only skip records as a pre-attempt
+    deadline break (reason "session_budget"), and the raise must still report
+    the terminal real attempt."""
+    import time
+    from paulsha_hippo.agent_profiles import AgentRunError
+
+    claude = _profile("claude", tier=1, priority=1)
+    codex = _profile("codex", tier=1, priority=2)
+    cg = _profile("cg", tier=2, priority=1)
+    local_vllm = _profile("local-vllm", tier=3, priority=1)
+
+    current_time = [100.0]
+    monkeypatch.setattr(time, "monotonic", lambda: current_time[0])
+
+    def execute(profile, prompt, attempt):
+        # chunk-0 validates but eats the whole session deadline; chunk-1 then
+        # hits the in-attempt remaining_seconds <= 0 budget raise.
+        current_time[0] += 650.0
+        return "answer", "", 0
+
+    router = ExternalAgentRouter((claude, codex, cg, local_vllm), executor=execute)
+
+    with pytest.raises(AgentRunError, match="fallback exhausted") as excinfo:
+        router.run_session(("chunk-0", "chunk-1"))
+
+    assert [attempt.profile_id for attempt in router.attempts] == [
+        "claude", "codex", "cg", "local-vllm",
+    ]
+    assert router.attempts[0].failure_category == "budget"
+    for attempt in router.attempts[1:]:
+        assert attempt.failure_category == "ineligible"
+        assert attempt.stderr == "session_budget"
+        assert attempt.elapsed_seconds == 0.0
+
+    assert excinfo.value.category == "budget"
+    assert excinfo.value.profile_id == "claude"
+
+
+def test_router_deadline_break_does_not_record_circuit_open_profile(monkeypatch):
+    """A remaining profile whose circuit breaker is open would have been
+    silently skipped by the main loop even with budget to spare; the
+    deadline-break skip records must not claim it was lost to the deadline."""
+    import time
+    from paulsha_hippo.agent_profiles import AgentRunError
+
+    claude = _profile("claude", tier=1, priority=1)
+    codex = _profile("codex", tier=1, priority=2)
+    cg = _profile("cg", tier=2, priority=1)
+    local_vllm = _profile("local-vllm", tier=3, priority=1)
+
+    current_time = [100.0]
+    monkeypatch.setattr(time, "monotonic", lambda: current_time[0])
+
+    def execute(profile, prompt, attempt):
+        current_time[0] += 700.0
+        raise AgentRunError("claude timeout", category="timeout")
+
+    router = ExternalAgentRouter((claude, codex, cg, local_vllm), executor=execute)
+    router._circuit_open_until["cg"] = current_time[0] + 3600.0
+
+    with pytest.raises(AgentRunError, match="fallback exhausted"):
+        router.run("prompt")
+
+    assert [attempt.profile_id for attempt in router.attempts] == [
+        "claude", "codex", "local-vllm",
+    ]
+
+
+def test_router_skip_records_may_exceed_max_attempts(monkeypatch):
+    """Documented issue-#106 semantic: skip records are appended after the
+    loop has already decided to break, so len(attempts) may exceed
+    max_attempts. They are provenance-only -- the raise still reports the
+    terminal real attempt and no extra agent call is consumed."""
+    import time
+    from paulsha_hippo.agent_profiles import AgentRunError
+
+    claude = _profile("claude", tier=1, priority=1)
+    codex = _profile("codex", tier=1, priority=2)
+    cg = _profile("cg", tier=2, priority=1)
+    local_vllm = _profile("local-vllm", tier=3, priority=1)
+
+    current_time = [100.0]
+    monkeypatch.setattr(time, "monotonic", lambda: current_time[0])
+
+    def execute(profile, prompt, attempt):
+        current_time[0] += 700.0
+        raise AgentRunError("claude timeout", category="timeout")
+
+    router = ExternalAgentRouter(
+        (claude, codex, cg, local_vllm), executor=execute, max_attempts=3
+    )
+
+    with pytest.raises(AgentRunError, match="fallback exhausted") as excinfo:
+        router.run("prompt")
+
+    assert len(router.attempts) == 4
+    assert [attempt.failure_category for attempt in router.attempts] == [
+        "timeout", "ineligible", "ineligible", "ineligible",
+    ]
+    assert excinfo.value.category == "timeout"
+    assert excinfo.value.profile_id == "claude"
 
 
 def test_router_sufficient_deadline_provenance_unchanged():

--- a/tests/test_external_agent_profiles.py
+++ b/tests/test_external_agent_profiles.py
@@ -1097,7 +1097,7 @@ def test_router_session_deadline_break_records_skipped_profile_provenance(monkey
 
     for attempt in router.attempts[1:]:
         assert attempt.failure_category == "ineligible"
-        assert attempt.error_message == "session_deadline"
+        assert attempt.stderr == "session_deadline"
 
 
 def test_router_sufficient_deadline_provenance_unchanged():

--- a/tests/test_external_agent_profiles.py
+++ b/tests/test_external_agent_profiles.py
@@ -1061,3 +1061,63 @@ def test_session_cache_lands_validated_chunk_even_when_session_later_exhausts(tm
     assert len(payloads) == 1
     assert payloads[0]["output"] == "valid"
     assert payloads[0]["provenance"]["profile_id"] == "first"
+
+
+def test_router_session_deadline_break_records_skipped_profile_provenance(monkeypatch):
+    import time
+    from paulsha_hippo.agent_profiles import AgentRunError
+
+    claude = _profile("claude", tier=1, priority=1)
+    codex = _profile("codex", tier=1, priority=2)
+    cg = _profile("cg", tier=2, priority=1)
+    local_vllm = _profile("local-vllm", tier=3, priority=1)
+
+    current_time = [100.0]
+
+    def mock_monotonic():
+        return current_time[0]
+
+    monkeypatch.setattr(time, "monotonic", mock_monotonic)
+
+    def execute(profile, prompt, attempt):
+        if profile.id == "claude":
+            current_time[0] += 700.0
+            raise AgentRunError("claude timeout", category="timeout")
+        return "answer", "", 0
+
+    router = ExternalAgentRouter((claude, codex, cg, local_vllm), executor=execute)
+
+    with pytest.raises(AgentRunError, match="fallback exhausted"):
+        router.run("prompt")
+
+    attempt_profiles = [attempt.profile_id for attempt in router.attempts]
+    assert attempt_profiles == ["claude", "codex", "cg", "local-vllm"]
+    assert router.attempts[0].profile_id == "claude"
+    assert router.attempts[0].failure_category == "timeout"
+
+    for attempt in router.attempts[1:]:
+        assert attempt.failure_category == "ineligible"
+        assert attempt.error_message == "session_deadline"
+
+
+def test_router_sufficient_deadline_provenance_unchanged():
+    from paulsha_hippo.agent_profiles import AgentRunError
+
+    profiles = (_profile("claude", tier=1, priority=1), _profile("codex", tier=1, priority=2))
+    calls: list[str] = []
+
+    def execute(profile, prompt, attempt):
+        calls.append(profile.id)
+        if profile.id == "claude":
+            raise AgentRunError("failed", category="process")
+        return "answer", "", 0
+
+    router = ExternalAgentRouter(profiles, executor=execute)
+    assert router.run("prompt") == "answer"
+    assert calls == ["claude", "codex"]
+    assert [attempt.profile_id for attempt in router.attempts] == ["claude", "codex"]
+    assert router.attempts[0].failure_category == "process"
+    assert router.attempts[1].failure_category is None
+
+
+


### PR DESCRIPTION
## 摘要

RouterState 主迴圈因 deadline / call-budget 耗盡提前 break 時，剩餘 enabled 且 task_class 匹配的 profiles 原本會從 `attempts_detail` 憑空消失。本 PR 對這些被跳過的 profiles 補記 skipped/ineligible provenance 記錄：pre-attempt deadline check 補 `session_deadline`、attempt 中途 deadline / call-budget 耗盡補 `session_budget`；circuit-open 的剩餘 profile 維持無聲跳過不補記。exhausted raise 的 category/profile_id/exit_code/stderr 錨定最後一筆真實 attempt，不受合成 skip 記錄影響，park 行為與修復前完全一致。skip 補記可使 attempts 長度超過 `max_attempts`，屬明文預期語意。

驗證證據（於 worktree 實跑）：

- `python3 -m pytest -q`：**1746 passed, 4 skipped, 184 subtests passed**（97.93s），無任何失敗
- `openspec validate --all --strict`：15 passed, 0 failed
- `python3 -m policy_check --repo .`：0 fail / 1 warn（R-22 為 26 筆陳年懸空引用，advisory，非本 PR 引入）
- `changelog.d/106-router-skip-provenance.md` 碎片已隨 PR 附上

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

## 風險與回復

變更侷限於 `paulsha_hippo/agent_profiles.py` 的 router provenance 記錄路徑與對應測試（`tests/test_external_agent_profiles.py` 新增 215 行覆蓋），無資料遷移、無 live deployment 影響、不改任何對外介面；如需回復，直接 revert 單一 squash commit 即可。已知語意變化：`attempts_detail` 長度可能超過 `max_attempts`（skip 補記所致），已於 spec delta 與測試明文鎖定。

Closes #106
