### PR TITLE
chore(policy): 同步 project policy 1.0.15 → 1.0.17

### DIFF
--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -9,8 +9,8 @@ permissions:
 
 jobs:
   policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab  # v1.0.15
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@9e7fabbf0b5eea9ad933fa6798764b723934a0b7  # v1.0.17
     with:
       policy_profile: flat
-      policy_version: "1.0.15"
-      policy_engine_ref: a764806046c410eb4f254ac0b6a8aec8b7559dab
+      policy_version: "1.0.17"
+      policy_engine_ref: 9e7fabbf0b5eea9ad933fa6798764b723934a0b7

--- a/.project-policy.yml
+++ b/.project-policy.yml
@@ -1,5 +1,5 @@
 policy_profile: flat
-policy_version: 1.0.15
+policy_version: 1.0.17
 tier: shareable
 secret_scan:
   allow:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.17 -->
 <!-- 此為 canonical 真檔；AGENTS.md / GEMINI.md / .github/copilot-instructions.md 為指向本檔的 symlink，只維護本檔 -->
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 # Agent Policy Checklist
 
-本 repo 受 hamanpaul project policy v1.0.15 管轄。
+本 repo 受 hamanpaul project policy v1.0.17 管轄。
 所有 agent 進入 session 時，必須依下列 checklist 行動。
 
 ## 本 repo 的 profile
 - policy_profile: `flat` （見 `.project-policy.yml`）
-- policy_version: `1.0.15`
+- policy_version: `1.0.17`
 
 ## 動工前
 - [ ] 確認當前分支不是 `main`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pipeline：hooks ingress → raw → atomize 蒸餾 → ledger/moc → dream（�
 
 目前 release candidate 為 `0.1.1`（Issue 34 語意保全、外部 CLI atomization 與可逆 recovery；尚未 tag/release）。版本記錄見 `CHANGELOG.md`；
 發版採 semver，主 repo 以 commit SHA pin 依賴（tag 僅人讀標記）。
-Repo policy 由 canonical `.project-policy.yml` 宣告，並 pin paulsha-conventions v1.0.15。
+Repo policy 由 canonical `.project-policy.yml` 宣告，並 pin paulsha-conventions v1.0.17。
 
 ## 家族
 

--- a/changelog.d/policy-1-0-17-sync.md
+++ b/changelog.d/policy-1-0-17-sync.md
@@ -1,0 +1,5 @@
+---
+type: change
+scope: policy
+---
+同步 hamanpaul project policy 1.0.15 → 1.0.17：`.project-policy.yml`、`Policy Check` workflow（`uses:` 與 `policy_engine_ref` 雙重釘選至 `9e7fabbf0b5eea9ad933fa6798764b723934a0b7`，尾註 `# v1.0.17`）、canonical `CLAUDE.md`（symlink `AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md` 自動跟隨）與 `README.md` 內的版本引用全數同步至 v1.0.17。1.0.16／1.0.17 對下游 repo 未新增或變更任何規則，僅上游引擎自身的 distribution identity、runtime bundle 與 release workflow 修正，故本次為純版本同步；其中 1.0.16 引入的引擎版本 gate（執行中引擎版本與 repo 宣告的 `policy_version` 不符即 fail-loud）正是本次同步的實益——pin SHA 與 `policy_version` 已同 PR 原子更新，版本對齊後本機 `policy_check` 預檢才能與 CI 判定一致。本 repo `tests.yml` 原本就無條件執行 `pytest`（無 template 骨架的條件式 `Detect test suite` gate），R-19 未觸發，無需比照 paulsha-patchmud/paulsha-cortex 同步時的額外修正。


### PR DESCRIPTION
Closes #132

## 變更

上游 hamanpaul/paulsha-conventions 已發布 v1.0.17。1.0.16 引入的引擎版本 gate 會在執行中引擎與 repo 宣告的 `policy_version` 不符時 fail-loud，因此 pin SHA 與 `policy_version` 必須**同 PR 原子更新**。1.0.16／1.0.17 對下游 repo 未新增或變更任何規則，本次為純版本同步：

- `.project-policy.yml` `policy_version` 1.0.15 → 1.0.17
- `Policy Check` workflow：`uses:` 與 `policy_engine_ref` 雙重釘選至 `9e7fabbf0b5eea9ad933fa6798764b723934a0b7`（尾註 `# v1.0.17`）
- canonical `CLAUDE.md`（`AGENTS.md`／`GEMINI.md`／`.github/copilot-instructions.md` symlink 自動跟隨）、`README.md` 版本引用同步
- changelog fragment：`changelog.d/policy-1-0-17-sync.md`

本 repo `tests.yml` 原本就無條件執行 `pytest`（無 template 骨架的條件式 `Detect test suite` gate，安裝行也無多餘 `pytest` 字樣），R-19 不受影響，不需比照 paulsha-patchmud／paulsha-cortex 同步時額外修正測試 gate。

## 驗證

- 本機以 v1.0.17 引擎 `python3 -m policy_check --repo .`：**EXIT=0**，R-19／R-20／R-23 全 pass（僅 R-22 33 個 pre-existing dangling doc reference，advisory、非本次引入）。
- 臨時 venv `python -m pytest tests/ -q`：**1764 passed, 4 skipped, 188 subtests passed**（89.24s）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK