### PR TITLE
fix(router): 單次呼叫上限 300→600、chain 下限 600→1200——修 #119 tier-1 逾時致全鏈耗盡

### DIFF
--- a/changelog.d/119-per-call-timeout-600.md
+++ b/changelog.d/119-per-call-timeout-600.md
@@ -1,0 +1,10 @@
+---
+type: fix
+---
+- 修 issue #119 的子形狀 B（tier-1 撞單次呼叫上限後整條降級鏈耗盡致 park）：`agent_profiles.FIXED_TIMEOUT_SECONDS` 由 300 提高到 600。300s 與 `FIXED_PER_CHUNK_DEADLINE_SECONDS`（240s）源自同一批量測（per-chunk 實測約 190.5s / 244s），最慢 chunk 距離硬上限只剩 56s、19% 裕度，稍重的 chunk 即撞上限；且 #74 量到 local-vllm 在 effort high 需 400s，300s 使 tier-3 對大 payload **結構上不可能完成**。
+- **先評估過 progress-aware（idle）逾時並以實測否決**：`claude --print` 在完成前不吐任何 bytes——實測一次 12.0s 的呼叫，2632 bytes 全部在 12.0s 的單一 read 落地，之前為零。idle 偵測器看到的是整段呼叫都靜默，設任何門檻都會誤殺慢而有進展的呼叫。串流需改用 `--output-format stream-json`，會打破 router 解析的單一 JSON 回應契約，故不採用。此判斷已寫入 `FIXED_TIMEOUT_SECONDS` 的註解，避免日後重複調查。
+- **同步上抬 chain 下限**：`FIXED_SESSION_DEADLINE_SECONDS` 由 600 提高到 1200。`_run_one` 收到的是 `min(profile.timeout, remaining_seconds)`，下限等於單次上限時第一棒燒滿自己的預算就把整條 chain 吃光、fallback 一秒都拿不到——與 #85 註解點名的結構性飢餓同型，只是換了位置。新增 `test_session_floor_admits_two_full_per_call_budgets` 釘住「下限 ≥ 兩倍單次上限」的不變量，並以假時鐘寫了行為測試（第一棒燒滿整個單次預算後第二棒仍須拿得到完整呼叫）；兩者在只提高單次上限、未動下限時皆會失敗，已實測確認。
+- 出貨模板 `paulsha_hippo/atomizer/atomizer.yaml` 的 `external_agents.deadline_seconds` 同步 600 → 1200。`atomizer/config.py` 對此值採 fail-closed（不等於常數即拒絕載入），故**部署時必須與 live config 同時更新**，詳見下方。
+- 同樣把 #114 新增的四個 deadline-break 測試改為常數推導。它們原本把時間推進量寫死（`700.0` / `650.0` / `350.0`），那是照當時 600s chain 下限校準的——下限提到 1200 後這些數字不再耗盡預算、deadline break 不會發生，測試意圖（「第幾棒之後耗盡」）隨之失效而非只是數字不合。改以 `session_deadline_seconds(1)` 推導出 `_EXHAUSTS_CHAIN_BUDGET` 與 `_HALF_CHAIN_BUDGET` 兩個具名量。
+- 清理兩處把 300 寫死、因而會隨常數漂移的測試設施：`tests/test_atomizer_backend_matrix.py` 的 `_write_profile()` 預設值與 `tests/stage2_integration_check.sh` 的 stub profile，改為引用 `FIXED_TIMEOUT_SECONDS`。既有的 per-call timeout 邊界測試改以常數表達（原本斷言字面值 `[300, 150]`，常數變動後第二個分支不再被觸發、失去覆蓋意義）。
+- **部署順序（重要）**：`FIXED_SESSION_DEADLINE_SECONDS` 與 live config 的 `external_agents.deadline_seconds` 必須**同時**變更。單獨改 live config 為 1200 而未重裝，會讓仍是 600 的已部署副本每輪 `AtomizerConfigError` 失敗；單獨重裝而未改 live config 亦然。正確步驟：`pipx install --force <repo>` 與 live config 改值一併完成，再 `hippo install service --enable` 更新 unit 的 `HIPPO_BUILD_COMMIT`。此為 2026-07-28 同型事故的反向重演，已於常數註解與模板註解兩處標註。

