### PR TITLE
fix(search): hippo search 走 to_fts_query 消毒——修 #98 含冒號查詢被當 FTS5 column-filter

### DIFF
--- a/changelog.d/98-search-fts-sanitizer.md
+++ b/changelog.d/98-search-fts-sanitizer.md
@@ -1,0 +1,9 @@
+---
+type: fix
+---
+- 修 issue #98：`hippo search` 對含冒號的查詢報 `search failed: no such column: build`。根因是 FTS5 對 `MATCH ?` 的綁定參數**仍會解析查詢語法**——`word:` 形式被當成 column-filter 前綴，該欄不存在即 `OperationalError`；裸露的 `AND`／`*`／`NEAR/`／未閉合引號同理是語法錯誤。本 issue 曾於 2026-08-05 關閉但無對應 commit 落地，缺陷在部署 build `1299fa1` 上仍完整重現，故重開修復。
+- 修法重用既有 sanitizer `paulsha_hippo/retrieval.py::to_fts_query()`，不新設計：prompt-time shortlist 路徑（`paulsha_hippo/hooks/_shortlist_common.py:377`）本來就走它，這正是 hooks 路徑不受此 bug 影響的原因；缺的是 `hippo search` CLI 這一條。
+- 消毒收在 `paulsha_hippo/moc/search.py::search()` 內而非 `moc/cli.py`：`search()` 的生產呼叫點目前僅 CLI 一處，收在函式內讓未來新增的 caller 也繞不過同一個收口點，而不是每個入口各自記得消毒。
+- 純 stopword／單字元輸入經 sanitizer 後為空字串，空 MATCH 本身是 FTS5 語法錯誤，故在開啟 DB 之前早退回傳 `[]`。
+- **語意變更（已於 docstring 標註）**：`to_fts_query()` 逐詞加引號後以 `OR` 串接，故多詞查詢由 FTS5 預設的隱含 AND 變為 OR，命中集合變寬，實際先後仍由既有 bm25 + link_weight + usage boost 排序決定。單詞查詢行為不變，既有排序／比對測試全數未動且通過。
+- 新增測試：含冒號查詢（`build: f5df394`）回傳正常結果而非拋錯；`AND* (bad`／未閉合引號／`NEAR/` 三種裸露運算子不再炸開；content-less 查詢在**開 DB 之前**早退（以 `sqlite3.connect` 未被呼叫斷言，而非只斷言回傳空集合——後者在修復前後皆成立、無法辨識缺陷）。

--- a/paulsha_hippo/moc/search.py
+++ b/paulsha_hippo/moc/search.py
@@ -20,6 +20,7 @@ from ..ledger import lifecycle
 from ..ledger import retrieval_set
 from ..ledger import usage as usage_ledger
 from ..noise import classify_noise, pool_exclude_reason
+from ..retrieval import to_fts_query
 from . import frontmatter_io as fio
 
 INDEX_WRITE_BATCH_SIZE = 100
@@ -479,9 +480,25 @@ def _row_read_count(row: tuple) -> int:
 
 def search(memory_root: Path, query: str, *, project: str | None, limit: int,
            include_decayed: bool) -> list[dict]:
+    """Lexical search over the slice index. ``query`` is arbitrary user text.
+
+    issue #98：`MATCH ?` 的綁定參數並不會讓 FTS5 停止解析查詢語法——`word:` 形式
+    仍被當成 column-filter 前綴（`build: f5df394` → `no such column: build`），裸露的
+    `AND` / `*` / `NEAR/` / 未閉合引號同理會是語法錯誤。消毒收在這裡而非 CLI，
+    讓所有 caller 共用同一個收口點；prompt-time shortlist 路徑
+    （`hooks/_shortlist_common.py`）本來就走同一個 `to_fts_query()`。
+
+    注意語意：`to_fts_query()` 逐詞加引號後以 OR 串接，故多詞查詢由 FTS5 預設的
+    隱含 AND 變成 OR，再由 bm25 排序決定先後——命中集合變寬、最相關者仍在前。
+    """
     path = index_path(memory_root)
     if not path.exists():
         raise SearchIndexError("search index not built; run the dream/moc pass first")
+    match_query = to_fts_query(query)
+    if not match_query:
+        # 純 stopword／單字元輸入沒有可搜尋的內容詞；空字串是 FTS5 語法錯誤，
+        # 因此在開 DB 之前早退。
+        return []
     conn = sqlite3.connect(path)
     try:
         has_usage_cols = _slice_meta_has_usage_columns(conn)
@@ -490,7 +507,7 @@ def search(memory_root: Path, query: str, *, project: str | None, limit: int,
                f"m.link_weight, m.active, m.path{usage_select} "
                "FROM slices_fts f JOIN slice_meta m ON m.slice_id = f.slice_id "
                "WHERE slices_fts MATCH ?")
-        params: list[object] = [query]
+        params: list[object] = [match_query]
         if project:
             sql += " AND m.project = ?"
             params.append(project)

--- a/tests/test_moc_search.py
+++ b/tests/test_moc_search.py
@@ -86,6 +86,42 @@ class SearchTests(unittest.TestCase):
             with self.assertRaises(search.SearchIndexError):
                 search.search(Path(tmp), "x", project=None, limit=5, include_decayed=False)
 
