### PR TITLE
fix(local-harness): pass 2 content-addressed 切輸入——修 #74 每個 concept 重送全量 payload

### DIFF
--- a/changelog.d/74-local-harness-input-windowing.md
+++ b/changelog.d/74-local-harness-input-windowing.md
@@ -1,0 +1,12 @@
+---
+type: fix
+---
+- 修 issue #74：`contrib/local-harness/harness.py` 的 map-reduce 只切輸出不切輸入——pass 2 每個 concept 的 write 都把整份 session payload（實測約 100KB）重送一遍，只在指令文字裡「告訴」模型該用哪些 fragment index。`maxItems: 8` 的 concept 上限意味著最壞情況 9 次呼叫 × 100KB ≈ 900KB 的輸入處理量，即 #74 量到的 203s／357s／400s 的來源。
+- 新增 `window_prompt()`：以 pass 1 已算出的 `fragment_indices`（`ENUM_SCHEMA` 的**必填**欄位，`minItems: 1`）content-addressed 地裁切輸入，只送該 concept 實際引用的 fragments。切分依據是 hippo 既有的 prompt 結構（`paulsha_hippo/atomizer/prompt.py` 對每個 fragment 輸出 `[fragment N]` 標記），**不需要改動 hippo 端的 prompt 契約**。
+- 預設附帶 ±1 鄰域（`NEIGHBOUR_FRAGMENTS = 1`）：決策往往落在觸發它的指令的下一個 turn，補鄰域是廉價的脈絡保險；設 0 即停用。
+- **fail-safe 優先於省時**：結構無法辨識（找不到 fragments／Output 標頭）、`fragment_indices` 為空、或裁切後零 fragment 命中時，一律回退送出**完整原始 prompt**。失去 skill contract 的殘缺 prompt，或沒有任何 fragment 的 prompt，都比慢但完整的呼叫糟糕得多。split fragment 的每個 part 都隨其 index 一起保留。
+- pass 2 組訊息的邏輯抽成 `build_write_message()` 並加測試守護：切輸入若被改回整份重送，會是一個 token 的隱形變更，抽出來才測得到「有沒有真的接上」，而不只測「切法對不對」。
+- 修正兩處已失真的註解：`REQUEST_TIMEOUT_S` 原註明「keep under hippo external_agents.deadline_seconds=300」，但真正約束單次呼叫的是 `agent_profiles.FIXED_TIMEOUT_SECONDS`（chain 全鏈預算不決定單次呼叫能跑多久）；270 同時低於舊的 300 與 #119 提高後的 600，且切輸入才是讓 per-write 耗時下降的主因，此上限已非綁定約束。模組 docstring 同步。
+- 新增 `tests/test_local_harness_windowing.py`（9 項）。`contrib/**` 不在 `code_paths` 內、原本無任何測試覆蓋，但它是 tier-3 保底層的實作，切輸入的正確性直接決定大 session 會不會 park，故納入 repo 測試套件（以 importlib 由檔案路徑載入；模組無 import 副作用）。
+- **未經 live 驗證**：本次無法對地端引擎實跑——`http://192.168.199.199:8001/v1` 於撰寫時無回應（連線 timeout）。因此耗時改善為依 payload 縮減幅度推導，**非實測值**；部署後應以實際 session 重新量測 per-write 耗時與 `truncated at max_tokens` 發生率，再回填證據。
+- **部署**：`~/.local/bin/local-vllm` 是本檔的獨立副本（撰寫時與 repo 版 byte-identical），不隨 wheel 發布。本修復要生效必須另外把 `contrib/local-harness/harness.py` 複製過去，`pipx install --force` 不會涵蓋它。