--- a/paulsha_hippo/agent_profiles.py
+++ b/paulsha_hippo/agent_profiles.py
@@ -22,19 +22,42 @@ from typing import Any, Callable, ClassVar, Mapping, Sequence
 ROUTER_CONTRACT_VERSION = "1"
 RESPONSE_SCHEMA_VERSION = "1"
 MIN_PROVIDER_CONTEXT = 32_768
-FIXED_TIMEOUT_SECONDS = 300
+# Bound for a *single* agent call; hang protection. Raised 300 -> 600 by issue
+# #119. 300s was calibrated from the same measurements as
+# FIXED_PER_CHUNK_DEADLINE_SECONDS below (per-chunk completion of roughly
+# 190.5s / 244s), leaving the worst measured chunk only 56s -- 19% -- of
+# headroom, so any chunk slightly heavier than the measurement window hit the
+# cap and fell through the chain. Worse, issue #74 measured local-vllm needing
+# 400s at effort high, which made the tier-3 fallback structurally incapable of
+# finishing a large payload no matter how much chain budget remained.
+#
+# An idle-based ("progress-aware") detector would be the principled way to tell
+# a hung call from a slow-but-progressing one, and was evaluated first. It is
+# not implementable here: `claude --print` emits nothing until completion
+# (measured: a 12.0s run delivered all 2632 bytes in a single read at 12.0s,
+# zero bytes before), so an idle detector observes total silence for the entire
+# call and would kill every slow call at whatever threshold it used. Streaming
+# would require `--output-format stream-json`, which breaks the single-JSON
+# response contract the router parses.
+FIXED_TIMEOUT_SECONDS = 600
 # Bound for the *whole* fallback chain, distinct from FIXED_TIMEOUT_SECONDS which
 # bounds a *single* agent call. Conflating the two structurally starves every
 # profile after the first: `_run_one` receives
 # `min(profile.timeout, remaining_seconds)`, so when four eligible profiles share
 # one agent's worth of budget the tier-3 fallback can never get its allotted
 # time. Measured: claude 35.1s + codex 16.5s + cg 66.6s consumed 118s of a 300s
-# session budget, leaving local-vllm 181s for work that needed 203s. The
-# per-call cap (and therefore hang protection) is deliberately left unchanged;
-# only the chain-wide budget grows, so a slow-but-progressing fallback can run
-# to its own limit instead of inheriting the leftovers.
-# 600s remains the lower bound to preserve single/double-chunk behavior.
-FIXED_SESSION_DEADLINE_SECONDS = 600
+# session budget, leaving local-vllm 181s for work that needed 203s.
+#
+# The floor must therefore stay at least two per-call budgets wide, or a first
+# profile that burns its full call leaves the fallback nothing at all -- the
+# same starvation in a new place. #119 raised it 600 -> 1200 in lockstep with
+# the per-call cap; `test_session_floor_admits_two_full_per_call_budgets` locks
+# the invariant so a future bump to one constant cannot silently re-open it.
+# NOTE: `atomizer/config.py` rejects any `external_agents.deadline_seconds`
+# that is not exactly this value, so changing it REQUIRES updating the shipped
+# `atomizer.yaml` template *and* every deployment's live config in the same
+# release -- an unsynchronized live config fails every dream cycle closed.
+FIXED_SESSION_DEADLINE_SECONDS = 1200
 # 240s/chunk is anchored by observed per-chunk completion on large sessions
 # (roughly 190.5s / 244s in measured profiles); the cap was tuned so one
 # session doesn't monopolize the hourly timer cycle.

--- a/paulsha_hippo/atomizer/atomizer.yaml
+++ b/paulsha_hippo/atomizer/atomizer.yaml
@@ -27,7 +27,11 @@ phase_map:
 default_artifact_kind: report
 default_phase: review
 external_agents:
-  deadline_seconds: 600
+  # issue #119：必須恰等於 agent_profiles.FIXED_SESSION_DEADLINE_SECONDS，
+  # 否則 config 載入 fail-closed。單次呼叫上限由 300 提到 600 之後，chain
+  # 下限同步 600 → 1200，讓第一棒燒滿自己的預算後 fallback 仍拿得到一次
+  # 完整呼叫。改這個值必須同時更新每個 deployment 的 live config。
+  deadline_seconds: 1200
   max_attempts: 6
   max_agent_calls: 6
   profiles:

--- a/tests/stage2_integration_check.sh
+++ b/tests/stage2_integration_check.sh
@@ -175,6 +175,8 @@ from pathlib import Path
 
 import yaml
 