+    def test_query_with_colon_is_not_parsed_as_fts5_column_filter(self):
+        # issue #98：`MATCH ?` 的綁定參數仍由 FTS5 解析查詢語法，`word:` 形式會被
+        # 當成 column-filter 前綴，欄位不存在即 `no such column: build`。
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _slice(root, "sl-1", "proj", "candidate-notes", "candidate f5df394 rebind")
+            search.build_index(root, link_weights={})
+            hits = search.search(root, "build: f5df394", project=None, limit=5,
+                                 include_decayed=True)
+            self.assertEqual([h["slice_id"] for h in hits], ["sl-1"])
+
+    def test_query_with_fts5_operators_is_neutralized(self):
+        # 裸露的 FTS5 運算子同樣不得讓使用者查詢炸開。
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _slice(root, "sl-1", "proj", "alpha", "alpha body")
+            search.build_index(root, link_weights={})
+            for query in ('alpha AND* (bad', 'alpha "unbalanced', 'NEAR/'):
+                with self.subTest(query=query):
+                    search.search(root, query, project=None, limit=5, include_decayed=True)
+
+    def test_content_less_query_returns_empty_without_searching(self):
+        # sanitizer 對純 stopword／單字元輸入回傳空字串；空 MATCH 是 FTS5 語法錯誤，
+        # 故必須在開 DB 之前就早退，而不是送一個空查詢進去。
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _slice(root, "sl-1", "proj", "alpha", "alpha body")
+            search.build_index(root, link_weights={})
+            with mock.patch("paulsha_hippo.moc.search.sqlite3.connect") as connect:
+                self.assertEqual(
+                    search.search(root, "how do I", project=None, limit=5,
+                                  include_decayed=True),
+                    [],
+                )
+            connect.assert_not_called()
+
     def test_build_index_failure_preserves_existing_db(self):
         # #16：建索引中途失敗，舊 DB 必須完整保留（廢除先 unlink）
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 摘要

Closes #98

`hippo search` 對含冒號的查詢報 `search failed: no such column: build`。根因是 FTS5 對 `MATCH ?` 的**綁定參數仍會解析查詢語法**——`word:` 形式被當成 column-filter 前綴，該欄不存在即 `OperationalError`；裸露的 `AND`／`*`／`NEAR/`／未閉合引號同理是語法錯誤。

修法重用既有 sanitizer `paulsha_hippo/retrieval.py::to_fts_query()`，不新設計。prompt-time shortlist 路徑（`paulsha_hippo/hooks/_shortlist_common.py:377`）本來就走它，這正是 hooks 路徑不受此 bug 影響的原因；缺的只是 `hippo search` CLI 這一條。

消毒收在 `moc/search.py::search()` 內而非 `moc/cli.py`：`search()` 的生產呼叫點目前僅 CLI 一處，收在函式內讓未來新增的 caller 也繞不過同一個收口點，而不是每個入口各自記得消毒。純 stopword／單字元輸入經 sanitizer 後為空字串，而空 MATCH 本身是 FTS5 語法錯誤，故在開 DB 之前早退回傳 `[]`。

**使用者可見結果**：`hippo search "build: f5df394"` 由拋錯改為正常回傳結果。

**語意變更**：`to_fts_query()` 逐詞加引號後以 `OR` 串接，故多詞查詢由 FTS5 預設的隱含 AND 變為 OR——命中集合變寬，實際先後仍由既有 bm25 + link_weight + usage boost 排序決定。單詞查詢行為不變。已於 `search()` docstring 標註。

### 關於本 issue 曾被關閉

#98 於 2026-08-05 關閉，但 `main` 最後一個 commit 為 `1299fa1`（2026-07-31），關閉之後無任何 commit 落地，缺陷在部署 build 上仍完整重現，故重開修復。詳見 issue 內的重開紀錄。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過 — `python3 -m pytest tests/ -q` → `1729 passed, 4 skipped, 187 subtests passed`
- [x] `python3 -m policy_check --repo .`（含 PR context）通過 — R-01…R-26 全 pass，R-22 為既有的本地無 diff context 降級 WARN
- [x] OpenSpec validation 與 repo 額外 gates 通過 — `openspec validate --all --strict` → `14 passed, 0 failed`
- [x] `changelog.d/` 已有對應碎片 — `changelog.d/98-search-fts-sanitizer.md`
- [x] `VERSION` 與 release 意圖一致 — 未動（維持 `0.1.1`，本 PR 非 release PR）
- [x] 文件與 CLI help 已同步，或已說明不適用 — CLI 參數與 help 未變動；語意變更記於 `search()` docstring 與 changelog 碎片

新增三項測試，其中 content-less 那項刻意以「`sqlite3.connect` 未被呼叫」斷言而非只斷言回傳空集合——後者在修復前後皆成立，無法辨識缺陷。

## 風險與回復

- 無資料遷移、無 schema 變更、不觸及索引建置路徑。
- 唯一行為面風險是上述 AND→OR 的語意變更，影響範圍限於 `hippo search` CLI 的多詞查詢；shortlist 注入路徑本來就是 OR，不受影響。
- rollback 即 revert 本 PR，無殘留狀態。
- 本 PR 屬 0.1.2 凍結前最後一批；合併後仍需重新部署（`pipx install --force`）才會在 dream 服務生效。
