### PR TITLE
fix(lifecycle): 詞彙表改取兩平面聯集，修復與 cortex 的 claim/research 對齊 FAIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- lifecycle 詞彙表改為記憶平面與治理平面的聯集，修復與 `paulsha-cortex` 的跨平面對齊 FAIL：`lib/lifecycle/schema.PHASES` 新增 cortex 的首階段 `claim`，成為 `("claim", "research", "define", "plan", "build", "verify", "review", "ship")`。`claim`（cortex 的 work item 認領）與 `research`（本平面記憶 slice 的調查階段）語意不同、不可互相改名，故採聯集——既有 235 個 `phase: research` slice 零遷移即維持合法。`PHASES` 在本平面只做成員資格檢查與 gates 產生、不決定順序，擴充不改變既有行為，`current_phase` 預設仍為 `research`。三套套件之間維持零 import 依賴，相等性續由 paulshaclaw 的消費端對齊測試守。
+
 ### Added
 - Entity hub 同步（#107）：新增 `moc/entity_hub.py` 維護 knowledge 層 `entities` 子目錄的 hub 頁，讓 linker 物化的 `[[EntityName]]` mentions 連結有持久解析目標——缺頁補 stub（`entity_kind: unclassified`＋反向連結清單）、既有頁只重刷反向連結段落（人工/agent 分類欄位保留；提及全消失刷成 0 篇不留死連結）、`alias_of` 歸戶 canonical、含 `#` 的 entity 於前綴頁維護 `## <錨點>` 段落（每輪整段重刷，slice 改名/新增 mentions 都進場）、外來檔一律拒寫；回報兩軌——`warnings` 只裝暫時性 I/O 失敗，結構性狀態記 `stats.structural` 不污染 dream clean 判定（#101 教訓）。`run_moc()` 接入（隨 dream hourly timer 自動執行），並新增 CLI `hippo knowledge entity-hubs（--dry-run|--apply）`：dry-run 有待辦、或 apply 有 I/O 失敗即 exit 1 供排程健檢。
 - Prompt-time shortlist 新增 offer 早停機制：同一 `(tool, session_id)` 歷史 offer 事件數達

--- a/changelog.d/lifecycle-vocabulary-union.md
+++ b/changelog.d/lifecycle-vocabulary-union.md
@@ -1,0 +1,7 @@
+---
+type: fix
+---
+- lifecycle 詞彙表改為記憶平面與治理平面的**聯集**，修復與 `paulsha-cortex` 的跨平面對齊 FAIL：`lib/lifecycle/schema.PHASES` 由 7 個擴充為 8 個，新增 cortex 的首階段 `claim`，成為 `("claim", "research", "define", "plan", "build", "verify", "review", "ship")`。背景：cortex 於 `ae4bc43` 把首階段由 `research` 改名為 `claim`，本平面未跟進，兩者的消費端對齊測試（paulshaclaw `tests/test_cortex_alignment.py::test_cortex_phases_match_hippo_schema`）自此 FAIL。
+- 採聯集而非改名的依據：`claim` 在 cortex 是結構上不同的階段（work item 認領、manager 決定性執行），與本平面 `research`（記憶 slice 的調查階段）語意不同，不可互相改名；且本平面既有 **235 個 `phase: research` slice** 若改名會被 `schema.py` 的 phase 驗證判為非法，聯集則零資料遷移。
+- 安全性：`PHASES` 在本平面只做成員資格檢查（`schema.py` 的 phase 驗證、`events.py` 的 transition 驗證）與 `template.py` 的 gates 產生，**不決定順序**，故擴充不改變既有行為；`build_lifecycle_template()` 的 `current_phase` 預設維持 `research`，新建 lifecycle 模板的 `gates` 多一個 `claim` 條目。
+- 新增 `tests/test_lifecycle_phases_vocabulary.py` 釘住聯集內容、本平面起始階段仍為 `research`，以及「共用詞彙不得退化成跨套件 import」的零依賴底限。異動此表必須同步 `paulsha-cortex` 的 `persona/contract.PHASES`，已在常數註解寫明。

--- a/paulsha_hippo/lib/lifecycle/schema.py
+++ b/paulsha_hippo/lib/lifecycle/schema.py
@@ -7,7 +7,17 @@ import json
 import re
 
 
+# 記憶平面與治理平面**共用的 lifecycle 詞彙聯集**。本表只做成員資格檢查
+# （`schema.py` 的 phase 驗證、`events.py` 的 transition 驗證、`template.py`
+# 的 gates 產生），不決定順序，因此收錄兩平面各自的首階段：
+#   - `research`：本平面記憶 slice 的調查階段（`template.py` 的 current_phase 預設）
+#   - `claim`   ：paulsha-cortex 的 work item 認領（manager 決定性執行）
+# 兩者語意不同、不可互相改名。共用是靠「各自持有相同常數 + 消費端對齊測試」
+# 達成，三套套件之間不得建立 import 依賴（見 paulshaclaw
+# tests/test_cortex_alignment.py）。異動此表必須同步 paulsha-cortex 的
+# `persona/contract.PHASES`，否則對齊測試會 FAIL。
 PHASES = (
+    "claim",
     "research",
     "define",
     "plan",

--- a/tests/test_lifecycle_phases_vocabulary.py
+++ b/tests/test_lifecycle_phases_vocabulary.py
@@ -1,0 +1,41 @@
+"""共用 lifecycle 詞彙表的釘樁測試。
+
+`PHASES` 是記憶平面與治理平面（paulsha-cortex）共用的詞彙聯集，靠「各自持有
+相同常數 + 消費端對齊測試」達成一致，套件之間**不建立 import 依賴**。本檔釘住
+本平面這一側的內容，cortex 側有對稱的 `tests/test_phases_constant.py`，最終相
+等性由 paulshaclaw 的 `tests/test_cortex_alignment.py` 守。
+"""
+
+from paulsha_hippo.lib.lifecycle.schema import PHASES
+
+
+def test_phases_is_the_shared_cross_plane_vocabulary():
+    assert PHASES == (
+        "claim",
+        "research",
+        "define",
+        "plan",
+        "build",
+        "verify",
+        "review",
+        "ship",
+    )
+
+
+def test_research_stays_this_planes_entry_phase():
+    """聯集不得改變本平面的起始階段——既有 slice 仍以 research 起。"""
+    from paulsha_hippo.lib.lifecycle.template import build_lifecycle_template
+
+    template = build_lifecycle_template(project="p", current_slice="s")
+
+    assert template["current_phase"] == "research"
+    assert set(template["gates"]) == set(PHASES)
+
+
+def test_lifecycle_module_does_not_import_cortex():
+    """零依賴底限：共用詞彙不得退化成跨套件 import。"""
+    import inspect
+
+    from paulsha_hippo.lib.lifecycle import schema
+
+    assert "paulsha_cortex" not in inspect.getsource(schema)


### PR DESCRIPTION
## 背景

本平面的 `lib/lifecycle/schema.PHASES` 與治理平面 `paulsha-cortex` 的 `persona/contract.PHASES` 應為同一組 lifecycle 詞彙，相等性由消費端 paulshaclaw 的 `tests/test_cortex_alignment.py::test_cortex_phases_match_hippo_schema` 守。該測試目前 FAIL：

| | 首階段 | 其餘 |
|---|---|---|
| paulsha-hippo（本 repo） | `research` | define / plan / build / verify / review / ship |
| paulsha-cortex | `claim` | 同上 |

分歧起於 cortex `ae4bc43` 把首階段由 `research` 改名為 `claim`，本平面未跟進。

## 為什麼不是改名而是聯集

兩者語意不同，不是別名關係：

- cortex 的 `claim` 是**work item 認領**——`coordinator/workflow.py:300` 強制 `steps[0].phase == "claim"`，`work_actions.py:1337-1342` 把它釘成 manager 決定性執行（`executor="cortex-manager"`、`model="deterministic"`、`gate_result="passed"`）
- 本平面的 `research` 是**記憶 slice 的調查階段**

且本平面若把 `research` 改名，既有 **235 個 `phase: research` slice** 會被 `schema.py` 的 phase 驗證判為非法，需要 legacy alias 或資料遷移；聯集則零遷移。

## 為什麼聯集是安全的

`PHASES` 在本平面**只做成員資格檢查，不決定順序**：

- `schema.py` 的 phase 欄位驗證
- `events.py` 的 transition 驗證
- `template.py` 依它產生 `gates` 條目

因此擴充不改變任何既有行為。`build_lifecycle_template()` 的 `current_phase` 預設維持 `research`（本平面起始階段不變），新建模板的 `gates` 多一個 `claim` 條目。無測試斷言 gates 的精確鍵集，故無回歸。

## 零依賴

三套套件之間不建立任何 import 依賴——共用是靠「各自持有相同常數 + 消費端對齊測試」達成。新增的 `test_lifecycle_module_does_not_import_cortex` 把這條底限釘進測試。

## 配套

須與 `paulsha-cortex` PR hamanpaul/paulsha-cortex#376 同組聯集，兩者 merge 後 paulshaclaw 再一併升 pin。

## 驗證

- `python3 -m pytest tests/ -q` → **1761 passed, 4 skipped, 188 subtests passed**
- 新增 `tests/test_lifecycle_phases_vocabulary.py` → 3 passed
- `python3 -m policy_check`（帶 PR 上下文）→ **fail: 0, warn: 2**（R-18 / R-22 皆為陳年項目，非本次新造成）

## Checklist

- [x] `changelog.d/lifecycle-vocabulary-union.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 分支命名符合 `feature/<slug>`
- [x] policy_check 帶 PR 上下文跑過，fail: 0
- [x] 測試全數通過