+from paulsha_hippo.agent_profiles import FIXED_TIMEOUT_SECONDS
+
 config_path = Path(os.environ["ATOMIZE_CONFIG_ROOT"]) / "config.yaml"
 document = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 document["known_projects_file"] = os.environ["ATOMIZE_PROJECTS"]
@@ -183,7 +185,8 @@ document["external_agents"]["profiles"] = [{
     "traits": ["test"], "task_classes": ["atomization"],
     "model": "fake-agent", "supported_models": ["fake-agent"],
     "effort": "medium", "supported_efforts": ["medium"],
-    "timeout": 300,
+    # profile 解析要求恰等於 FIXED_TIMEOUT_SECONDS，不可硬編碼數值（#119）
+    "timeout": FIXED_TIMEOUT_SECONDS,
     "argv": ["python3", os.environ["ATOMIZE_AGENT"]],
 }]
 config_path.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")

--- a/tests/test_atomizer_backend_matrix.py
+++ b/tests/test_atomizer_backend_matrix.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from paulsha_hippo import cli as memory_cli, paths
+from paulsha_hippo.agent_profiles import FIXED_TIMEOUT_SECONDS
 from paulsha_hippo.ledger import processing
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "atomizer"
@@ -32,7 +33,8 @@ def _seed(root: Path) -> None:
     shutil.copyfile(RAW_FIXTURE, raw)
 
 
-def _write_profile(root: Path, agent_script: str, *, timeout_seconds: int = 300) -> None:
+def _write_profile(root: Path, agent_script: str,
+                   *, timeout_seconds: int = FIXED_TIMEOUT_SECONDS) -> None:
     import yaml
 
     projects = root / "projects.yaml"
@@ -132,7 +134,7 @@ class NonZeroExitTests(unittest.TestCase):
 
 
 class TimeoutTests(unittest.TestCase):
-    def test_timeout_override_cannot_weaken_fixed_300_second_contract(self):
+    def test_timeout_override_cannot_weaken_the_fixed_per_call_contract(self):
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             _seed(root)
@@ -140,7 +142,7 @@ class TimeoutTests(unittest.TestCase):
             rc, out = _atomize(root, "2026-07-10T00:00:00Z")
             self.assertEqual(rc, 1)
             self.assertIsNone(processing.state_of(root, SESSION_KEY))
-            self.assertIn("timeout is fixed at 300", out)
+            self.assertIn(f"timeout is fixed at {FIXED_TIMEOUT_SECONDS}", out)
             self.assertEqual(_cache_json_files(root), [])
 
 

--- a/tests/test_atomizer_config.py
+++ b/tests/test_atomizer_config.py
@@ -418,11 +418,18 @@ class SessionDeadlineStarvationTests(unittest.TestCase):
         finally:
             path.unlink(missing_ok=True)
 
-    def test_per_agent_timeout_cap_is_unchanged(self):
-        """Hang protection for a single call must not be relaxed by this fix."""
+    def test_per_agent_timeout_cap_is_pinned_and_not_per_deployment(self):
+        """單次呼叫的 hang protection 仍是固定值，且不可由 deployment 覆寫。
+
+        #75 當時的立場是「本修復不放寬單次上限」，故此測試原本釘住 300。#119
+        以量測推翻了那個值本身——300s 距離實測最慢 chunk（244s）只剩 19% 裕度，
+        且低於 #74 量到的 local-vllm effort-high 400s，使 tier-3 對大 payload
+        結構上不可能完成。值改為 600，但「固定、不可 per-deployment 覆寫」這個
+        性質不變，仍由 `agent_profiles` 的 profile 解析主動拒絕覆寫。
+        """
         from paulsha_hippo.agent_profiles import FIXED_TIMEOUT_SECONDS, AgentProfile
 
-        self.assertEqual(FIXED_TIMEOUT_SECONDS, 300)
+        self.assertEqual(FIXED_TIMEOUT_SECONDS, 600)
         self.assertEqual(AgentProfile.timeout, FIXED_TIMEOUT_SECONDS)
 
 

