### PR TITLE
chore(cortex): 註冊 2026-08-04 open-issue batch 的六個 work items

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -48,3 +48,51 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/workstreams/issue-64-ledger-torn-line-repair/todo.md'
     excludes: []
+  issue-98-search-retrieval-schema:
+    title: 'issue-98-search-retrieval-schema'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-hippo#98'
+      - kind: path
+        ref: 'docs/superpowers/plans/2026-08-04-issue-98-search-fts-sanitizer.md'
+    excludes: []
+  issue-74-local-harness-input-slicing:
+    title: 'issue-74-local-harness-input-slicing'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-hippo#74'
+      - kind: path
+        ref: 'docs/superpowers/plans/2026-08-04-issue-74-harness-input-slicing.md'
+    excludes: []
+  issue-99-cg-max-session-chunks:
+    title: 'issue-99-cg-max-session-chunks'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-hippo#99'
+      - kind: path
+        ref: 'docs/superpowers/plans/2026-08-04-issue-99-cg-max-session-chunks.md'
+    excludes: []
+  issue-105-proposal-soft-repair:
+    title: 'issue-105-proposal-soft-repair'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-hippo#105'
+      - kind: path
+        ref: 'docs/superpowers/plans/2026-08-04-issue-105-proposal-soft-repair.md'
+    excludes: []
+  issue-106-router-skipped-profile-provenance:
+    title: 'issue-106-router-skipped-profile-provenance'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-hippo#106'
+      - kind: path
+        ref: 'docs/superpowers/plans/2026-08-04-issue-106-router-skip-provenance.md'
+    excludes: []
+  issue-109-normalize-tags-migration:
+    title: 'issue-109-normalize-tags-migration'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-hippo#109'
+      - kind: path
+        ref: 'docs/superpowers/plans/2026-08-04-issue-109-normalize-tags-migration.md'
+    excludes: []


### PR DESCRIPTION
## 變更

`.cortex/work-items.yaml` 新增 issue 74/98/99/105/106/109 的 work item 登錄（github_issue link + accepted plan path link）。

## 為什麼

2026-08-04 batch 以 cortex workflow lane 驅動六個 issue（build 全數完成後因 [cortex#296](https://github.com/hamanpaul/paulsha-cortex/issues/296) 的 verify 閘門矛盾改走直接收尾，PR #110-#115 已 merge）。六個 WorkflowRun 保留於 instance `hippo-open-issues` 待 cortex#296 修復後稽核——work item 登錄需入庫供該稽核與 monitor read model 對齊。

## 豁免說明

- `skip-changelog`：純治理登錄資料（`.cortex/`），非 code_paths 變更、不影響任何執行路徑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GN6LmDgGKy8wyE8T77wDjg