### PR TITLE
feat(knowledge): normalize-tags 一次性 migration CLI——回填修復既存非字串 tags

### DIFF
--- a/changelog.d/109-normalize-tags-migration.md
+++ b/changelog.d/109-normalize-tags-migration.md
@@ -1,0 +1,5 @@
+---
+type: fix
+---
+- 提供 `hippo knowledge normalize-tags --memory-root <root> [--dry-run|--apply]` 指令與 `paulsha_hippo/tags_migration.py` 模組，提供一次性回填修復磁碟上既存非字串 tags slice（如裸數字 320）的遷移工具 (#109)。
+- 實現冪等掃描與改寫：`--dry-run` 報告待修 slice 數量與正規化預覽且不修改檔案；`--apply` 使用 `normalize_tags()` 正規化 tags 並以 `frontmatter_io.update()` 安全改寫 frontmatter，保留 body 與其他欄位。再次執行 `--dry-run` 回報 0。

--- a/changelog.d/109-normalize-tags-migration.md
+++ b/changelog.d/109-normalize-tags-migration.md
@@ -2,4 +2,6 @@
 type: fix
 ---
 - 提供 `hippo knowledge normalize-tags --memory-root <root> [--dry-run|--apply]` 指令與 `paulsha_hippo/tags_migration.py` 模組，提供一次性回填修復磁碟上既存非字串 tags slice（如裸數字 320）的遷移工具 (#109)。
-- 實現冪等掃描與改寫：`--dry-run` 報告待修 slice 數量與正規化預覽且不修改檔案；`--apply` 使用 `normalize_tags()` 正規化 tags 並以 `frontmatter_io.update()` 安全改寫 frontmatter，保留 body 與其他欄位。再次執行 `--dry-run` 回報 0。
+- 實現冪等掃描與改寫：`--dry-run` 報告待修 slice 數量與正規化預覽且不修改檔案；`--apply` 使用 `normalize_tags()` 正規化 tags 並以 `frontmatter_io.update()` 安全改寫 frontmatter，語意契約為 parse-equivalent——body 逐位元不變、tags 以外欄位 parsed 值不變（表層引號樣式可正規化；未引號 datetime 正規化為等值 ISO8601 字串、null 維持 null）。再次執行 `--dry-run` 回報 0。
+- 掃描無條件過濾 `memory_layer != "knowledge"`（比照 rekey/linker 慣例）：`--memory-root` 打錯（無 knowledge/ 子目錄）時不會改寫 inbox/episodic 或一般 markdown 文件；非 list scalar tags 依 #101 語意抹為 `[]`，決策以測試明文鎖住。
+- 修正 `moc/frontmatter_io.py::_scalar()`：None 改輸出 YAML `null`（原輸出 `None` 字面值，`update()` 往返後劣化成字串 `"None"`），比照 #102/#104 型別保真精神 (#109 review)。

--- a/docs/superpowers/plans/2026-08-04-issue-109-normalize-tags-migration.md
+++ b/docs/superpowers/plans/2026-08-04-issue-109-normalize-tags-migration.md
@@ -33,7 +33,7 @@ work_item: issue-109-normalize-tags-migration
 
 ## Task 2: apply + 冪等
 
-- [ ] 先寫測試：`--apply` 後該 2 個 slice 的 tags 全為字串、body 與其他 frontmatter 欄位逐位元不變（僅 tags 行改動）；再跑 `--dry-run` 回報 0；再跑一次 `--apply` 為 no-op。
+- [ ] 先寫測試：`--apply` 後該 2 個 slice 的 tags 全為字串、body 逐位元不變、其他 frontmatter 欄位 parsed 值不變（parse-equivalent：update() 整份重 dump，表層引號樣式可正規化；datetime→ISO8601 字串、null 維持 null 為宣告的正規化，見 openspec design D4）；含 production-shaped fixture 全欄位斷言；再跑 `--dry-run` 回報 0；再跑一次 `--apply` 為 no-op。
 - [ ] 先寫測試（回歸 #104 保護）：apply 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle），重新解析 tags 仍全為字串。
 - [ ] 實作 apply：`normalize_tags()` + `frontmatter_io.update()`。
 - [ ] CLI 接線 `hippo knowledge normalize-tags`；全套綠；`changelog.d/109-normalize-tags-migration.md`（type: fix）。

--- a/docs/superpowers/plans/2026-08-04-issue-109-normalize-tags-migration.md
+++ b/docs/superpowers/plans/2026-08-04-issue-109-normalize-tags-migration.md
@@ -1,0 +1,39 @@
+---
+status: accepted
+work_item: issue-109-normalize-tags-migration
+---
+
+# 既存非字串 tags 一次性 migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development——先寫失敗測試再實作。
+
+**Goal:** 提供 `hippo knowledge normalize-tags --memory-root <root> [--dry-run|--apply]`，一次性回填修復磁碟上既存的非字串 tags slice（如裸數字 `320`），使 MOC index 不再每輪因 `invalid tags type` warning 把 dream 判成 partial。
+
+**範圍註記：** issue #109 第 2 段（`_scalar()` 純數字字串引號）已由 PR #104 修復並含 round-trip 測試，本 plan 只做第 1 段（資料 migration）。known 案例：`knowledge/github.com-hamanpaul-intellidbgkit--p-7ae7dbfe5516/terminal-directory-seal-and-crash-recovery--sl-1010b51101ebe096.md` 第 23 行裸數字 `320`。
+
+**Architecture:** 仿 repo 既有三個 dry-run/apply 一次性遷移模板：`paulsha_hippo/retitle.py`、`paulsha_hippo/rekey.py`、`paulsha_hippo/moc/entity_hub.py`。重用 `paulsha_hippo/atomizer/slice_frontmatter.py::normalize_tags()` 做正規化、`paulsha_hippo/moc/frontmatter_io.py::update()` 做改寫（#104 已保證純數字字串往返不劣化）。
+
+**Target branch:** `feature/109-normalize-tags-migration`
+
+## Global Constraints
+
+- 語言 zh-tw；TDD 先 RED 再實作。
+- 交付治理：`changelog.d/<slug>.md` 碎片、pytest／policy_check／openspec strict 全綠、PR template checklist 全勾、body `Closes #109`。
+- 全套測試在非巢狀 sibling worktree 跑（巢狀下 test_project_resolver 2 個假失敗為已知）。
+- 純附加：不動 MOC index 的嚴格驗證（它是正確的最後防線）、不動熱路徑。
+- migration 必須冪等：apply 後再跑 dry-run 零殘留。
+- commit 前 `rm -rf .psc_tmp`；不要 `git add -A`。
+
+## Task 1: scan + dry-run
+
+**檔案**：新模組（建議 `paulsha_hippo/tags_migration.py`）、`paulsha_hippo/cli.py`、`tests/`（新測試檔）
+
+- [ ] 先寫測試：建 tmp memory root 放 3 個 fixture slice（正常 tags／含裸 int tag／含 None 與嵌套 list 的 tags），`--dry-run` 回報恰好 2 個待修 slice 與各自的正規化後 tags 預覽，不改任何檔案（bytes 比對）。
+- [ ] 實作 scan：走訪 knowledge 層 markdown，YAML frontmatter 的 `tags` 含非字串元素者列入。
+
+## Task 2: apply + 冪等
+
+- [ ] 先寫測試：`--apply` 後該 2 個 slice 的 tags 全為字串、body 與其他 frontmatter 欄位逐位元不變（僅 tags 行改動）；再跑 `--dry-run` 回報 0；再跑一次 `--apply` 為 no-op。
+- [ ] 先寫測試（回歸 #104 保護）：apply 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle），重新解析 tags 仍全為字串。
+- [ ] 實作 apply：`normalize_tags()` + `frontmatter_io.update()`。
+- [ ] CLI 接線 `hippo knowledge normalize-tags`；全套綠；`changelog.d/109-normalize-tags-migration.md`（type: fix）。

--- a/docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-design.md
@@ -1,0 +1,66 @@
+---
+status: accepted
+work_item: issue-109-normalize-tags-migration
+---
+
+# 既存非字串 tags 一次性 migration（issue #109）設計
+
+- 日期：2026-08-04
+- Issue：[#109](https://github.com/hamanpaul/paulsha-hippo/issues/109)
+- 狀態：已核可，待實作
+
+## 背景
+
+證據與 root cause 見 spec
+（`docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-spec.md`）。摘要：
+既存磁碟 slice 的 frontmatter `tags` 含裸數字 `320`，MOC index 每輪重建判
+`invalid tags type` 而排除、記 warning，令 orchestrator 整輪永久 `partial`，與 #101 同構
+（sticky diagnostic 反模式）。#103 只修了未來新寫入路徑；issue 第 2 段的
+`_scalar()` 純數字字串引號劣化風險已由 PR #104（closes #102）修復並含 round-trip 測試。
+本設計只處理剩餘範圍：既存壞資料的一次性 migration 該怎麼做。
+
+## Decisions
+
+### D1：仿 retitle/rekey/entity_hub 的 dry-run/apply 模板
+
+repo 內已有三個一次性遷移模板：`paulsha_hippo/retitle.py`、`paulsha_hippo/rekey.py`、
+`paulsha_hippo/moc/entity_hub.py`，皆採「掃描 → 產生變更清單（dry-run 預覽）→ 逐檔改寫
+（apply 落地）」兩階段結構。新模組 `paulsha_hippo/tags_migration.py` 沿用同一結構，CLI
+接線比照三者慣例，掛在 `hippo knowledge normalize-tags --memory-root <root>
+[--dry-run|--apply]`。選擇仿既有模板而非另造新框架，理由是三者已在生產驗證過
+dry-run/apply 的安全邊界（不誤動未命中檔案、失敗不留半套狀態），沿用可直接繼承這些性質。
+
+### D2：重用 normalize_tags() + frontmatter_io.update()，不新造正規化/序列化邏輯
+
+- 正規化：`paulsha_hippo/atomizer/slice_frontmatter.py::normalize_tags()` 已是 #103
+  落地的正規化單一真理來源（新寫入路徑 `build_from_proposal()` 已使用它）。既存資料
+  migration 直接重用同一函式，避免出現兩套 tags 正規化規則互相分岔的風險。
+- 序列化：`paulsha_hippo/moc/frontmatter_io.py::update()` 已由 PR #104 補上
+  `_needs_quoting_for_type_fidelity()`，純數字字串 tag 經 `update()` 往返不再被 YAML
+  剝回 int。apply 階段直接呼叫 `update()` 落地改寫，不另寫 frontmatter dump 邏輯，天然
+  繼承 #104 的型別保真保護，且與既有三個模板使用同一改寫入口一致。
+
+### D3：冪等性
+
+migration 必須支援重複執行不產生額外變更或副作用：
+
+- scan 邏輯只挑出「`tags` 含至少一個非字串元素」的 slice；`--apply` 後同一 slice 的
+  tags 已全為字串，下一輪 scan 自然不會再命中，不需要額外的「已處理」標記機制。
+- `--apply` 對「已無非字串 tags」的 slice 是 no-op：不改寫、不觸碰檔案 mtime/checksum，
+  避免每次重跑都造成無意義 diff。
+- 驗收方式：`--apply` → `--dry-run` 回報 0 待修 slice → 再次 `--apply` 為 no-op（bytes
+  與上一次 apply 後逐位元相同）。
+- 回歸保護：`--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle
+  等下游呼叫）重新解析 tags 仍全為字串，坐實 #104 的往返修復對本 migration 輸出同樣
+  有效，不會出現「migration 修好、下一次 retitle 又劣化回 int」的復發。
+
+## Testing
+
+- `--dry-run` 對 3 個 fixture slice（tags 全字串／含裸 int tag／含 None 與嵌套 list）
+  回報恰好 2 個待修 slice 及各自正規化後 tags 預覽，不改任何檔案（bytes 逐位元比對）。
+- `--apply` 後該 2 個 slice tags 全為字串，body 與其他 frontmatter 欄位逐位元不變
+  （僅 tags 行改動）；再 `--dry-run` 回報 0；再 `--apply` 為 no-op。
+- `--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`，重新解析 tags 仍全為
+  字串（回歸 #104 保護）。
+- CLI 接線 `hippo knowledge normalize-tags`；全套 pytest、
+  `python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠。

--- a/docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-design.md
+++ b/docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-design.md
@@ -54,12 +54,41 @@ migration 必須支援重複執行不產生額外變更或副作用：
   等下游呼叫）重新解析 tags 仍全為字串，坐實 #104 的往返修復對本 migration 輸出同樣
   有效，不會出現「migration 修好、下一次 retitle 又劣化回 int」的復發。
 
+### D4：apply 的語意契約是 parse-equivalent，不是逐位元（issue #109 review 收斂）
+
+`--apply` 走 `frontmatter_io.update()` 整份重 dump，結構上不保證「僅 tags 行變動、
+其他行逐位元不變」——YAML 表層形（json 引號 free-text 的引號樣式等）會被正規化。
+issue owner 指定重用 `update()`（D2），因此收斂為接受重 dump 語意並明文鎖住：
+
+- body 逐位元不變；tags 以外欄位 parsed 值不變（parsed-equality 全欄位斷言，
+  production-shaped fixture）。
+- 宣告的型別正規化僅兩項：未引號 YAML datetime 標量 → 等值 ISO8601 字串（stage3
+  schema 對 `created_at` 的契約本就是字串，`lib/lifecycle/schema.py::_is_iso8601`
+  對 datetime 物件 FAIL，此為朝 schema 收斂的正規化而非劣化）；null 維持 null。
+- 順手修 `frontmatter_io._scalar()`：None 原輸出 `None` 字面值（PyYAML 不視為
+  null），`update()` 往返後劣化成字串 `"None"`——改輸出 `null`，比照 #102/#104
+  型別保真精神，附直接 round-trip 測試。
+
+### D5：無條件 memory_layer 過濾（issue #109 review 收斂）
+
+`<root>/knowledge` 不存在時 fallback 掃 root 下 `.md`，但 `memory_layer !=
+"knowledge"` 的過濾無條件生效（repo 慣例，比照 `rekey.py`／`moc/linker.py`）：
+使用者把 `--memory-root` 打錯再加 `--apply` 時，不會改寫 inbox/episodic 或一般
+markdown 文件。非 list scalar tags（`tags: hello`）依 #101 語意整體視為空 list，
+不另設第二套正規化規則，抹除在 dry-run 預覽可見並以測試明文鎖住。
+
 ## Testing
 
 - `--dry-run` 對 3 個 fixture slice（tags 全字串／含裸 int tag／含 None 與嵌套 list）
   回報恰好 2 個待修 slice 及各自正規化後 tags 預覽，不改任何檔案（bytes 逐位元比對）。
-- `--apply` 後該 2 個 slice tags 全為字串，body 與其他 frontmatter 欄位逐位元不變
-  （僅 tags 行改動）；再 `--dry-run` 回報 0；再 `--apply` 為 no-op。
+- `--apply` 後該 2 個 slice tags 全為字串，body 逐位元不變、其他 frontmatter 欄位
+  parsed 值不變（D4 parse-equivalent）；再 `--dry-run` 回報 0；再 `--apply` 為 no-op。
+- production-shaped fixture（json 引號 free-text、未引號 datetime、裸 null distiller
+  欄位、非空 provenance/distiller dict、引號數字樣 version）：apply 後全欄位
+  parsed-equality、datetime→ISO8601 字串、null 維持 null、bytes 級冪等。
+- 打錯 `--memory-root`（無 knowledge/）：僅 `memory_layer: knowledge` 檔案被改寫，
+  一般文件與 inbox 層檔案 bytes 不變（D5）。
+- 非 list scalar tags（`tags: hello`）→ dry-run 預覽 `[]`、apply 後 `[]`（D5 決策鎖）。
 - `--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`，重新解析 tags 仍全為
   字串（回歸 #104 保護）。
 - CLI 接線 `hippo knowledge normalize-tags`；全套 pytest、

--- a/docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-spec.md
+++ b/docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-spec.md
@@ -36,8 +36,11 @@ cycle 不再被此類 sticky diagnostic 打斷。
 - G2：`--dry-run` 列出所有 tags 含非字串元素的既存 slice 及其正規化後 tags 預覽，不修改
   任何檔案（bytes 逐位元不變）。
 - G3：`--apply` 重用 `atomizer/slice_frontmatter.py::normalize_tags()` 正規化、
-  `moc/frontmatter_io.py::update()` 落地改寫，僅 tags 行變動，body 與其他 frontmatter
-  欄位逐位元不變。
+  `moc/frontmatter_io.py::update()` 落地改寫，語意契約為 parse-equivalent（issue #109
+  review 收斂）：body 逐位元不變；tags 以外的 frontmatter 欄位 parsed 值不變
+  （`update()` 整份重 dump，YAML 表層引號樣式可正規化），僅宣告兩項型別正規化——
+  未引號 datetime 標量 → 等值 ISO8601 字串（stage3 schema 契約）、null 維持 null
+  （`_scalar()` None→`null` 修正，杜絕劣化成字串 `"None"`）。
 - G4：冪等——`--apply` 後重跑 `--dry-run` 回報 0 待修 slice；再次 `--apply` 為 no-op。
 - G5：回歸鎖——`--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle
   等下游呼叫），重新解析 tags 仍全為字串，坐實 PR #104 的往返保護對本 migration 輸出同樣

--- a/docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-spec.md
+++ b/docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-spec.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+work_item: issue-109-normalize-tags-migration
+---
+
+# 既存非字串 tags 一次性 migration（issue #109）規格
+
+## Problem and Outcome
+
+2026-08-04 部署 candidate `1299fa1`（含 #103 tag 正規化修復）後，第一輪 dream cycle
+（`04:00:08Z`）仍判定 `partial`。根因非新蒸餾失敗（本輪 zero-ingress，backlog 標記無
+增長），而是既存磁碟檔案
+`knowledge/github.com-hamanpaul-intellidbgkit--p-7ae7dbfe5516/terminal-directory-seal-and-crash-recovery--sl-1010b51101ebe096.md`
+（codex 於 2026-08-02T07:52 蒸餾產生，早於本次修復部署）frontmatter `tags` 含裸數字
+`320`（第 23 行），MOC index 每輪重建時判 `invalid tags type` 而排除、記 warning，令
+orchestrator `moc_clean=False` → 整輪永久 `partial`，直到人工熱修——與 #101 症狀同構
+（sticky diagnostic 反模式）。
+
+#103 修復方向正確但範圍侷限於「未來新寫入路徑」（`build_from_proposal()` 呼叫
+`normalize_tags()`）；已落地的既存檔案不會被回溯修復，任何在該修復生效前寫入的裸數字
+tag 都會持續讓 soak 卡在 partial，直到人工逐檔熱修。
+
+issue #109 原文第 2 段描述的殘留風險——`frontmatter_io.py::_scalar()` 對純數字字串輸出
+缺少強制引號，導致任何 `frontmatter_io.update()` 呼叫都可能把已正規化的 tags 於下一次
+讀取時劣化回 int——已由 PR #104（closes #102）修復並含 write→read→write→read 往返測試。
+本套件不重工該段，只涵蓋 issue 留言「範圍更新」明確標定的剩餘範圍：**既存壞資料的一次
+性 migration**。
+
+預期結果：提供一次性、可重跑、有 dry-run 的 migration 工具，掃描並修復既存 knowledge
+slice 中非字串 tags，使 MOC index 不再因此類殘留噴 `invalid tags type` warning，dream
+cycle 不再被此類 sticky diagnostic 打斷。
+
+## Goals
+
+- G1：提供 `hippo knowledge normalize-tags --memory-root <root> [--dry-run|--apply]` CLI。
+- G2：`--dry-run` 列出所有 tags 含非字串元素的既存 slice 及其正規化後 tags 預覽，不修改
+  任何檔案（bytes 逐位元不變）。
+- G3：`--apply` 重用 `atomizer/slice_frontmatter.py::normalize_tags()` 正規化、
+  `moc/frontmatter_io.py::update()` 落地改寫，僅 tags 行變動，body 與其他 frontmatter
+  欄位逐位元不變。
+- G4：冪等——`--apply` 後重跑 `--dry-run` 回報 0 待修 slice；再次 `--apply` 為 no-op。
+- G5：回歸鎖——`--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle
+  等下游呼叫），重新解析 tags 仍全為字串，坐實 PR #104 的往返保護對本 migration 輸出同樣
+  有效。
+
+## Non-goals
+
+- 不重工 issue #109 第 2 段（`_scalar()` 純數字字串引號劣化風險）——該風險已由 PR #104
+  修復並含 round-trip 測試。
+- 不改動 MOC index 的嚴格驗證邏輯（fail-soft warning 是正確的最後防線，維持不動）。
+- 不動 dream/atomize/janitor 既有寫入熱路徑，不新增查詢語法或 schema 變動。
+
+## Acceptance
+
+- 已知案例
+  `terminal-directory-seal-and-crash-recovery--sl-1010b51101ebe096.md`（tags 含裸數字
+  `320`）：`--dry-run` 列出、`--apply` 後修復為字串，MOC rebuild 不再出
+  `invalid tags type` warning。
+- 全套 pytest、`python3 -m policy_check --repo .`、`openspec validate --all --strict`
+  全綠。

--- a/openspec/changes/issue-109-normalize-tags-migration/design.md
+++ b/openspec/changes/issue-109-normalize-tags-migration/design.md
@@ -34,7 +34,9 @@ dry-run/apply 安全邊界。
 
 - 正規化：`paulsha_hippo/atomizer/slice_frontmatter.py::normalize_tags()` 已是 #103
   落地的正規化單一真理來源。既存資料 migration 直接重用同一函式，避免兩套 tags 正規化
-  規則互相分岔。
+  規則互相分岔。此取捨包含「非 list scalar tags（如 `tags: hello`）依 #101 語意整體
+  視為空 list」：migration 不為保留 scalar 另設第二套規則，抹除在 `--dry-run` 預覽
+  （`normalized_tags: []`）中對操作者可見，並以測試明文鎖住（issue #109 review）。
 - 序列化：`paulsha_hippo/moc/frontmatter_io.py::update()` 已由 PR #104 補上
   `_needs_quoting_for_type_fidelity()`，純數字字串 tag 經 `update()` 往返不再被 YAML
   剝回 int。apply 階段直接呼叫 `update()` 落地，不另寫 frontmatter dump 邏輯，天然
@@ -50,12 +52,41 @@ dry-run/apply 安全邊界。
   等下游呼叫）重新解析 tags 仍全為字串，坐實 #104 的往返修復對本 migration 輸出同樣
   有效。
 
+### D4：apply 的語意契約是 parse-equivalent，不是逐位元（issue #109 review 收斂）
+
+`--apply` 走 `frontmatter_io.update()` 整份重 dump，結構上不保證「僅 tags 行變動、
+其他行逐位元不變」——YAML 表層形（json 引號 free-text 的引號樣式等）會被正規化。
+issue owner 指定重用 `update()`（D2），因此收斂為接受重 dump 語意並明文鎖住：
+
+- body 逐位元不變；tags 以外欄位 parsed 值不變（parsed-equality 全欄位斷言，
+  production-shaped fixture）。
+- 宣告的型別正規化僅兩項：未引號 YAML datetime 標量（`created_at: 2026-08-02
+  07:52:28`）→ 等值 ISO8601 字串——stage3 schema 對 `created_at` 的契約本就是字串
+  （`lib/lifecycle/schema.py::_is_iso8601` 對 datetime 物件 FAIL），此為朝 schema
+  收斂的正規化而非劣化；null 維持 null。
+- 順手修 `frontmatter_io._scalar()`：None 原輸出 `None` 字面值（PyYAML 不視為
+  null），`update()` 往返後劣化成字串 `"None"`——改輸出 `null`，比照 #102/#104
+  型別保真精神，附直接 round-trip 測試。
+
+### D5：無條件 memory_layer 過濾（issue #109 review 收斂）
+
+`<root>/knowledge` 不存在時 fallback 掃 root 下 `.md`，但 `memory_layer !=
+"knowledge"` 的過濾無條件生效（repo 慣例，比照 `rekey.py`／`moc/linker.py`）：
+使用者把 `--memory-root` 打錯再加 `--apply` 時，不會改寫 inbox/episodic 或一般
+markdown 文件。
+
 ## Testing
 
 - `--dry-run` 對 3 個 fixture slice（tags 全字串／含裸 int tag／含 None 與嵌套 list）
   回報恰好 2 個待修 slice 及各自正規化後 tags 預覽，不改任何檔案（bytes 逐位元比對）。
-- `--apply` 後該 2 個 slice tags 全為字串，body 與其他 frontmatter 欄位逐位元不變
-  （僅 tags 行改動）；再 `--dry-run` 回報 0；再 `--apply` 為 no-op。
+- `--apply` 後該 2 個 slice tags 全為字串，body 逐位元不變、其他 frontmatter 欄位
+  parsed 值不變（D4 parse-equivalent）；再 `--dry-run` 回報 0；再 `--apply` 為 no-op。
+- production-shaped fixture（json 引號 free-text、未引號 datetime、裸 null distiller
+  欄位、非空 provenance/distiller dict、引號數字樣 version）：apply 後全欄位
+  parsed-equality、datetime→ISO8601 字串、null 維持 null、bytes 級冪等。
+- 打錯 `--memory-root`（無 knowledge/）：僅 `memory_layer: knowledge` 檔案被改寫，
+  一般文件與 inbox 層檔案 bytes 不變（D5）。
+- 非 list scalar tags（`tags: hello`）→ dry-run 預覽 `[]`、apply 後 `[]`（D2 決策鎖）。
 - `--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`，重新解析 tags 仍全為
   字串（回歸 #104 保護）。
 - CLI 接線 `hippo knowledge normalize-tags`；全套 pytest、

--- a/openspec/changes/issue-109-normalize-tags-migration/design.md
+++ b/openspec/changes/issue-109-normalize-tags-migration/design.md
@@ -1,0 +1,62 @@
+---
+status: accepted
+work_item: issue-109-normalize-tags-migration
+---
+
+# Issue #109 既存非字串 tags 一次性 migration 設計
+
+- 日期：2026-08-04
+- Issue：[#109](https://github.com/hamanpaul/paulsha-hippo/issues/109)
+- 狀態：已核可，待實作
+
+## 背景
+
+既存磁碟 slice 的 frontmatter `tags` 含裸數字 `320`，MOC index 每輪重建判
+`invalid tags type` 而排除、記 warning，令 orchestrator 整輪永久 `partial`，與 #101
+同構（sticky diagnostic 反模式）。#103 只修了未來新寫入路徑（`build_from_proposal()`
+呼叫 `normalize_tags()`）；issue 第 2 段的 `_scalar()` 純數字字串引號劣化風險已由
+PR #104（closes #102）修復並含 round-trip 測試。證據見
+`docs/superpowers/specs/2026-08-04-issue-109-normalize-tags-migration-spec.md`。本設計
+只處理剩餘範圍：既存壞資料的一次性 migration 該怎麼做。
+
+## Decisions
+
+### D1：仿 retitle/rekey/entity_hub 的 dry-run/apply 模板
+
+repo 內已有三個一次性遷移模板：`paulsha_hippo/retitle.py`、`paulsha_hippo/rekey.py`、
+`paulsha_hippo/moc/entity_hub.py`，皆採「掃描 → 產生變更清單（dry-run 預覽）→ 逐檔改寫
+（apply 落地）」兩階段結構。新模組 `paulsha_hippo/tags_migration.py` 沿用同一結構，CLI
+接線比照三者慣例，掛在 `hippo knowledge normalize-tags --memory-root <root>
+[--dry-run|--apply]`。沿用既有模板而非另造新框架，可直接繼承它們已在生產驗證過的
+dry-run/apply 安全邊界。
+
+### D2：重用 normalize_tags() + frontmatter_io.update()，不新造正規化/序列化邏輯
+
+- 正規化：`paulsha_hippo/atomizer/slice_frontmatter.py::normalize_tags()` 已是 #103
+  落地的正規化單一真理來源。既存資料 migration 直接重用同一函式，避免兩套 tags 正規化
+  規則互相分岔。
+- 序列化：`paulsha_hippo/moc/frontmatter_io.py::update()` 已由 PR #104 補上
+  `_needs_quoting_for_type_fidelity()`，純數字字串 tag 經 `update()` 往返不再被 YAML
+  剝回 int。apply 階段直接呼叫 `update()` 落地，不另寫 frontmatter dump 邏輯，天然
+  繼承 #104 的型別保真保護。
+
+### D3：冪等性
+
+- scan 邏輯只挑出「`tags` 含至少一個非字串元素」的 slice；`--apply` 後同一 slice 的
+  tags 已全為字串，下一輪 scan 自然不會再命中。
+- `--apply` 對「已無非字串 tags」的 slice 是 no-op：不改寫、不觸碰 mtime/checksum。
+- 驗收方式：`--apply` → `--dry-run` 回報 0 待修 slice → 再次 `--apply` 為 no-op。
+- 回歸保護：`--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle
+  等下游呼叫）重新解析 tags 仍全為字串，坐實 #104 的往返修復對本 migration 輸出同樣
+  有效。
+
+## Testing
+
+- `--dry-run` 對 3 個 fixture slice（tags 全字串／含裸 int tag／含 None 與嵌套 list）
+  回報恰好 2 個待修 slice 及各自正規化後 tags 預覽，不改任何檔案（bytes 逐位元比對）。
+- `--apply` 後該 2 個 slice tags 全為字串，body 與其他 frontmatter 欄位逐位元不變
+  （僅 tags 行改動）；再 `--dry-run` 回報 0；再 `--apply` 為 no-op。
+- `--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`，重新解析 tags 仍全為
+  字串（回歸 #104 保護）。
+- CLI 接線 `hippo knowledge normalize-tags`；全套 pytest、
+  `python3 -m policy_check --repo .`、`openspec validate --all --strict` 全綠。

--- a/openspec/changes/issue-109-normalize-tags-migration/proposal.md
+++ b/openspec/changes/issue-109-normalize-tags-migration/proposal.md
@@ -1,0 +1,46 @@
+---
+status: accepted
+work_item: issue-109-normalize-tags-migration
+---
+
+# Issue #109 既存非字串 tags 一次性 migration 提案
+
+## Why
+
+2026-08-04 部署 candidate `1299fa1`（含 #103 tag 正規化修復）後，第一輪 dream cycle
+仍判定 `partial`：既存磁碟檔案
+（`knowledge/github.com-hamanpaul-intellidbgkit--p-7ae7dbfe5516/terminal-directory-seal-and-crash-recovery--sl-1010b51101ebe096.md`，
+codex 於 2026-08-02T07:52 蒸餾產生，早於修復部署）frontmatter `tags` 含裸數字 `320`，
+MOC index 每輪重建判 `invalid tags type` 而排除、記 warning，令 orchestrator
+`moc_clean=False`，整輪永久 `partial`，與 #101 症狀同構（sticky diagnostic 反模式）。
+
+#103 修復方向正確但範圍侷限於「未來新寫入路徑」（`build_from_proposal()` 呼叫
+`normalize_tags()`），已落地的舊檔案不會被回溯修復。issue #109 原文第 2 段描述的
+`_scalar()` 純數字字串引號劣化風險已由 PR #104（closes #102）修復並含 round-trip
+測試（見 issue #109 comment「範圍更新（batch 前置分析）」），本提案不重工，只涵蓋
+剩餘範圍：既存壞資料的一次性 migration。
+
+## What Changes
+
+- 新增一次性 janitor/migration CLI
+  `hippo knowledge normalize-tags --memory-root <root> [--dry-run|--apply]`，仿 repo
+  既有 `retitle.py`／`rekey.py`／`moc/entity_hub.py` 的 dry-run/apply 模板。
+- 新模組 `paulsha_hippo/tags_migration.py`：掃描 knowledge 層 markdown，找出 frontmatter
+  `tags` 含非字串元素的既存 slice；`--dry-run` 僅列出待修清單與正規化後 tags 預覽；
+  `--apply` 重用 `atomizer/slice_frontmatter.py::normalize_tags()` 正規化、
+  `moc/frontmatter_io.py::update()` 落地改寫。
+- `paulsha_hippo/cli.py` 接線新子命令。
+- 新增回歸測試：dry-run 精確計數與 bytes 不變、apply 後 tags 全為字串且僅 tags 行變動、
+  冪等（apply 後 dry-run 為 0、再次 apply 為 no-op）、apply 後呼叫
+  `frontmatter_io.update()` 坐實 #104 round-trip 保護。
+- 新增 `changelog.d/109-normalize-tags-migration.md`（type: fix）。
+
+## Impact
+
+- 影響範圍：新增獨立 CLI 子命令與新模組；不修改 MOC index 的嚴格驗證邏輯（維持
+  fail-soft 最後防線），不動 dream/atomize/janitor 既有熱路徑。
+- 風險：低——重用單一真理來源的正規化（`normalize_tags()`）與已修復的序列化
+  （`frontmatter_io.update()`，PR #104），無新序列化邏輯，migration 為純附加、
+  可重跑、有 dry-run。
+- Authority：`docs/superpowers/plans/2026-08-04-issue-109-normalize-tags-migration.md`、
+  spec/design 同名對。

--- a/openspec/changes/issue-109-normalize-tags-migration/proposal.md
+++ b/openspec/changes/issue-109-normalize-tags-migration/proposal.md
@@ -30,15 +30,24 @@ MOC index 每輪重建判 `invalid tags type` 而排除、記 warning，令 orch
   `--apply` 重用 `atomizer/slice_frontmatter.py::normalize_tags()` 正規化、
   `moc/frontmatter_io.py::update()` 落地改寫。
 - `paulsha_hippo/cli.py` 接線新子命令。
-- 新增回歸測試：dry-run 精確計數與 bytes 不變、apply 後 tags 全為字串且僅 tags 行變動、
-  冪等（apply 後 dry-run 為 0、再次 apply 為 no-op）、apply 後呼叫
-  `frontmatter_io.update()` 坐實 #104 round-trip 保護。
+- `moc/frontmatter_io.py::_scalar()` 型別保真修正（review 收斂）：None 改輸出
+  YAML `null`（原輸出 `None` 字面值，PyYAML 不視為 null，`update()` 往返後劣化
+  成字串 `"None"`），比照 #102/#104 精神；附直接 round-trip 測試。
+- 新增回歸測試：dry-run 精確計數與 bytes 不變、apply 後 tags 全為字串且
+  parse-equivalent（body 逐位元不變、其他欄位 parsed 值不變，僅宣告的
+  datetime→ISO8601 字串正規化與 null 保真；production-shaped fixture 全欄位
+  斷言）、無條件 memory_layer 過濾（打錯 --memory-root 不改寫非 knowledge
+  文件）、scalar tags→[] 決策鎖、冪等（apply 後 dry-run 為 0、再次 apply 為
+  no-op 且 bytes 不變）、apply 後呼叫 `frontmatter_io.update()` 坐實 #104
+  round-trip 保護。
 - 新增 `changelog.d/109-normalize-tags-migration.md`（type: fix）。
 
 ## Impact
 
 - 影響範圍：新增獨立 CLI 子命令與新模組；不修改 MOC index 的嚴格驗證邏輯（維持
-  fail-soft 最後防線），不動 dream/atomize/janitor 既有熱路徑。
+  fail-soft 最後防線），不動 dream/atomize/janitor 既有熱路徑的呼叫結構。唯一
+  申報的共用路徑修正：`frontmatter_io._scalar()` None→`null` 一行型別保真修正
+  ——只影響「原本就會劣化成字串 `"None"`」的 None 序列化，附直接測試。
 - 風險：低——重用單一真理來源的正規化（`normalize_tags()`）與已修復的序列化
   （`frontmatter_io.update()`，PR #104），無新序列化邏輯，migration 為純附加、
   可重跑、有 dry-run。

--- a/openspec/changes/issue-109-normalize-tags-migration/specs/stage2-memory-governance/spec.md
+++ b/openspec/changes/issue-109-normalize-tags-migration/specs/stage2-memory-governance/spec.md
@@ -2,15 +2,23 @@
 
 ### Requirement: 既存非字串 tags 一次性 migration
 
-系統 SHALL 提供一次性 migration CLI `hippo knowledge normalize-tags --memory-root <root> [--dry-run|--apply]`，掃描 knowledge 層 slice frontmatter 的 `tags`，找出含至少一個非字串元素（如裸數字、`null`、嵌套 list）的既存 slice。`--dry-run`（預設）SHALL 回報待修 slice 清單與各自以 `normalize_tags()` 正規化後的 tags 預覽，且 MUST NOT 修改任何檔案（bytes 逐位元不變）。`--apply` SHALL 重用 `atomizer/slice_frontmatter.py::normalize_tags()` 做正規化、`moc/frontmatter_io.py::update()` 落地改寫，僅 tags 變動，body 與其他 frontmatter 欄位 SHALL 保持不變；對已無非字串 tags 的 slice SHALL 為 no-op。migration SHALL 為冪等：`--apply` 後重跑 `--dry-run` SHALL 回報 0 個待修 slice，再次 `--apply` SHALL 為 no-op。migration 輸出經後續 `frontmatter_io.update()` 往返（如 retitle）後，tags SHALL 仍全為字串（繼承 #104 型別保真保護）。本 migration MUST NOT 修改 MOC index 的嚴格驗證邏輯，MUST NOT 動 dream/atomize/janitor 既有寫入熱路徑。
+系統 SHALL 提供一次性 migration CLI `hippo knowledge normalize-tags --memory-root <root> [--dry-run|--apply]`，掃描 knowledge 層 slice frontmatter 的 `tags`，找出含至少一個非字串元素（如裸數字、`null`、嵌套 list）或值為非 list 的既存 slice；掃描 SHALL 無條件過濾 `memory_layer != "knowledge"` 的檔案（含 `<root>/knowledge` 不存在的 fallback 掃描情境），MUST NOT 改寫 inbox/episodic 或一般 markdown 文件。`--dry-run`（預設）SHALL 回報待修 slice 清單與各自以 `normalize_tags()` 正規化後的 tags 預覽，且 MUST NOT 修改任何檔案（bytes 逐位元不變）。`--apply` SHALL 重用 `atomizer/slice_frontmatter.py::normalize_tags()` 做正規化（非 list scalar tags 依 #101 語意整體視為空 list，不另設第二套正規化規則）、`moc/frontmatter_io.py::update()` 落地改寫，語意契約為 **parse-equivalent**：body SHALL 逐位元不變；tags 以外的 frontmatter 欄位 parsed 值 SHALL 不變（`update()` 整份重 dump，YAML 表層形如引號樣式 MAY 正規化），僅允許兩個宣告的型別正規化——原生 datetime 標量正規化為等值 ISO8601 字串（stage3 schema 對 `created_at` 的契約即為字串）、null SHALL 維持 null（不得劣化為字串 `"None"`）；對已無非字串 tags 的 slice SHALL 為 no-op。migration SHALL 為冪等：`--apply` 後重跑 `--dry-run` SHALL 回報 0 個待修 slice，再次 `--apply` SHALL 為 no-op 且 bytes 不變。migration 輸出經後續 `frontmatter_io.update()` 往返（如 retitle）後，tags SHALL 仍全為字串（繼承 #104 型別保真保護）。本 migration MUST NOT 修改 MOC index 的嚴格驗證邏輯，MUST NOT 動 dream/atomize/janitor 既有寫入熱路徑。
 
 #### Scenario: dry-run 精確回報且不動檔案
 - **WHEN** memory root 內有 tags 全為字串、tags 含裸 int、tags 含 null 與嵌套 list 的三個 slice，執行 `--dry-run`
 - **THEN** 回報恰好 2 個待修 slice 及各自正規化後 tags 預覽，且三個檔案 bytes 逐位元不變
 
-#### Scenario: apply 正規化且冪等
+#### Scenario: apply 正規化且冪等（parse-equivalent）
 - **WHEN** 對同一 memory root 執行 `--apply`
-- **THEN** 待修 slice 的 tags 全為字串、body 與其他 frontmatter 欄位不變；重跑 `--dry-run` 回報 0 個待修 slice；再次 `--apply` 為 no-op
+- **THEN** 待修 slice 的 tags 全為字串、body 逐位元不變、tags 以外欄位 parsed 值不變（僅宣告的 datetime→ISO8601 字串正規化；null 維持 null）；重跑 `--dry-run` 回報 0 個待修 slice；再次 `--apply` 為 no-op 且 bytes 不變
+
+#### Scenario: 打錯 memory-root 不改寫非 knowledge 文件
+- **WHEN** `--memory-root` 指向沒有 `knowledge/` 子目錄的目錄且其中有帶非字串 tags 的一般 markdown 或 inbox 層檔案，執行 `--apply`
+- **THEN** 僅 `memory_layer: knowledge` 的檔案被掃描與改寫，其餘檔案 bytes 逐位元不變
+
+#### Scenario: 非 list scalar tags 依 #101 語意抹為空 list
+- **WHEN** 既存 slice 的 frontmatter 為 `tags: hello`（非 list scalar），先 `--dry-run` 再 `--apply`
+- **THEN** dry-run 預覽顯示 `normalized_tags: []`（抹除在 apply 前可見），apply 後 tags 為 `[]`——沿用 `normalize_tags()` 單一真理來源，不為 migration 另設保留 scalar 的第二套規則
 
 #### Scenario: migration 輸出經 update() 往返不劣化
 - **WHEN** `--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle 等下游呼叫）

--- a/openspec/changes/issue-109-normalize-tags-migration/specs/stage2-memory-governance/spec.md
+++ b/openspec/changes/issue-109-normalize-tags-migration/specs/stage2-memory-governance/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: 既存非字串 tags 一次性 migration
+
+系統 SHALL 提供一次性 migration CLI `hippo knowledge normalize-tags --memory-root <root> [--dry-run|--apply]`，掃描 knowledge 層 slice frontmatter 的 `tags`，找出含至少一個非字串元素（如裸數字、`null`、嵌套 list）的既存 slice。`--dry-run`（預設）SHALL 回報待修 slice 清單與各自以 `normalize_tags()` 正規化後的 tags 預覽，且 MUST NOT 修改任何檔案（bytes 逐位元不變）。`--apply` SHALL 重用 `atomizer/slice_frontmatter.py::normalize_tags()` 做正規化、`moc/frontmatter_io.py::update()` 落地改寫，僅 tags 變動，body 與其他 frontmatter 欄位 SHALL 保持不變；對已無非字串 tags 的 slice SHALL 為 no-op。migration SHALL 為冪等：`--apply` 後重跑 `--dry-run` SHALL 回報 0 個待修 slice，再次 `--apply` SHALL 為 no-op。migration 輸出經後續 `frontmatter_io.update()` 往返（如 retitle）後，tags SHALL 仍全為字串（繼承 #104 型別保真保護）。本 migration MUST NOT 修改 MOC index 的嚴格驗證邏輯，MUST NOT 動 dream/atomize/janitor 既有寫入熱路徑。
+
+#### Scenario: dry-run 精確回報且不動檔案
+- **WHEN** memory root 內有 tags 全為字串、tags 含裸 int、tags 含 null 與嵌套 list 的三個 slice，執行 `--dry-run`
+- **THEN** 回報恰好 2 個待修 slice 及各自正規化後 tags 預覽，且三個檔案 bytes 逐位元不變
+
+#### Scenario: apply 正規化且冪等
+- **WHEN** 對同一 memory root 執行 `--apply`
+- **THEN** 待修 slice 的 tags 全為字串、body 與其他 frontmatter 欄位不變；重跑 `--dry-run` 回報 0 個待修 slice；再次 `--apply` 為 no-op
+
+#### Scenario: migration 輸出經 update() 往返不劣化
+- **WHEN** `--apply` 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle 等下游呼叫）
+- **THEN** 重新解析後 tags 仍全為字串，純數字字串 tag 不被剝回 int

--- a/openspec/changes/issue-109-normalize-tags-migration/tasks.md
+++ b/openspec/changes/issue-109-normalize-tags-migration/tasks.md
@@ -1,11 +1,11 @@
 # Tasks: issue-109-normalize-tags-migration
 
-- [ ] Task 1: scan + dry-run <!-- id: 0 -->
+- [x] Task 1: scan + dry-run <!-- id: 0 -->
   - [x] 先寫測試：建 tmp memory root 放 3 個 fixture slice（正常 tags／含裸 int tag／含 None 與嵌套 list 的 tags），`--dry-run` 回報恰好 2 個待修 slice 與各自的正規化後 tags 預覽，不改任何檔案（bytes 比對）。 <!-- id: 1 -->
-  - [ ] 實作 scan：走訪 knowledge 層 markdown，YAML frontmatter 的 `tags` 含非字串元素者列入。 <!-- id: 2 -->
-- [ ] Task 2: apply + 冪等 <!-- id: 3 -->
+  - [x] 實作 scan：走訪 knowledge 層 markdown，YAML frontmatter 的 `tags` 含非字串元素者列入。 <!-- id: 2 -->
+- [x] Task 2: apply + 冪等 <!-- id: 3 -->
   - [x] 先寫測試：`--apply` 後該 2 個 slice 的 tags 全為字串、body 與其他 frontmatter 欄位逐位元不變（僅 tags 行改動）；再跑 `--dry-run` 回報 0；再跑一次 `--apply` 為 no-op。 <!-- id: 4 -->
   - [x] 先寫測試（回歸 #104 保護）：apply 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle），重新解析 tags 仍全為字串。 <!-- id: 5 -->
-  - [ ] 實作 apply：`normalize_tags()` + `frontmatter_io.update()`。 <!-- id: 6 -->
-  - [ ] CLI 接線 `hippo knowledge normalize-tags`；全套綠；`changelog.d/109-normalize-tags-migration.md`（type: fix）。 <!-- id: 7 -->
+  - [x] 實作 apply：`normalize_tags()` + `frontmatter_io.update()`。 <!-- id: 6 -->
+  - [x] CLI 接線 `hippo knowledge normalize-tags`；全套綠；`changelog.d/109-normalize-tags-migration.md`（type: fix）。 <!-- id: 7 -->
 

--- a/openspec/changes/issue-109-normalize-tags-migration/tasks.md
+++ b/openspec/changes/issue-109-normalize-tags-migration/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: issue-109-normalize-tags-migration
+
+- [ ] Task 1: scan + dry-run <!-- id: 0 -->
+  - [x] 先寫測試：建 tmp memory root 放 3 個 fixture slice（正常 tags／含裸 int tag／含 None 與嵌套 list 的 tags），`--dry-run` 回報恰好 2 個待修 slice 與各自的正規化後 tags 預覽，不改任何檔案（bytes 比對）。 <!-- id: 1 -->
+  - [ ] 實作 scan：走訪 knowledge 層 markdown，YAML frontmatter 的 `tags` 含非字串元素者列入。 <!-- id: 2 -->
+- [ ] Task 2: apply + 冪等 <!-- id: 3 -->
+  - [x] 先寫測試：`--apply` 後該 2 個 slice 的 tags 全為字串、body 與其他 frontmatter 欄位逐位元不變（僅 tags 行改動）；再跑 `--dry-run` 回報 0；再跑一次 `--apply` 為 no-op。 <!-- id: 4 -->
+  - [x] 先寫測試（回歸 #104 保護）：apply 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle），重新解析 tags 仍全為字串。 <!-- id: 5 -->
+  - [ ] 實作 apply：`normalize_tags()` + `frontmatter_io.update()`。 <!-- id: 6 -->
+  - [ ] CLI 接線 `hippo knowledge normalize-tags`；全套綠；`changelog.d/109-normalize-tags-migration.md`（type: fix）。 <!-- id: 7 -->
+

--- a/openspec/changes/issue-109-normalize-tags-migration/tasks.md
+++ b/openspec/changes/issue-109-normalize-tags-migration/tasks.md
@@ -4,7 +4,7 @@
   - [x] 先寫測試：建 tmp memory root 放 3 個 fixture slice（正常 tags／含裸 int tag／含 None 與嵌套 list 的 tags），`--dry-run` 回報恰好 2 個待修 slice 與各自的正規化後 tags 預覽，不改任何檔案（bytes 比對）。 <!-- id: 1 -->
   - [x] 實作 scan：走訪 knowledge 層 markdown，YAML frontmatter 的 `tags` 含非字串元素者列入。 <!-- id: 2 -->
 - [x] Task 2: apply + 冪等 <!-- id: 3 -->
-  - [x] 先寫測試：`--apply` 後該 2 個 slice 的 tags 全為字串、body 與其他 frontmatter 欄位逐位元不變（僅 tags 行改動）；再跑 `--dry-run` 回報 0；再跑一次 `--apply` 為 no-op。 <!-- id: 4 -->
+  - [x] 先寫測試：`--apply` 後該 2 個 slice 的 tags 全為字串、body 逐位元不變、其他 frontmatter 欄位 parsed 值不變（parse-equivalent，見 design D4：update() 整份重 dump，表層引號樣式可正規化；datetime→ISO8601 字串、null 維持 null 為宣告的正規化）；含 production-shaped fixture 全欄位斷言；再跑 `--dry-run` 回報 0；再跑一次 `--apply` 為 no-op。 <!-- id: 4 -->
   - [x] 先寫測試（回歸 #104 保護）：apply 後對其中一個 slice 呼叫 `frontmatter_io.update()`（模擬 retitle），重新解析 tags 仍全為字串。 <!-- id: 5 -->
   - [x] 實作 apply：`normalize_tags()` + `frontmatter_io.update()`。 <!-- id: 6 -->
   - [x] CLI 接線 `hippo knowledge normalize-tags`；全套綠；`changelog.d/109-normalize-tags-migration.md`（type: fix）。 <!-- id: 7 -->

--- a/paulsha_hippo/cli.py
+++ b/paulsha_hippo/cli.py
@@ -397,8 +397,18 @@ def _build_parser() -> argparse.ArgumentParser:
     entity_hubs_p.add_argument("--now", default=None)
     egroup = entity_hubs_p.add_mutually_exclusive_group()
     egroup.add_argument("--dry-run", action="store_true")
-    egroup.add_argument("--apply", action="store_true")
+    entity_hubs_p.add_argument("--apply", action="store_true")
     entity_hubs_p.set_defaults(func=_entity_hubs)
+
+    normalize_tags_p = knowledge_subparsers.add_parser(
+        "normalize-tags",
+        help="一次性正規化 knowledge slice frontmatter 中的非字串 tags (#109)",
+    )
+    normalize_tags_p.add_argument("--memory-root", required=True)
+    ngroup = normalize_tags_p.add_mutually_exclusive_group()
+    ngroup.add_argument("--dry-run", action="store_true")
+    ngroup.add_argument("--apply", action="store_true")
+    normalize_tags_p.set_defaults(func=_normalize_tags)
 
     usage_p = memory_subparsers.add_parser("usage")
     # Let argparse accept `hippo usage mark-applied --memory-root ...`; the report path
@@ -872,6 +882,20 @@ def _entity_hubs(args: argparse.Namespace) -> int:
     if warnings:
         return 1
     if not apply and actions:
+        return 1
+    return 0
+
+
+def _normalize_tags(args: argparse.Namespace) -> int:
+    from . import tags_migration
+
+    root = Path(args.memory_root)
+    apply = bool(getattr(args, "apply", False))
+    summary, warnings = tags_migration.normalize_tags_migration(root, apply=apply)
+    for warning in warnings:
+        print(f"warning: {warning}", file=sys.stderr)
+    print(json.dumps(summary, ensure_ascii=False))
+    if warnings:
         return 1
     return 0
 

--- a/paulsha_hippo/cli.py
+++ b/paulsha_hippo/cli.py
@@ -397,7 +397,7 @@ def _build_parser() -> argparse.ArgumentParser:
     entity_hubs_p.add_argument("--now", default=None)
     egroup = entity_hubs_p.add_mutually_exclusive_group()
     egroup.add_argument("--dry-run", action="store_true")
-    entity_hubs_p.add_argument("--apply", action="store_true")
+    egroup.add_argument("--apply", action="store_true")
     entity_hubs_p.set_defaults(func=_entity_hubs)
 
     normalize_tags_p = knowledge_subparsers.add_parser(

--- a/paulsha_hippo/moc/frontmatter_io.py
+++ b/paulsha_hippo/moc/frontmatter_io.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from typing import Any
 
 
-def read(text: str) -> tuple[dict[str, Any], str]:
+def read(text: str | Path) -> tuple[dict[str, Any], str]:
     """Return (frontmatter_dict, body). Body is everything after the closing ---."""
+    if isinstance(text, Path):
+        text = text.read_text(encoding="utf-8")
     lines = text.splitlines(keepends=True)
     if not lines or lines[0].strip() != "---":
         return {}, text

--- a/paulsha_hippo/moc/frontmatter_io.py
+++ b/paulsha_hippo/moc/frontmatter_io.py
@@ -7,10 +7,8 @@ from pathlib import Path
 from typing import Any
 
 
-def read(text: str | Path) -> tuple[dict[str, Any], str]:
+def read(text: str) -> tuple[dict[str, Any], str]:
     """Return (frontmatter_dict, body). Body is everything after the closing ---."""
-    if isinstance(text, Path):
-        text = text.read_text(encoding="utf-8")
     lines = text.splitlines(keepends=True)
     if not lines or lines[0].strip() != "---":
         return {}, text
@@ -87,6 +85,11 @@ def _needs_quoting_for_type_fidelity(s: str) -> bool:
 
 
 def _scalar(value: Any) -> str:
+    if value is None:
+        # YAML 原生 null 必須序列化回 ``null``：str(None) 會寫出 ``None``，
+        # 而 PyYAML 不把 ``None`` 當 null 詞彙，下一次 read() 就劣化成字串
+        # "None"（issue #109 review；比照 #102/#104 的型別保真精神）。
+        return "null"
     if isinstance(value, bool):
         return "true" if value else "false"
     s = str(value)
@@ -105,8 +108,8 @@ def _scalar(value: Any) -> str:
     # A str value whose bare form would silently change type on re-parse
     # (numeric-like/bool-like/null-like/empty strings, e.g. "264" -> int 264)
     # must also be quoted (#102). Scoped to actual str inputs: non-str values
-    # (int/float/None/datetime, etc.) already serialize through the checks
-    # above using their str() form and are left as-is.
+    # (int/float/datetime, etc.; None handled above as null) already serialize
+    # through the checks above using their str() form and are left as-is.
     if not needs_quote and isinstance(value, str):
         needs_quote = _needs_quoting_for_type_fidelity(s)
     if needs_quote:

--- a/paulsha_hippo/tags_migration.py
+++ b/paulsha_hippo/tags_migration.py
@@ -32,7 +32,11 @@ def normalize_tags_migration(root_dir: Path | str, apply: bool = False) -> tuple
                 warnings.append(f"Failed to read {path}: {exc}")
                 continue
 
-            if fm.get("memory_layer") != "knowledge" and knowledge.exists():
+            # 無條件過濾（repo 慣例，比照 rekey.py/linker.py）：即使 knowledge
+            # 子目錄不存在而 fallback 掃 root，也只碰 memory_layer == "knowledge"
+            # 的 slice，--memory-root 打錯時不會改寫 inbox、episodic 或一般文件
+            # （issue #109 review）。
+            if fm.get("memory_layer") != "knowledge":
                 continue
 
             scanned += 1

--- a/paulsha_hippo/tags_migration.py
+++ b/paulsha_hippo/tags_migration.py
@@ -1,4 +1,73 @@
 """Module for normalizing non-string tags in knowledge slices."""
 
-def normalize_tags_migration(root_dir, apply: bool = False):
-    raise NotImplementedError("normalize_tags_migration not implemented yet")
+from __future__ import annotations
+
+from pathlib import Path
+from paulsha_hippo.atomizer.slice_frontmatter import normalize_tags
+from paulsha_hippo.moc import frontmatter_io as fio
+
+
+def normalize_tags_migration(root_dir: Path | str, apply: bool = False) -> tuple[dict, list[str]]:
+    """Scan knowledge slices for non-string tags and normalize them.
+
+    Returns (summary_dict, warnings_list).
+    """
+    root = Path(root_dir)
+    knowledge = root / "knowledge"
+    search_root = knowledge if knowledge.exists() else root
+
+    scanned = 0
+    pending_details: list[dict] = []
+    warnings: list[str] = []
+    updated = 0
+
+    if search_root.exists():
+        for path in sorted(search_root.rglob("*.md")):
+            if path.name.endswith("-moc.md"):
+                continue
+            try:
+                content = path.read_text(encoding="utf-8")
+                fm, _body = fio.read(content)
+            except (OSError, UnicodeDecodeError) as exc:
+                warnings.append(f"Failed to read {path}: {exc}")
+                continue
+
+            if fm.get("memory_layer") != "knowledge" and knowledge.exists():
+                continue
+
+            scanned += 1
+
+            raw_tags = fm.get("tags")
+            has_non_string = False
+            if isinstance(raw_tags, list):
+                has_non_string = any(not isinstance(t, str) for t in raw_tags)
+            elif raw_tags is not None:
+                has_non_string = True
+
+            if has_non_string:
+                norm_tags = normalize_tags(raw_tags)
+                try:
+                    rel_path = str(path.relative_to(root))
+                except ValueError:
+                    rel_path = str(path)
+
+                pending_details.append({
+                    "path": rel_path,
+                    "normalized_tags": norm_tags,
+                })
+
+                if apply:
+                    try:
+                        fio.update(path, {"tags": norm_tags})
+                        updated += 1
+                    except Exception as exc:
+                        warnings.append(f"Failed to update {path}: {exc}")
+
+    summary = {
+        "scanned": scanned,
+        "pending": len(pending_details),
+        "updated": updated,
+        "details": pending_details,
+    }
+    return summary, warnings
+

--- a/paulsha_hippo/tags_migration.py
+++ b/paulsha_hippo/tags_migration.py
@@ -1,0 +1,4 @@
+"""Module for normalizing non-string tags in knowledge slices."""
+
+def normalize_tags_migration(root_dir, apply: bool = False):
+    raise NotImplementedError("normalize_tags_migration not implemented yet")

--- a/tests/test_moc_frontmatter_io.py
+++ b/tests/test_moc_frontmatter_io.py
@@ -103,6 +103,39 @@ class ScalarQuotingRoundTripTests(unittest.TestCase):
                     self.assertTrue(all(isinstance(t, str) for t in fm2["tags"]))
 
 
+class NullFidelityRoundTripTests(unittest.TestCase):
+    """Issue #109 review：``_scalar(None)`` 曾輸出 ``None`` 字面值，但 PyYAML
+    不把 ``None`` 當 null 詞彙，``update()`` 往返後原生 null 劣化成字串
+    "None"（實質資料劣化）。修正為輸出 ``null``，比照 #102/#104 的型別保真
+    精神；同時與既有 ROUND_TRIP_HAZARDS 的字串 ``"null"``（維持引號字串）
+    方向相反、互不干擾。"""
+
+    def test_scalar_none_emits_yaml_null_literal(self):
+        self.assertEqual(fio._scalar(None), "null")
+
+    def test_null_values_survive_repeated_update_round_trips(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "s.md"
+            text = _slice_text().replace(
+                "distilled_from: claude:s1\n",
+                "distilled_from: claude:s1\n"
+                "fallback_note: null\n"
+                "distiller:\n  profile_id: cg\n  fallback_reason: null\n",
+            )
+            path.write_text(text, encoding="utf-8")
+            fm0, _ = fio.read(path.read_text(encoding="utf-8"))
+            self.assertIsNone(fm0["fallback_note"])
+            self.assertIsNone(fm0["distiller"]["fallback_reason"])
+
+            # 多輪無關欄位 update（janitor/moc 每輪 rewrite 劇本）後 null 不漂移
+            for i in range(2):
+                fio.update(path, {"title": f"pass {i}"})
+                fm, _ = fio.read(path.read_text(encoding="utf-8"))
+                self.assertIsNone(fm["fallback_note"], "top-level null 劣化成字串 'None'")
+                self.assertIsNone(fm["distiller"]["fallback_reason"], "nested null 劣化成字串 'None'")
+            self.assertIn("fallback_reason: null", path.read_text(encoding="utf-8"))
+
+
 class ProductionTagQuotingScenarioTests(unittest.TestCase):
     """整合測試：重現 issue #101 熱修（tag ``264`` -> ``"264"``）在下一輪
     ``frontmatter_io.update()`` 後被剝除引號、令 MOC index 的嚴格 tags

--- a/tests/test_tags_migration.py
+++ b/tests/test_tags_migration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -17,7 +18,7 @@ def _create_slice(root: Path, rel_path: str, tags: list | None, body: str = "Tes
             tags_yaml = "tags: []\n"
         else:
             tags_yaml = "tags:\n" + "\n".join(f"  - {'null' if t is None else t}" for t in tags) + "\n"
-    
+
     content = (
         "---\n"
         "slice_id: sl-test12345678\n"
@@ -31,6 +32,46 @@ def _create_slice(root: Path, rel_path: str, tags: list | None, body: str = "Tes
     )
     p.write_text(content, encoding="utf-8")
     return p
+
+
+# Production-shaped fixture（issue #109 review MAJOR）：仿 atomizer render() 的
+# canonical 形狀，涵蓋 update() 整份重 dump 時所有已知的表層/型別變化熱點——
+# json 引號 free-text 欄位、未引號 YAML datetime、裸 null distiller 欄位、
+# 非空 provenance/distiller dict、引號數字樣字串（version: "1"）。
+_PRODUCTION_SHAPED_SLICE = (
+    "---\n"
+    "phase: review\n"
+    'project: "github.com/hamanpaul/intellidbgkit"\n'
+    "slice_id: sl-1010b51101ebe096\n"
+    "artifact_kind: report\n"
+    'version: "1"\n'
+    "created_at: 2026-08-02 07:52:28\n"
+    "created_by: codex\n"
+    'source_session: "codex-session-0102"\n'
+    "gate_required: false\n"
+    "checksum: abc123checksum\n"
+    "memory_layer: knowledge\n"
+    "source_agent: codex\n"
+    'captured_at: "2026-08-02T07:52:28Z"\n'
+    "supersedes: []\n"
+    'distilled_from: "codex:codex-session-0102"\n'
+    'title: "Terminal directory seal: crash recovery"\n'
+    "tags:\n"
+    "  - terminal\n"
+    "  - 320\n"
+    "  - crash-recovery\n"
+    "provenance:\n"
+    '  repo: "hamanpaul/intellidbgkit"\n'
+    '  commit: "abc123"\n'
+    '  path: "docs/seal.md"\n'
+    "distiller:\n"
+    '  profile_id: "codex"\n'
+    "  tier: 1\n"
+    "  fallback_reason: null\n"
+    "---\n"
+    "Body line one\n"
+    "Body line two\n"
+)
 
 
 class NormalizeTagsMigrationTests(unittest.TestCase):
@@ -76,15 +117,20 @@ class NormalizeTagsMigrationTests(unittest.TestCase):
             p_int = _create_slice(root, "knowledge/testprj/with_int--sl-2.md", ["tag1", 320, "tag2"], body="Body content\nMore lines")
             p_complex = _create_slice(root, "knowledge/testprj/complex--sl-3.md", ["tag1", None, [1, 2]])
 
+            fm_int_before, body_int_before = fio.read(p_int.read_text(encoding="utf-8"))
+
             summary, warnings = tags_migration.normalize_tags_migration(root, apply=True)
             self.assertEqual(warnings, [])
             self.assertEqual(summary["updated"], 2)
 
-            # verify tags are strings now
-            fm_int, body_int = fio.read(p_int)
+            # verify tags are strings now, everything else parse-equivalent
+            fm_int, body_int = fio.read(p_int.read_text(encoding="utf-8"))
             self.assertEqual(fm_int["tags"], ["tag1", "320", "tag2"])
             self.assertTrue(all(isinstance(t, str) for t in fm_int["tags"]))
-            self.assertEqual(body_int.strip(), "Body content\nMore lines".strip())
+            self.assertEqual(body_int, body_int_before)
+            expected = dict(fm_int_before)
+            expected["tags"] = ["tag1", "320", "tag2"]
+            self.assertEqual(fm_int, expected)
 
             # rerun dry-run reports 0 pending
             summary2, warnings2 = tags_migration.normalize_tags_migration(root, apply=False)
@@ -96,6 +142,123 @@ class NormalizeTagsMigrationTests(unittest.TestCase):
             self.assertEqual(warnings3, [])
             self.assertEqual(summary3["updated"], 0)
 
+    def test_apply_on_production_shaped_slice_is_parse_equivalent_outside_tags(self):
+        """MAJOR 收斂鎖（issue #109 review）：apply 走 ``frontmatter_io.update()``
+        整份重 dump，YAML 表層形（引號樣式）可正規化，因此 SHALL 鎖的是
+        parse-equivalent 而非逐位元——body 逐位元不變；tags 以外所有 frontmatter
+        欄位 parsed 值不變，僅一個已宣告的型別正規化例外：
+
+        - 未引號 YAML datetime 標量（如 ``created_at: 2026-08-02 07:52:28``）
+          正規化為等值 ISO8601 字串。stage3 schema 對 ``created_at`` 的契約本來
+          就是字串（``lib/lifecycle/schema.py::_is_iso8601`` 對 datetime 物件
+          直接 FAIL），此轉換是朝 schema 收斂的正規化而非劣化。
+        - 裸 null（``fallback_reason: null``）維持 null——鎖住 #109 review 抓到
+          的 ``_scalar(None)`` → ``None`` 字面值 → 重讀劣化成字串 "None"。
+        """
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            p = root / "knowledge" / "prj" / "terminal-directory-seal--sl-1010b51101ebe096.md"
+            p.parent.mkdir(parents=True)
+            p.write_text(_PRODUCTION_SHAPED_SLICE, encoding="utf-8")
+
+            fm_before, body_before = fio.read(_PRODUCTION_SHAPED_SLICE)
+            # fixture 前提自檢：datetime 未引號、null 裸寫、version 為引號字串
+            self.assertIsInstance(fm_before["created_at"], datetime)
+            self.assertIsNone(fm_before["distiller"]["fallback_reason"])
+            self.assertIsInstance(fm_before["version"], str)
+
+            summary, warnings = tags_migration.normalize_tags_migration(root, apply=True)
+            self.assertEqual(warnings, [])
+            self.assertEqual(summary["updated"], 1)
+
+            text_after = p.read_text(encoding="utf-8")
+            fm_after, body_after = fio.read(text_after)
+
+            # body 逐位元不變
+            self.assertEqual(body_after, body_before)
+
+            # tags 以外全欄位 parsed-equality（含巢狀 dict 與型別）
+            expected = dict(fm_before)
+            expected["tags"] = ["terminal", "320", "crash-recovery"]
+            expected["created_at"] = str(fm_before["created_at"])  # 宣告的 datetime→ISO8601 str 正規化
+            self.assertEqual(fm_after, expected)
+
+            # 劣化熱點逐一點名：
+            self.assertTrue(all(isinstance(t, str) for t in fm_after["tags"]))
+            self.assertIsInstance(fm_after["created_at"], str)
+            self.assertEqual(fm_after["created_at"], "2026-08-02 07:52:28")
+            self.assertIsNone(fm_after["distiller"]["fallback_reason"], "null 劣化成字串 'None'")
+            self.assertIn("fallback_reason: null", text_after)
+            self.assertIsInstance(fm_after["version"], str, "引號數字樣字串被剝回 int（#102/#104 回歸）")
+            self.assertEqual(fm_after["title"], "Terminal directory seal: crash recovery")
+            self.assertEqual(fm_after["provenance"], {"repo": "hamanpaul/intellidbgkit", "commit": "abc123", "path": "docs/seal.md"})
+            self.assertEqual(fm_after["distiller"]["tier"], 1)
+
+            # 冪等：dry-run 歸零、再 apply 為 no-op 且 bytes 穩定
+            bytes_after_first_apply = p.read_bytes()
+            summary2, _ = tags_migration.normalize_tags_migration(root, apply=False)
+            self.assertEqual(summary2["pending"], 0)
+            summary3, _ = tags_migration.normalize_tags_migration(root, apply=True)
+            self.assertEqual(summary3["updated"], 0)
+            self.assertEqual(p.read_bytes(), bytes_after_first_apply)
+
+    def test_missing_knowledge_dir_never_touches_non_knowledge_markdown(self):
+        """MINOR 收斂（issue #109 review）：--memory-root 打錯（指到沒有
+        knowledge/ 的目錄）時，memory_layer 過濾必須無條件生效（repo 慣例，
+        比照 rekey.py/linker.py），fallback 掃描不得改寫 inbox/episodic 或一般
+        markdown 文件。"""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)  # 沒有 knowledge/ 子目錄
+            plain = root / "notes" / "plain-doc.md"
+            plain.parent.mkdir(parents=True)
+            plain.write_text("---\ntitle: doc\ntags:\n  - 320\n---\nplain body\n", encoding="utf-8")
+            inbox = root / "inbox" / "item.md"
+            inbox.parent.mkdir(parents=True)
+            inbox.write_text("---\nmemory_layer: inbox\ntags:\n  - 320\n---\ninbox body\n", encoding="utf-8")
+            # root 直下的 knowledge 層 slice（fallback 掃描的唯一合法對象）
+            direct = root / "direct--sl-9.md"
+            direct.write_text("---\nslice_id: sl-9\nmemory_layer: knowledge\ntags:\n  - 320\n---\ndirect body\n", encoding="utf-8")
+
+            plain_before = plain.read_bytes()
+            inbox_before = inbox.read_bytes()
+
+            summary, warnings = tags_migration.normalize_tags_migration(root, apply=True)
+
+            self.assertEqual(warnings, [])
+            self.assertEqual(summary["scanned"], 1)
+            self.assertEqual(summary["updated"], 1)
+            self.assertEqual(plain.read_bytes(), plain_before)
+            self.assertEqual(inbox.read_bytes(), inbox_before)
+            fm, _ = fio.read(direct.read_text(encoding="utf-8"))
+            self.assertEqual(fm["tags"], ["320"])
+
+    def test_scalar_tags_normalize_to_empty_list_locked_decision(self):
+        """決策鎖（issue #109 review）：非 list scalar tags（如 ``tags: hello``）
+        沿用 #101 單一真理來源 ``normalize_tags()`` 的語意——非 list 整體視為
+        空 list，migration 不另設第二套正規化規則（設計 D2 的取捨）。dry-run
+        預覽會顯示 ``normalized_tags: []``，操作者在 apply 前可見這個抹除。"""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            p = root / "knowledge" / "testprj" / "scalar--sl-4.md"
+            p.parent.mkdir(parents=True)
+            p.write_text(
+                "---\nslice_id: sl-4\nmemory_layer: knowledge\ntags: hello\n---\nbody\n",
+                encoding="utf-8",
+            )
+
+            summary, warnings = tags_migration.normalize_tags_migration(root, apply=False)
+            self.assertEqual(warnings, [])
+            self.assertEqual(summary["pending"], 1)
+            self.assertEqual(summary["details"][0]["normalized_tags"], [])
+
+            summary2, _ = tags_migration.normalize_tags_migration(root, apply=True)
+            self.assertEqual(summary2["updated"], 1)
+            fm, _ = fio.read(p.read_text(encoding="utf-8"))
+            self.assertEqual(fm["tags"], [])
+
+            summary3, _ = tags_migration.normalize_tags_migration(root, apply=False)
+            self.assertEqual(summary3["pending"], 0)
+
     def test_apply_followed_by_frontmatter_update_maintains_string_tags(self):
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -105,7 +268,7 @@ class NormalizeTagsMigrationTests(unittest.TestCase):
 
             # Simulate retitle / update
             fio.update(p_int, {"title": "Updated Title"})
-            fm_updated, _ = fio.read(p_int)
+            fm_updated, _ = fio.read(p_int.read_text(encoding="utf-8"))
             self.assertEqual(fm_updated["title"], "Updated Title")
             self.assertEqual(fm_updated["tags"], ["tag1", "320", "tag2"])
             self.assertTrue(all(isinstance(t, str) for t in fm_updated["tags"]))
@@ -113,4 +276,3 @@ class NormalizeTagsMigrationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_tags_migration.py
+++ b/tests/test_tags_migration.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from paulsha_hippo import tags_migration
+from paulsha_hippo.moc import frontmatter_io as fio
+
+
+def _create_slice(root: Path, rel_path: str, tags: list | None, body: str = "Test body", title: str = "Test Slice") -> Path:
+    p = root / rel_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tags_yaml = ""
+    if tags is not None:
+        if not tags:
+            tags_yaml = "tags: []\n"
+        else:
+            tags_yaml = "tags:\n" + "\n".join(f"  - {t}" for t in tags) + "\n"
+    
+    content = (
+        "---\n"
+        "slice_id: sl-test12345678\n"
+        "memory_layer: knowledge\n"
+        "project: testprj\n"
+        "artifact_kind: report\n"
+        f"title: \"{title}\"\n"
+        f"{tags_yaml}"
+        "---\n"
+        f"{body}\n"
+    )
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class NormalizeTagsMigrationTests(unittest.TestCase):
+    def test_dry_run_scans_and_reports_non_string_tags_without_modifying_files(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # 1. 正常 tags (全為 string)
+            p_normal = _create_slice(root, "knowledge/testprj/normal--sl-1.md", ["tag1", "tag2"])
+            # 2. 含裸 int tag
+            p_int = _create_slice(root, "knowledge/testprj/with_int--sl-2.md", ["tag1", 320, "tag2"])
+            # 3. 含 None 與嵌套 list 的 tags
+            p_complex = _create_slice(root, "knowledge/testprj/complex--sl-3.md", ["tag1", None, [1, 2]])
+
+            content_normal_before = p_normal.read_bytes()
+            content_int_before = p_int.read_bytes()
+            content_complex_before = p_complex.read_bytes()
+
+            summary, warnings = tags_migration.normalize_tags_migration(root, apply=False)
+
+            self.assertEqual(warnings, [])
+            self.assertEqual(summary["scanned"], 3)
+            self.assertEqual(summary["pending"], 2)
+            self.assertEqual(summary["updated"], 0)
+
+            # 驗證 2 個待修 slice 與各自的正規化預覽
+            pending_map = {item["path"]: item for item in summary["details"]}
+            rel_int = str(p_int.relative_to(root))
+            rel_complex = str(p_complex.relative_to(root))
+
+            self.assertIn(rel_int, pending_map)
+            self.assertIn(rel_complex, pending_map)
+            self.assertEqual(pending_map[rel_int]["normalized_tags"], ["tag1", "320", "tag2"])
+            self.assertEqual(pending_map[rel_complex]["normalized_tags"], ["tag1"])
+
+            # 確信位元不變 (bytes 比對)
+            self.assertEqual(p_normal.read_bytes(), content_normal_before)
+            self.assertEqual(p_int.read_bytes(), content_int_before)
+            self.assertEqual(p_complex.read_bytes(), content_complex_before)
+
+    def test_apply_normalizes_tags_preserves_other_fields_and_is_idempotent(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            p_int = _create_slice(root, "knowledge/testprj/with_int--sl-2.md", ["tag1", 320, "tag2"], body="Body content\nMore lines")
+            p_complex = _create_slice(root, "knowledge/testprj/complex--sl-3.md", ["tag1", None, [1, 2]])
+
+            summary, warnings = tags_migration.normalize_tags_migration(root, apply=True)
+            self.assertEqual(warnings, [])
+            self.assertEqual(summary["updated"], 2)
+
+            # verify tags are strings now
+            fm_int, body_int = fio.read(p_int)
+            self.assertEqual(fm_int["tags"], ["tag1", "320", "tag2"])
+            self.assertTrue(all(isinstance(t, str) for t in fm_int["tags"]))
+            self.assertEqual(body_int.strip(), "Body content\nMore lines".strip())
+
+            # rerun dry-run reports 0 pending
+            summary2, warnings2 = tags_migration.normalize_tags_migration(root, apply=False)
+            self.assertEqual(warnings2, [])
+            self.assertEqual(summary2["pending"], 0)
+
+            # rerun apply is no-op
+            summary3, warnings3 = tags_migration.normalize_tags_migration(root, apply=True)
+            self.assertEqual(warnings3, [])
+            self.assertEqual(summary3["updated"], 0)
+
+    def test_apply_followed_by_frontmatter_update_maintains_string_tags(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            p_int = _create_slice(root, "knowledge/testprj/with_int--sl-2.md", ["tag1", 320, "tag2"])
+
+            tags_migration.normalize_tags_migration(root, apply=True)
+
+            # Simulate retitle / update
+            fio.update(p_int, {"title": "Updated Title"})
+            fm_updated, _ = fio.read(p_int)
+            self.assertEqual(fm_updated["title"], "Updated Title")
+            self.assertEqual(fm_updated["tags"], ["tag1", "320", "tag2"])
+            self.assertTrue(all(isinstance(t, str) for t in fm_updated["tags"]))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_tags_migration.py
+++ b/tests/test_tags_migration.py
@@ -16,7 +16,7 @@ def _create_slice(root: Path, rel_path: str, tags: list | None, body: str = "Tes
         if not tags:
             tags_yaml = "tags: []\n"
         else:
-            tags_yaml = "tags:\n" + "\n".join(f"  - {t}" for t in tags) + "\n"
+            tags_yaml = "tags:\n" + "\n".join(f"  - {'null' if t is None else t}" for t in tags) + "\n"
     
     content = (
         "---\n"


### PR DESCRIPTION
## 摘要

新增 `hippo knowledge normalize-tags --memory-root <root> [--dry-run|--apply]` 一次性 migration CLI（`paulsha_hippo/tags_migration.py`），回填修復磁碟上既存非字串 tags 的 knowledge slice（如 #101 修復前寫入的裸數字 tag `320`），關閉 sticky partial 第六例的舊資料殘留面。

- **冪等掃描與改寫**：`--dry-run`（預設）僅回報待修 slice 數與正規化預覽、不動檔案；`--apply` 以 `normalize_tags()` 正規化後經 `frontmatter_io.update()` 安全改寫，契約鎖 parse-equivalent——body 逐位元不變、tags 以外欄位 parsed 值不變。修完再跑 `--dry-run` 回報 0。
- **安全邊界**：無條件過濾 `memory_layer != "knowledge"`（比照 rekey/linker 慣例），`--memory-root` 打錯也不會改寫 inbox/episodic 或一般 markdown；非 list scalar tags 依 #101 語意抹為 `[]`，以測試明文鎖住。
- **順手修 `_scalar()` 殘留風險**：`moc/frontmatter_io.py::_scalar()` 對 None 原輸出 `None` 字面值（往返劣化成字串 `"None"`），改輸出 YAML `null`，比照 #102/#104 型別保真精神。

驗證證據（worktree 內實跑）：

- `python3 -m pytest -q`：1748 passed, 4 skipped, 184 subtests passed in 95.01s
- `openspec validate --all --strict`：15 passed, 0 failed
- `python3 -m policy_check --repo .`：exit 0，無 FAIL；僅 R-22 既存懸空引用 advisory（26 筆 pre-existing，非本 PR 造成）

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

## 風險與回復

- **資料遷移**：一次性、冪等；預設 `--dry-run` 只讀不寫，`--apply` 才改檔。改寫契約為 parse-equivalent（body 逐位元不變），且無條件跳過非 knowledge layer，誤指 root 不會波及其他檔案。
- **回復**：memory root 通常在使用者資料目錄（非 git 管控），建議 `--apply` 前先以 `--dry-run` 確認範圍；若需回復可從備份還原，migration 本身不刪欄位、不動 body，破壞面極小。
- **未竟事項**：無；openspec change `issue-109-normalize-tags-migration` 隨本 PR 一併落地。

Closes #109