--- a/tests/test_external_agent_profiles.py
+++ b/tests/test_external_agent_profiles.py
@@ -17,6 +17,8 @@ from paulsha_hippo.agent_profiles import (
     FIXED_PER_CHUNK_DEADLINE_SECONDS,
     FIXED_SESSION_DEADLINE_CAP_SECONDS,
     FIXED_SESSION_DEADLINE_SECONDS,
+    FIXED_TIMEOUT_SECONDS,
+    AgentRunError,
     cache_identity,
     child_environment,
     default_profiles,
@@ -121,12 +123,22 @@ def test_per_call_timeout_still_bounded_by_fixed_timeout_seconds():
 
     router = ExternalAgentRouter((_profile("only", tier=1),))
     router._run_one = run_one  # type: ignore[method-assign]
+    # Both branches of `min(profile.timeout, remaining_seconds)` must stay
+    # covered: chunk 0 starts with the whole chain budget available and is
+    # therefore bounded by the per-call cap, while chunk 1 starts late enough
+    # that the *remaining* budget is the smaller of the two. Expressed via the
+    # constants rather than literals so raising either one (issue #119 raised
+    # both) cannot silently collapse this into a single-branch test.
+    tail_remaining = 300
+    elapsed = session_deadline_seconds(2) - tail_remaining
+    assert tail_remaining < FIXED_TIMEOUT_SECONDS  # chunk 1 must hit the remainder branch
+
     # 9 monotonic() reads per this 1-profile/2-chunk session: started, the
     # deadline/circuit checks, attempt_started, then per chunk a shared
     # chunk_started/remaining_seconds read plus one elapsed-time read after
     # the call returns (issue #86 per-chunk provenance), and finally the
     # attempt's own elapsed-time read.
-    time_points = iter([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 450.0, 450.0, 450.0])
+    time_points = iter([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, elapsed, elapsed, elapsed])
 
     original_monotonic = time.monotonic
     time.monotonic = lambda: next(time_points)  # type: ignore[method-assign]
@@ -138,7 +150,7 @@ def test_per_call_timeout_still_bounded_by_fixed_timeout_seconds():
     finally:
         time.monotonic = original_monotonic
 
-    assert captured == [300, 150]
+    assert captured == [FIXED_TIMEOUT_SECONDS, tail_remaining]
 
 
 def test_router_rejects_invalid_max_session_chunks():
@@ -1123,6 +1135,14 @@ def test_session_cache_lands_validated_chunk_even_when_session_later_exhausts(tm
     assert payloads[0]["provenance"]["profile_id"] == "first"
 
 
+# issue #114 的四個 deadline-break 測試原本把時間推進量寫死（700.0 / 650.0 /
+# 350.0），那是照當時的 600s chain 下限校準的。#119 把下限提到 1200 後，寫死的
+# 數字不再耗盡預算、deadline break 不會發生，測試意圖隨之失效。改以常數推導，
+# 讓「幾棒之後耗盡」這個意圖不隨下限數值漂移。單 chunk session 走 chain 下限。
+_EXHAUSTS_CHAIN_BUDGET = session_deadline_seconds(1) + 1.0
+_HALF_CHAIN_BUDGET = session_deadline_seconds(1) / 2 + 1.0
+
+
 def test_router_session_deadline_break_records_skipped_profile_provenance(monkeypatch):
     import time
     from paulsha_hippo.agent_profiles import AgentRunError
@@ -1141,7 +1161,7 @@ def test_router_session_deadline_break_records_skipped_profile_provenance(monkey
 
     def execute(profile, prompt, attempt):
         if profile.id == "claude":
-            current_time[0] += 700.0
+            current_time[0] += _EXHAUSTS_CHAIN_BUDGET
             raise AgentRunError("claude timeout", category="timeout")
         return "answer", "", 0
 
@@ -1187,7 +1207,7 @@ def test_router_deadline_break_raise_reports_terminal_real_attempt(monkeypatch):
     monkeypatch.setattr(time, "monotonic", lambda: current_time[0])
 
     def execute(profile, prompt, attempt):
-        current_time[0] += 350.0
+        current_time[0] += _HALF_CHAIN_BUDGET
         raise AgentRunError(f"{profile.id} timeout", category="timeout")
 
     router = ExternalAgentRouter((claude, codex, cg, local_vllm), executor=execute)
@@ -1229,7 +1249,7 @@ def test_router_mid_attempt_budget_break_records_skipped_profile_provenance(monk
     def execute(profile, prompt, attempt):
         # chunk-0 validates but eats the whole session deadline; chunk-1 then
         # hits the in-attempt remaining_seconds <= 0 budget raise.
-        current_time[0] += 650.0
+        current_time[0] += _EXHAUSTS_CHAIN_BUDGET
         return "answer", "", 0
 
     router = ExternalAgentRouter((claude, codex, cg, local_vllm), executor=execute)
@@ -1266,7 +1286,7 @@ def test_router_deadline_break_does_not_record_circuit_open_profile(monkeypatch)
     monkeypatch.setattr(time, "monotonic", lambda: current_time[0])
 
     def execute(profile, prompt, attempt):
-        current_time[0] += 700.0
+        current_time[0] += _EXHAUSTS_CHAIN_BUDGET
         raise AgentRunError("claude timeout", category="timeout")
 
     router = ExternalAgentRouter((claude, codex, cg, local_vllm), executor=execute)
@@ -1297,7 +1317,7 @@ def test_router_skip_records_may_exceed_max_attempts(monkeypatch):
     monkeypatch.setattr(time, "monotonic", lambda: current_time[0])
 
     def execute(profile, prompt, attempt):
-        current_time[0] += 700.0
+        current_time[0] += _EXHAUSTS_CHAIN_BUDGET
         raise AgentRunError("claude timeout", category="timeout")
 
     router = ExternalAgentRouter(
@@ -1336,3 +1356,43 @@ def test_router_sufficient_deadline_provenance_unchanged():
 
 
 
+
+def test_session_floor_admits_two_full_per_call_budgets():
+    """Issue #119：單次呼叫上限與 chain 下限之間必須留得下第二棒。
+
+    `_run_one` 收到的是 ``min(profile.timeout, remaining_seconds)``，所以當
+    chain 下限等於單次上限時，第一棒耗盡自己的預算就把整條 chain 吃光，
+    fallback 一秒都拿不到——正是 #85 註解點名的結構性飢餓。把單次上限由
+    300 提到 600（#74 實測 local-vllm effort high 需 400s，300s 讓 tier-3 對
+    大 payload 結構上不可能完成）之後，下限必須同步上抬，否則修好 tier-3
+    的同時會廢掉小 session 的 fallback。
+    """
+    assert FIXED_SESSION_DEADLINE_SECONDS >= 2 * FIXED_TIMEOUT_SECONDS
+
+
+def test_first_profile_burning_full_per_call_budget_does_not_starve_fallback(monkeypatch):
+    """第一棒燒滿單次預算後，第二棒仍必須拿得到一次完整呼叫。
+
+    以假時鐘取代真 sleep：executor 每次被呼叫就把時鐘推進整個單次上限，
+    模擬「跑到自己的上限才失敗」的最壞情況。單 chunk session 走 chain 下限。
+    """
+    clock = {"now": 0.0}
+    monkeypatch.setattr(
+        "paulsha_hippo.agent_profiles.time.monotonic", lambda: clock["now"]
+    )
+
+    profiles = (_profile("first", tier=1), _profile("second", tier=2))
+    calls: list[str] = []
+
+    def execute(profile, prompt, call):
+        calls.append(profile.id)
+        clock["now"] += FIXED_TIMEOUT_SECONDS
+        if profile.id == "first":
+            raise AgentRunError(
+                "agent timed out", category="timeout", profile_id=profile.id
+            )
+        return "valid", "", 0
+
+    router = ExternalAgentRouter(profiles, executor=execute)
+    assert router.run_session(("chunk-0",)) == ("valid",)
+    assert calls == ["first", "second"]


### PR DESCRIPTION
## 摘要

Closes #119

修 issue #119 的**子形狀 B**（tier-1 撞單次呼叫上限後整條降級鏈耗盡致 park）。子形狀 A（tier-2/tier-3 大 payload 承接不住）由 #99 與 #74 各自處理，不在本 PR 範圍。

### 為什麼是 600

`FIXED_TIMEOUT_SECONDS` 由 300 提高到 600：

- 300s 與 `FIXED_PER_CHUNK_DEADLINE_SECONDS`（240s）**源自同一批量測**（per-chunk 實測約 190.5s / 244s），最慢 chunk 距離硬上限只剩 56s、19% 裕度。稍重於量測窗口的 chunk 就撞上限，profile 以 `timeout` 失敗並落入下一棒。
- #74 量到 local-vllm 在 effort high 需 400s。300s 的單次上限讓 tier-3 對大 payload **結構上不可能完成**，無論 chain 還剩多少預算。

### progress-aware 逾時：評估後以實測否決

原本的首選方案是改用 idle 判定（stdout 靜默 N 秒才算 hang），既保留 hang protection 又不殺慢而有進展的呼叫。**實測否決**：

```
claude --print → exit=0 total=12.0s reads=1
first byte at 12.0s, last byte at 12.0s
verdict: SINGLE BURST
```

`claude --print` 在完成前不吐任何 bytes——2632 bytes 全部在 12.0s 的單一 read 落地。idle 偵測器看到的是整段呼叫都靜默，設任何門檻都會誤殺，而 claude 正是本批 timeout park 的來源 profile。串流需改用 `--output-format stream-json`，會打破 router 解析的單一 JSON 回應契約。此判斷已寫進 `FIXED_TIMEOUT_SECONDS` 的註解，避免日後重複調查。

### chain 下限必須同步上抬

`_run_one` 收到的是 `min(profile.timeout, remaining_seconds)`。下限等於單次上限時，第一棒燒滿自己的預算就把整條 chain 吃光，fallback 一秒都拿不到——與 #85 註解點名的結構性飢餓同型，只是換了位置。故 `FIXED_SESSION_DEADLINE_SECONDS` 同步 600 → 1200。

兩個新測試釘住這件事，且**都在只提高單次上限、未動下限時實測失敗過**：

- `test_session_floor_admits_two_full_per_call_budgets` — 不變量：下限 ≥ 兩倍單次上限。
- `test_first_profile_burning_full_per_call_budget_does_not_starve_fallback` — 行為：以假時鐘讓第一棒燒滿整個單次預算，第二棒仍須拿得到完整呼叫。未修時報 `fallback exhausted (timeout)`，第二棒完全沒跑。

### 順帶清掉的硬編碼

`tests/test_atomizer_backend_matrix.py` 的 `_write_profile()` 預設值與 `tests/stage2_integration_check.sh` 的 stub profile 都把 `timeout` 寫死 300，常數一動就整批失敗（本次實際被它們擋下）。兩處改為引用 `FIXED_TIMEOUT_SECONDS`。既有的 per-call timeout 邊界測試原本斷言字面值 `[300, 150]`，常數變動後第二個分支不再被觸發、失去覆蓋意義，改以常數表達並加上「必須落在 remainder 分支」的前置斷言。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過 — `python3 -m pytest tests/ -q` → `1728 passed, 4 skipped, 184 subtests passed`
- [x] `python3 -m policy_check --repo .`（含 PR context）通過 — R-01…R-26 全 pass，R-22 為既有的本地無 diff context 降級 WARN
- [x] OpenSpec validation 與 repo 額外 gates 通過 — `openspec validate --all --strict` → `14 passed, 0 failed`
- [x] `changelog.d/` 已有對應碎片 — `changelog.d/119-per-call-timeout-600.md`
- [x] `VERSION` 與 release 意圖一致 — 未動（維持 `0.1.1`，本 PR 非 release PR）
- [x] 文件與 CLI help 已同步，或已說明不適用 — 無 CLI 介面變動；兩個常數的立法理由與部署耦合寫在 `agent_profiles.py` 常數註解與 `atomizer.yaml` 模板註解

## 風險與回復

**部署順序是本 PR 最大的風險，且無法只靠 merge 完成。**

`atomizer/config.py:598` 對 `external_agents.deadline_seconds` 採 fail-closed——不等於 `FIXED_SESSION_DEADLINE_SECONDS` 即拒絕載入。因此：

- 單獨把 live config 改成 1200 而未重裝 → 仍是 600 的已部署副本每輪 `AtomizerConfigError` 失敗。
- 單獨重裝而未改 live config → 新副本要 1200、live config 給 600，同樣每輪失敗。

這是 2026-07-28 事故的反向重演（當時是 live config 改 600、安裝副本仍是 300 的檢查）。**正確步驟**：`pipx install --force <repo>` 與 live config 改值一併完成，再 `hippo install service --enable` 更新 unit 的 `HIPPO_BUILD_COMMIT`。

其他：

- 無資料遷移、無 schema 變更。
- 行為面：小 session 的 chain 預算由 600s 增為 1200s，最壞情況下單一 session 佔用 timer cycle 的時間上限不變（`FIXED_SESSION_DEADLINE_CAP_SECONDS` 1800 未動）。
- rollback 為 revert 本 PR + 同步回滾 live config 的 `deadline_seconds`，兩者同樣必須成對。
- 本 PR 屬 0.1.2 凍結前最後一批；部署換版會依 AR-11 窗口語意重開 soak 窗口。
