### PR TITLE
fix(profiles): cg 宣告 max_session_chunks: 6——修 #99 大 session 燒 153s 才失敗

### DIFF
--- a/changelog.d/99-cg-session-size-gate.md
+++ b/changelog.d/99-cg-session-size-gate.md
@@ -1,0 +1,9 @@
+---
+type: fix
+---
+- 部分處理 issue #99（fail-fast 半）：tier-2 `cg` profile 宣告 `max_session_chunks: 6`。cg 對一般 session 是目前最穩的 profile（organic 勝出 80.9%、promote 100%），問題特定於大 payload——>6 chunks 的 session（實例 213KB／47+ fragments）燒 153s 後以 exit 3 吐出不可解析 JSON。宣告閘門後這類 session 以 `session_size` 立即不合格、直接落到 tier-3，而不是先浪費 153s 再失敗。
+- 兩道天花板刻意相鄰：tier-1 為 7（#89），cg 為 6，因此 cg 實際只會接到「tier-1 因其他原因失敗的 ≤6 chunk session」。tier-3 維持不設限——它是最後一棒，若也能以 size 婉拒，大 session 就無處可去。
+- 同步三處，避免「宣告了但沒同步」：`agent_profiles.default_profiles()` 的 canonical row（新增具名常數 `_CG_MAX_SESSION_CHUNKS`）、出貨模板 `paulsha_hippo/atomizer/atomizer.yaml`，以及既有的 template↔canonical parity 測試。該 parity 測試在本次實際擋下了只改一邊的版本。
+- 新增測試：模板宣告值、啟用狀態下 7 chunks 判 `session_size` 不合格、6 chunks 不受此閘門影響。測試需以 `dataclasses.replace(cg, enabled=True)` 建構——出貨模板把 cg 設為 `enabled: false`（部署端才啟用），而 `eligible()` 的 `disabled` 檢查會先短路，直接用模板 profile 驗不到 size 閘門本身。
+- **未涵蓋**：copilot 鏈路的輸出上限／截斷行為量測仍未進行，「cg 對大 payload 為何不可靠」未定調，issue #99 保持開啟。本次只是止血，不是根因修復。
+- **部署**：live config（`~/.config/paulsha-hippo/config.yaml`）的 cg profile 目前 `max_session_chunks` 為未設定，且該檔為使用者值勝出、不會被模板刷新，需手動同步才會生效。

--- a/paulsha_hippo/agent_profiles.py
+++ b/paulsha_hippo/agent_profiles.py
@@ -483,6 +483,16 @@ def _validate_fallback_on(value: object, field_name: str) -> tuple[str, ...]:
 # unparseable JSON on a >6-chunk session that fell through when tier-1 was
 # still capped at 6).
 _TIER1_MAX_SESSION_CHUNKS = 7
+# tier-2 cg (issue #99): the same production evidence cited above also says what
+# cg must *not* be handed. cg is the strongest profile on ordinary sessions
+# (organic win rate 80.9%, promote 100%), so it stays in the chain -- but on a
+# >6-chunk payload it burned 153s and then returned unparseable JSON. Declaring
+# the ceiling turns that into an immediate `session_size` ineligibility, so an
+# oversized session drops straight to tier-3 instead of paying 153s first.
+# With tier-1 capped at 7, cg only ever sees <=6-chunk sessions that tier-1
+# failed for some other reason. The full large-payload reliability measurement
+# is still open; this is the fail-fast half.
+_CG_MAX_SESSION_CHUNKS = 6
 
 
 def default_profiles() -> tuple[AgentProfile, ...]:
@@ -490,7 +500,7 @@ def default_profiles() -> tuple[AgentProfile, ...]:
         ("claude", 1, 10, ("judge", "reasoner"), ("atomization", "title", "skillopt"), "sonnet", "high", ("medium", "high", "xhigh"), ("claude", "--model", "{MODEL}", "--effort", "{EFFORT}", "--safe-mode", "--disable-slash-commands", "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}', "--tools", "", "--no-session-persistence", "--print"), _TIER1_MAX_SESSION_CHUNKS),
         ("codex", 1, 20, ("judge", "reasoner"), ("atomization", "title", "skillopt"), "gpt-5.6-sol", "high", ("high",), ("codex", "exec", "--model", "{MODEL}", "-c", "model_reasoning_effort=high", "--sandbox", "read-only", "--skip-git-repo-check", "--ephemeral", "--ignore-user-config", "--ignore-rules", "--disable", "shell_tool", "-"), _TIER1_MAX_SESSION_CHUNKS),
         ("agy", 2, 10, ("fast", "responsive"), ("title", "skillopt"), "default", "medium", ("low", "medium", "high"), ("agy", "--model", "{MODEL}", "--effort", "{EFFORT}", "--mode", "plan", "--sandbox", "--print"), None),
-        ("cg", 2, 20, ("heavy-implementation", "fast"), ("atomization", "title", "skillopt"), "default", "high", ("medium", "high", "xhigh"), ("cg", "--model", "{MODEL}", "--effort", "{EFFORT}", "--headless", "--stdin"), None),
+        ("cg", 2, 20, ("heavy-implementation", "fast"), ("atomization", "title", "skillopt"), "default", "high", ("medium", "high", "xhigh"), ("cg", "--model", "{MODEL}", "--effort", "{EFFORT}", "--headless", "--stdin"), _CG_MAX_SESSION_CHUNKS),
         ("co-gem", 3, 10, ("low-cost", "fallback"), ("atomization", "title", "skillopt"), "local", "low", ("low", "medium"), ("co-gem", "--model", "{MODEL}", "--effort", "{EFFORT}", "--headless", "--stdin"), None),
         ("claude-gem", 3, 20, ("low-cost", "fallback"), ("atomization", "title", "skillopt"), "local", "low", ("low", "medium"), ("claude-gem", "--model", "{MODEL}", "--effort", "{EFFORT}", "--headless", "--stdin"), None),
     )

--- a/paulsha_hippo/atomizer/atomizer.yaml
+++ b/paulsha_hippo/atomizer/atomizer.yaml
@@ -73,6 +73,14 @@ external_agents:
       enabled: false
       tier: 2
       priority: 20
+      # issue #99：cg 對一般 session 是最穩的 profile（organic 勝出 80.9%、
+      # promote 100%），但對大 payload 已實證不可靠——>6 chunks 的 session
+      # （實例 213KB/47+ fragments）燒 153s 後吐出不可解析 JSON（exit 3）。
+      # 宣告閘門讓這類 session 以 session_size 立即不合格、直接落到 tier-3，
+      # 而不是先浪費 153s 再失敗。tier-1 上限為 7，故 cg 實際只會接到
+      # tier-1 因其他原因失敗的 ≤6 chunk session。
+      # 完整的 copilot 大 payload 可靠性量測仍未完成，見 issue #99。
+      max_session_chunks: 6
       traits: [heavy-implementation, fast]
       task_classes: [atomization, title, skillopt]
       model: default

--- a/tests/test_atomizer_config.py
+++ b/tests/test_atomizer_config.py
@@ -454,3 +454,36 @@ class SessionDeadlineIsNotASilentKnobTests(unittest.TestCase):
                 load_config(default_dir=DEFAULT_CONFIG_DIR, override_path=path)
         finally:
             path.unlink(missing_ok=True)
+
+
+class CgSessionSizeGateTests(unittest.TestCase):
+    """issue #99：cg 對大 payload 已實證不可靠，須以 session_size 閘門 fail-fast。"""
+
+    def test_shipped_template_declares_cg_session_size_gate(self):
+        cfg, _ = load_config(default_dir=DEFAULT_CONFIG_DIR, override_path=None)
+        profiles_by_id = {profile.id: profile for profile in cfg.external_profiles}
+        self.assertEqual(profiles_by_id["cg"].max_session_chunks, 6)
+
+    def _enabled_cg(self):
+        # 出貨模板把 cg 設為 enabled: false（部署端才啟用），而 eligible() 的
+        # disabled 檢查會先短路，故要在啟用狀態下才驗得到 size 閘門本身。
+        import dataclasses
+
+        cfg, _ = load_config(default_dir=DEFAULT_CONFIG_DIR, override_path=None)
+        cg = {profile.id: profile for profile in cfg.external_profiles}["cg"]
+        return dataclasses.replace(cg, enabled=True)
+
+    def test_cg_rejects_oversized_sessions_before_spending_a_call(self):
+        # 不合格必須在呼叫之前判定（reason=session_size），否則就只是把
+        # 153s 的浪費換個地方發生。
+        eligible, reason = self._enabled_cg().eligible(
+            task_class="atomization", chunk_count=7
+        )
+        self.assertFalse(eligible)
+        self.assertEqual(reason, "session_size")
+
+    def test_cg_still_accepts_sessions_within_its_proven_range(self):
+        _, reason = self._enabled_cg().eligible(
+            task_class="atomization", chunk_count=6
+        )
+        self.assertNotEqual(reason, "session_size")

--- a/tests/test_external_agent_profiles.py
+++ b/tests/test_external_agent_profiles.py
@@ -191,12 +191,21 @@ def test_router_skips_profile_with_oversized_session_without_call():
 
 
 def test_default_profiles_have_max_session_chunks_bounds():
-    """Issue #89: tier-1 max_session_chunks raised 6->7 (1800s cap / 240s ~= 7.5)."""
+    """Issue #89: tier-1 max_session_chunks raised 6->7 (1800s cap / 240s ~= 7.5).
+
+    Issue #99 then bounded tier-2 cg at 6 so an oversized session is rejected
+    with `session_size` instead of burning 153s before returning unparseable
+    JSON. The two ceilings are deliberately adjacent: with tier-1 at 7, cg only
+    ever sees <=6-chunk sessions that tier-1 failed for some other reason.
+    """
     profiles = default_profiles()
     mapping = {profile.id: profile.max_session_chunks for profile in profiles}
     assert mapping["claude"] == 7
     assert mapping["codex"] == 7
-    assert mapping["cg"] is None
+    assert mapping["cg"] == 6
+    # tier-3 stays unbounded: it is the last resort and must never decline on
+    # size, or a large session has nowhere left to go.
+    assert mapping["co-gem"] is None
 
 
 def test_default_profiles_have_three_deterministic_tiers_and_traits():


### PR DESCRIPTION
## 摘要

Refs #99（**部分處理，issue 不關閉**）

只做 issue #99 的 **fail-fast 半**：tier-2 `cg` profile 宣告 `max_session_chunks: 6`。

cg 對一般 session 是目前最穩的 profile（organic 勝出 80.9%、promote 100%），問題特定於大 payload——>6 chunks 的 session（實例 213KB／47+ fragments）燒 153s 後以 exit 3 吐出不可解析 JSON。宣告閘門後，這類 session 在 `eligible()` 即以 `session_size` 不合格、直接落到 tier-3，而不是先浪費 153s 再失敗。

兩道天花板刻意相鄰：tier-1 為 7（#89），cg 為 6，因此 cg 實際只會接到「tier-1 因其他原因失敗的 ≤6 chunk session」。tier-3 維持不設限——它是最後一棒，若也能以 size 婉拒，大 session 就無處可去。

### 三處同步

`max_session_chunks` 同時存在於 `agent_profiles.default_profiles()` 的 canonical row、出貨模板 `atomizer.yaml`、以及兩者之間的 parity 測試。本次只改一邊的中間版本**實際被 parity 測試擋下**，三處已同步（canonical 側新增具名常數 `_CG_MAX_SESSION_CHUNKS` 與立法理由註解）。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過 — `python3 -m pytest tests/ -q` → `1729 passed, 4 skipped, 184 subtests passed`
- [x] `python3 -m policy_check --repo .`（含 PR context）通過 — R-01…R-26 全 pass，R-22 為既有的本地無 diff context 降級 WARN
- [x] OpenSpec validation 與 repo 額外 gates 通過 — `openspec validate --all --strict` → `14 passed, 0 failed`
- [x] `changelog.d/` 已有對應碎片 — `changelog.d/99-cg-session-size-gate.md`
- [x] `VERSION` 與 release 意圖一致 — 未動（維持 `0.1.1`，本 PR 非 release PR）
- [x] 文件與 CLI help 已同步，或已說明不適用 — 無 CLI 介面變動；立法理由寫在 canonical 常數與模板兩處註解

新增測試：模板宣告值、啟用狀態下 7 chunks 判 `session_size` 不合格、6 chunks 不受此閘門影響。測試需以 `dataclasses.replace(cg, enabled=True)` 建構——出貨模板把 cg 設為 `enabled: false`（部署端才啟用），而 `eligible()` 的 `disabled` 檢查會先短路，直接拿模板 profile 驗根本觸不到 size 閘門。

## 風險與回復

- **issue #99 保持開啟**：copilot 鏈路的輸出上限／截斷行為量測仍未進行，「cg 對大 payload 為何不可靠」未定調。本 PR 是止血，不是根因修復，故用 `Refs` 而非 `Closes`。
- 行為面風險：>6 chunks 的 session 從此不再嘗試 cg。若 cg 其實能處理 7 chunks，這是一次不必要的降級——但代價只是多走一棒到 tier-3，而已知的另一邊代價是每次 153s 且必然失敗。
- 本 PR 與 #74（tier-3 切輸入）互補：cg 讓路之後，接手的 tier-3 必須真的接得住，那是 #74 的事。兩者無程式碼耦合，合併順序不拘。
- 無資料遷移、無 schema 變更。rollback 即 revert。
- **部署**：live config（`~/.config/paulsha-hippo/config.yaml`）的 cg profile 目前 `max_session_chunks` 未設定，且該檔為使用者值勝出、不會被模板刷新，**需手動同步**才會生效。
- 本 PR 屬 0.1.2 凍結前最後一批。