--- a/contrib/local-harness/harness.py
+++ b/contrib/local-harness/harness.py
@@ -20,8 +20,10 @@ Quality levers (方案 1/3 of issue #55):
     - guided decoding: response_format json_schema = hippo canonical schema v1
     - reasoning control mapped from {EFFORT}: low -> thinking off,
       medium -> reasoning_effort low, high -> model default
-    - temperature 0 + fixed seed, bounded max_tokens, request timeout < hippo
-      deadline_seconds (300)
+    - temperature 0 + fixed seed, bounded max_tokens, request timeout under
+      hippo's per-call cap (agent_profiles.FIXED_TIMEOUT_SECONDS)
+    - pass 2 sends only the fragments a concept actually cites, not the whole
+      session payload (issue #74)
     - one retry-with-repair round on canonical-validation failure; then fail
       closed (non-zero exit, empty stdout) so hippo parks the session
 """
@@ -29,6 +31,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -37,7 +40,13 @@ from pathlib import Path
 HARNESS_DIR = Path(__file__).resolve().parent
 SCHEMA_PATH = HARNESS_DIR / "schema-v1.json"
 DEFAULT_ENV_FILE = "~/.config/paulsha-hippo/local-vllm.env"
-REQUEST_TIMEOUT_S = 270  # keep under hippo external_agents.deadline_seconds=300
+# Must stay under hippo's *per-call* cap (agent_profiles.FIXED_TIMEOUT_SECONDS),
+# not the chain-wide `external_agents.deadline_seconds` the old comment named --
+# a single write that outlives the per-call cap is killed by hippo regardless of
+# how much chain budget remains. 270 sits under both the old 300 and the 600 that
+# issue #119 raised it to; issue #74's input windowing is what brings per-write
+# time down, so this ceiling is no longer the binding constraint.
+REQUEST_TIMEOUT_S = 270
 SEED = 20260723
 
 ARTIFACT_KINDS = {
@@ -252,6 +261,83 @@ Return ONLY the JSON object for this one slice.
 """
 
 
+# ---- content-addressed input windowing (issue #74) -----------------------
+# Pass 1 already computes, per concept, exactly which fragments support it
+# (`fragment_indices` is a *required*, minItems:1 field of ENUM_SCHEMA). Before
+# this, pass 2 threw that away and re-sent the entire prompt for every concept,
+# merely *naming* the indices in the instruction text: with `maxItems: 8` the
+# worst case was 9 calls x the full payload (~100KB measured), which is where
+# the 200-400s per-write times came from. Since the prompt labels every
+# fragment (`paulsha_hippo/atomizer/prompt.py` emits `[fragment N]`), the input
+# can be cut here without any change to hippo's prompt contract.
+FRAGMENTS_HEADER = "## Session fragments to atomize"
+OUTPUT_HEADER = "## Output"
+_FRAGMENT_LABEL_RE = re.compile(r"^\[fragment (\d+)(?: part \d+/\d+)?\]$")
+# Adjacent fragments are cheap insurance for distillation context (a decision
+# often reads one turn after the command that caused it). 0 disables it.
+NEIGHBOUR_FRAGMENTS = 1
+
+
+def window_prompt(prompt: str, indices, *, neighbours: int = NEIGHBOUR_FRAGMENTS) -> str:
+    """Return `prompt` carrying only the fragments that support `indices`.
+
+    Falls back to the unmodified prompt whenever the structure is not
+    recognisable or the selection would be empty: a partial prompt that lost
+    its skill contract, or one with no fragments at all, is far worse than a
+    slow complete one. Every part of a split fragment travels with its index.
+    """
+    wanted = {int(i) for i in indices if isinstance(i, (int, float)) or str(i).isdigit()}
+    if not wanted:
+        return prompt
+    if neighbours > 0:
+        wanted |= {i + offset for i in set(wanted)
+                   for offset in range(-neighbours, neighbours + 1)}
+
+    head_at = prompt.find(FRAGMENTS_HEADER)
+    if head_at < 0:
+        return prompt
+    body_at = head_at + len(FRAGMENTS_HEADER)
+    tail_at = prompt.find(OUTPUT_HEADER, body_at)
+    if tail_at < 0:
+        return prompt
+
+    preamble, fragments_text, trailer = (
+        prompt[:body_at], prompt[body_at:tail_at], prompt[tail_at:],
+    )
+
+    kept: list[str] = []
+    current_index: "int | None" = None
+    for line in fragments_text.splitlines():
+        label = _FRAGMENT_LABEL_RE.match(line.strip())
+        if label is not None:
+            current_index = int(label.group(1))
+        if current_index is not None and current_index in wanted:
+            kept.append(line)
+    if not kept:
+        return prompt
+
+    return preamble + "\n" + "\n".join(kept).strip("\n") + "\n\n" + trailer
+
+
+def build_write_message(prompt: str, concept: dict, siblings: list) -> str:
+    """Assemble the pass-2 user message for one concept.
+
+    Extracted so the windowing is covered by a test rather than living inline
+    in `main()`: reverting to the whole-payload form would otherwise be an
+    invisible one-token change (issue #74).
+    """
+    return (
+        WRITE_INSTRUCTION.format(
+            title=concept["title"],
+            kind=concept["artifact_kind"],
+            indices=concept["fragment_indices"],
+            siblings=", ".join(siblings),
+        )
+        + "\n\n"
+        + window_prompt(prompt, concept["fragment_indices"])
+    )
+
+
 def guided(payload: dict, name: str, schema: dict) -> dict:
     out = dict(payload)
     out["response_format"] = {
@@ -417,17 +503,7 @@ def main() -> None:
         write_payload = dict(base_payload)
         write_payload.update(thinking_off)
         write_payload["messages"] = [
-            {
-                "role": "user",
-                "content": WRITE_INSTRUCTION.format(
-                    title=concept["title"],
-                    kind=concept["artifact_kind"],
-                    indices=concept["fragment_indices"],
-                    siblings=", ".join(siblings),
-                )
-                + "\n\n"
-                + prompt,
-            }
+            {"role": "user", "content": build_write_message(prompt, concept, siblings)}
         ]
         item = request_json(
             base_url, api_key,

--- a/tests/test_local_harness_windowing.py
+++ b/tests/test_local_harness_windowing.py
@@ -1,0 +1,150 @@
+"""issue #74：local-harness pass 2 的 content-addressed input windowing。
+
+`contrib/local-harness/harness.py` 是本機部署產物（不進 wheel），但它是
+tier-3 保底層的實作，切輸入的正確性直接決定大 session 會不會 park，故在
+repo 測試套件內守護。以 importlib 由檔案路徑載入（目錄含連字號、非套件），
+模組本身無 import 副作用（main() 有 __main__ 保護）。
+"""
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+from paulsha_hippo.atomizer.prompt import build_prompt
+from paulsha_hippo.atomizer.splitter import Fragment
+
+HARNESS_PATH = Path(__file__).resolve().parents[1] / "contrib" / "local-harness" / "harness.py"
+
+
+def _load_harness():
+    spec = importlib.util.spec_from_file_location("hippo_local_harness", HARNESS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+harness = _load_harness()
+
+
+def _fragment(index: int, body: str, *, part_index: int = 1, part_count: int = 1) -> Fragment:
+    return Fragment(
+        project="proj",
+        source_agent="claude",
+        source_session="sess",
+        source_artifact="artifact.md",
+        captured_at="2026-08-01T00:00:00Z",
+        provenance={},
+        fragment_index=index,
+        body=body,
+        part_index=part_index,
+        part_count=part_count,
+    )
+
+
+def _prompt(fragments: list[Fragment]) -> str:
+    return build_prompt("SKILL CONTRACT TEXT", fragments, ["proj"])
+
+
+class WindowPromptTests(unittest.TestCase):
+    def test_keeps_only_requested_fragments_and_their_neighbours(self):
+        prompt = _prompt([_fragment(i, f"body-of-{i}") for i in range(10)])
+
+        windowed = harness.window_prompt(prompt, [5], neighbours=1)
+
+        for kept in (4, 5, 6):
+            self.assertIn(f"body-of-{kept}", windowed)
+        for dropped in (0, 1, 2, 3, 7, 8, 9):
+            self.assertNotIn(f"body-of-{dropped}", windowed)
+
+    def test_preserves_preamble_and_output_contract(self):
+        # WRITE_INSTRUCTION 明說「follow the field rules from the skill contract
+        # in the original prompt」，切掉 preamble 會讓 pass 2 失去欄位契約。
+        prompt = _prompt([_fragment(i, f"body-of-{i}") for i in range(10)])
+
+        windowed = harness.window_prompt(prompt, [5], neighbours=0)
+
+        self.assertIn("SKILL CONTRACT TEXT", windowed)
+        self.assertIn("## Known projects", windowed)
+        self.assertIn("## Session fragments to atomize", windowed)
+        self.assertIn("## Output", windowed)
+        self.assertIn("Return ONLY a canonical JSON object.", windowed)
+
+    def test_keeps_every_part_of_a_split_fragment(self):
+        prompt = _prompt([
+            _fragment(0, "body-of-0"),
+            _fragment(1, "first-half", part_index=1, part_count=2),
+            _fragment(1, "second-half", part_index=2, part_count=2),
+            _fragment(2, "body-of-2"),
+        ])
+
+        windowed = harness.window_prompt(prompt, [1], neighbours=0)
+
+        self.assertIn("first-half", windowed)
+        self.assertIn("second-half", windowed)
+        self.assertNotIn("body-of-0", windowed)
+        self.assertNotIn("body-of-2", windowed)
+
+    def test_substantially_shrinks_a_large_session(self):
+        # #74 的核心量測：48 fragments / ~100KB，每個 concept 只需少數 fragment。
+        fragments = [_fragment(i, f"body-of-{i} " + "x" * 2000) for i in range(48)]
+        prompt = _prompt(fragments)
+
+        windowed = harness.window_prompt(prompt, [10, 11, 12], neighbours=1)
+
+        self.assertLess(len(windowed), len(prompt) / 4)
+
+    def test_falls_back_to_full_prompt_when_structure_is_unrecognised(self):
+        # prompt 契約若改變，切輸入必須整個放棄而不是送出殘缺 prompt。
+        prompt = "no headers here, just prose"
+        self.assertEqual(harness.window_prompt(prompt, [0]), prompt)
+
+    def test_falls_back_to_full_prompt_when_no_fragment_matches(self):
+        # 越界／錯誤的 fragment_indices 不得產生零 fragment 的 prompt。
+        prompt = _prompt([_fragment(i, f"body-of-{i}") for i in range(3)])
+        self.assertEqual(harness.window_prompt(prompt, [99], neighbours=0), prompt)
+
+    def test_falls_back_to_full_prompt_when_indices_are_absent(self):
+        prompt = _prompt([_fragment(i, f"body-of-{i}") for i in range(3)])
+        self.assertEqual(harness.window_prompt(prompt, []), prompt)
+
+
+class BuildWriteMessageTests(unittest.TestCase):
+    """pass 2 必須真的用切過的 prompt——守護「有沒有接上」，而非只守護切法。"""
+
+    def test_write_message_carries_only_the_concepts_fragments(self):
+        # fragment 需有實際體積，否則 WRITE_INSTRUCTION 的固定開銷會蓋過
+        # 切輸入的效果，讓大小斷言失去意義。
+        prompt = _prompt([
+            _fragment(i, f"body-of-{i} " + "x" * 2000) for i in range(10)
+        ])
+        concept = {
+            "title": "the concept",
+            "artifact_kind": "report",
+            "fragment_indices": [5],
+        }
+
+        message = harness.build_write_message(prompt, concept, ["other"])
+
+        self.assertIn("the concept", message)       # 指令段
+        self.assertIn("body-of-5", message)         # 命中的 fragment
+        self.assertNotIn("body-of-0", message)      # 未命中的 fragment 不得重送
+        self.assertNotIn("body-of-9", message)
+        self.assertLess(len(message), len(prompt))
+
+    def test_write_message_still_contains_the_skill_contract(self):
+        prompt = _prompt([_fragment(i, f"body-of-{i}") for i in range(10)])
+        concept = {
+            "title": "the concept",
+            "artifact_kind": "report",
+            "fragment_indices": [5],
+        }
+
+        message = harness.build_write_message(prompt, concept, ["other"])
+
+        self.assertIn("SKILL CONTRACT TEXT", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

Closes #74

`contrib/local-harness/harness.py` 的 map-reduce 只切輸出不切輸入：pass 2 每個 concept 的 write 都把整份 session payload（實測約 100KB）重送一遍，只在指令文字裡「告訴」模型該用哪些 fragment index。`maxItems: 8` 的 concept 上限意味著最壞情況 9 次呼叫 × 100KB ≈ 900KB 的輸入處理量——這正是 issue 內量到的 203s／357s／400s 的來源。

而切輸入所需的資訊**早已存在且被丟棄**：`ENUM_SCHEMA` 的 `fragment_indices` 是必填欄位（`minItems: 1`），pass 1 已精確算出每個 concept 需要哪些 fragment。

### 修法

新增 `window_prompt()`，依 hippo 既有的 prompt 結構裁切（`paulsha_hippo/atomizer/prompt.py` 對每個 fragment 輸出 `[fragment N]` 標記），**不需要改動 hippo 端的 prompt 契約**。

**fail-safe 優先於省時**——以下情況一律回退送出完整原始 prompt：

- 找不到 `## Session fragments to atomize` 或 `## Output` 標頭（prompt 契約改變）
- `fragment_indices` 為空或全非數字
- 裁切後零 fragment 命中（越界索引）

失去 skill contract 的殘缺 prompt，或沒有任何 fragment 的 prompt，都比慢但完整的呼叫糟糕得多。split fragment 的每個 part 都隨其 index 一起保留。

預設附帶 ±1 鄰域（`NEIGHBOUR_FRAGMENTS = 1`）：決策往往落在觸發它的指令的下一個 turn，補鄰域是廉價的脈絡保險；設 0 即停用。

pass 2 組訊息的邏輯抽成 `build_write_message()` 並加測試守護——切輸入若被改回整份重送，會是一個 token 的隱形變更，抽出來才測得到「有沒有真的接上」，而不只測「切法對不對」。

### 順帶修正的失真註解

`REQUEST_TIMEOUT_S` 原註明「keep under hippo `external_agents.deadline_seconds`=300」，但真正約束單次呼叫的是 `agent_profiles.FIXED_TIMEOUT_SECONDS`——chain 全鏈預算不決定單次呼叫能跑多久。270 同時低於舊的 300 與 #119 提高後的 600，且切輸入才是讓 per-write 耗時下降的主因，此上限已非綁定約束。值本身未動，本 PR 因此不依賴 #119 是否先合併。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過 — `python3 -m pytest tests/ -q` → `1735 passed, 4 skipped, 184 subtests passed`
- [x] `python3 -m policy_check --repo .`（含 PR context）通過 — R-01…R-26 全 pass，R-22 為既有的本地無 diff context 降級 WARN
- [x] OpenSpec validation 與 repo 額外 gates 通過 — `openspec validate --all --strict` → `14 passed, 0 failed`
- [x] `changelog.d/` 已有對應碎片 — `changelog.d/74-local-harness-input-windowing.md`
- [x] `VERSION` 與 release 意圖一致 — 未動（維持 `0.1.1`，本 PR 非 release PR）
- [x] 文件與 CLI help 已同步，或已說明不適用 — 無 CLI 介面變動；harness 模組 docstring 已同步切輸入行為與逾時約束

新增 `tests/test_local_harness_windowing.py`（9 項）。`contrib/**` 不在 `code_paths` 內、原本無任何測試覆蓋，但它是 tier-3 保底層的實作，切輸入的正確性直接決定大 session 會不會 park，故納入 repo 測試套件（以 importlib 由檔案路徑載入；模組無 import 副作用，`main()` 有 `__main__` 保護）。

### 未經 live 驗證（重要）

**本次無法對地端引擎實跑**——`http://192.168.199.199:8001/v1` 於撰寫時無回應（連線 timeout）。因此：

- 耗時改善為依 payload 縮減幅度**推導**，非實測值。單元測試證明的是「切得對」與「有接上」，不是「跑得比較快」。
- issue #74 記錄的 203s／357s／400s 是修復前的實測基準，可作為部署後的對照。
- **部署後應以實際大 session 重新量測** per-write 耗時與 `truncated at max_tokens` 發生率，再把證據回填到本 issue。在那之前，「tier-3 已能承接大 payload」仍屬未證。

## 風險與回復

- 無資料遷移、無 schema 變更、不觸及 hippo 主套件（`contrib/**` 不在 `code_paths`）。
- 品質風險：pass 2 的可見脈絡由整份 session 縮為少數 fragment。issue 預期這會**提升**輸出品質（注意力集中），但方向未經實測確認；±1 鄰域與完整 preamble 保留是對此的緩衝。若部署後發現 slice 品質下降，先把 `NEIGHBOUR_FRAGMENTS` 調高再評估，不必整個 revert。
- **部署**：`~/.local/bin/local-vllm` 是本檔的獨立副本（撰寫時與 repo 版 byte-identical），不隨 wheel 發布。本修復要生效必須另外把 `contrib/local-harness/harness.py` 複製過去——`pipx install --force` **不會**涵蓋它。
- rollback 即 revert 本 PR + 還原該副本。
- 本 PR 屬 0.1.2 凍結前最後一批。
