### PR TITLE
feat(skills): 新增 Hippo memory KPI 稽核

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Added
+- 新增 repo-local `custom-skills/hippo-memory-kpi/`：唯讀產生 7/30 天 session→atomic note、note machine-valid/searchable、Agent offer→read→applied KPI，固定排除 observer/no-findings 污染並區分 Cortex source material、offer、read、applied 與 Codex 可觀測下限。
+
 ### Changed
 - 0.1.2 的 post-tag 發版證據（本身不含於 `v0.1.2` tag，故記於此而非下面已定稿的 `[0.1.2]` 段）：`reports/verify/release-readiness-matrix.json` 由 `f5df394` 重綁至 candidate `ddeba3a3`（wheel `919d685d…`），依 `bind_candidate()` 漂移語意作廢全部既有 `passed` 後逐 gate 重新 attest，**16/16 passed**；`reports/verify/release-0.1.2-closeout.md` 新增追加批次段，涵蓋 `f5df394..ddeba3a3` 期間關閉的 10 個 issue，closing PR 的 merge commit 逐筆以 `git merge-base --is-ancestor` 驗證為 candidate 祖先。
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 
 日常命令：`hippo dream run|status`／`hippo wakeup`／`hippo recall`（跨 CLI 任務相關檢索）／`hippo search`／`hippo usage`（漏斗報表；`mark-applied` 回報 applied）／`hippo index verify`／`hippo replay`／`hippo bundle`／`hippo requeue <session-key>|--all-parked`（parked session 修復後重排）／`hippo recovery plan|apply|resume|rollback`（hash-pinned、預設 5-session 的 importer recovery，不自動重播 LLM）。
 跨 CLI 消費能力（codex/copilot 的 prompt-time／read attribution 實測）見 `docs/cross-cli-capability-matrix.md`。
+唯讀 7／30 天記憶 KPI 稽核可使用 repo-local `custom-skills/hippo-memory-kpi/`；它分開呈現 session→atomic note、machine-valid/searchable 與嚴格 `offer → read → applied` 漏斗，且不呼叫 `hippo recall` 污染分母。
 蒸餾失敗顯性化：backend 不可用／重試超限的 session 進 `parked`（證據在 `runtime/queue/_failed/`），修復後 `hippo requeue` 恢復；`dream run` 以 global lock 保證單一 writer，並發第二實例記 log 後跳過。
 維運：`hippo doctor`（含 dream lock 持鎖狀態與 dream/supervise 進程健康報告——PID/start/cmdline、非 canonical 標記，只報告不自動 kill）；`hippo locks cleanup-legacy --memory-root <root> [--apply]`（legacy per-session lock 一次性清理，預設 dry-run，僅維護窗口使用）。
 

--- a/changelog.d/hippo-memory-kpi.md
+++ b/changelog.d/hippo-memory-kpi.md
@@ -1,0 +1,4 @@
+---
+type: feat
+---
+- `custom-skills/hippo-memory-kpi/`：新增 repo-local 唯讀 KPI skill 與 deterministic report script，固定呈現 7/30 天 session→atomic note 轉化、schema/checksum 機器可讀 proxy、raw/adjusted searchable 參考價值、strict offer→read→applied Agent 看過／採用率；排除 no-findings 與稽核 session，並明列 Cortex source_material 與 Codex attribution 下限。

--- a/custom-skills/hippo-memory-kpi/SKILL.md
+++ b/custom-skills/hippo-memory-kpi/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: hippo-memory-kpi
+description: Use when auditing Hippo session-to-atomic-note conversion, note readability or reference value, Agent viewed or adopted rates, offer/read/applied telemetry, 7-day or 30-day trends, or Cortex memory-consumption semantics.
+compatibility: Requires Python 3.10+, a paulsha-hippo checkout or installed package, and read access to the target memory root.
+---
+
+# Hippo Memory KPI
+
+## 執行方式
+
+1. 釘住 `memory_root`、UTC `now`、7/30 天窗口，以及目前稽核用的 `tool:session-id`。
+2. 解析本 skill 所在目錄，執行 bundled script：
+
+   ```bash
+   python <skill-dir>/scripts/report.py \
+     --memory-root "$PSC_MEMORY_ROOT" \
+     --days 7 --days 30 \
+     --exclude-session codex:<current-session-id> \
+     --format json
+   ```
+
+3. 用同一組參數改成 `--format markdown` 取得可直接交付的表格。
+4. 若使用者同時問「目前執行版本」，另以唯讀方式核對 `hippo --version`、systemd `ExecStart` 與 build identity；不要把 repo HEAD 當成 deployed runtime。
+
+稽核期間不要執行 `hippo recall`。Recall 會新增 offer，使觀測行為本身污染分母；需要排除的目前 session 改用 `--exclude-session`，可重複指定。
+
+## 指標契約
+
+| 指標 | 主分子／分母 | 證據來源 |
+|---|---|---|
+| Session → Atomic note | final `processing.state=promoted` / non-empty unique intake sessions | `import.jsonl` + folded `processing.jsonl` |
+| 機器可讀 proxy | current file 且 schema/checksum valid / committed produced unique notes | `publication.jsonl` + knowledge files |
+| 參考價值 proxy | searchable / produced unique notes | retrieval index |
+| 調整後參考價值 | searchable / machine-valid non-review notes | knowledge files + retrieval index |
+| 原始 Read（補充） | 排除後所有 unique `source=read` notes | `memory_usage.jsonl` |
+| Agent 看過率 | unique offered notes with a strictly later matching read / eligible unique offered notes | `offered.jsonl` + `memory_usage.jsonl` |
+| Agent 嚴格採用率 | unique offered notes with `offer < read < applied` / eligible unique offered notes | both usage ledgers |
+
+主轉化率保留 `no-findings`、`parked`、`pending` 的狀態列；`empty-skip` 不進 non-empty 分母。`substantive_conversion` 只作補充，分母為 `promoted + parked`。
+
+主消費漏斗以 unique atomic notes 計算，並排除 final `state=no-findings` 與目前稽核 session。原始 Read 包含 pre-offer／never-offered；`direct_read_events` 則專指無法歸因至先行 offer 的 Read。寬鬆 applied 仍須 `offer < applied`，只作補充。
+
+## Cortex 分類
+
+| 行為 | 分類 | 是否進主漏斗 |
+|---|---|---|
+| Cortex `source_material` 直接放進 job prompt | neither | 否 |
+| Hippo shortlist/context 注入並寫 `offered.jsonl` | offer | 分母 |
+| Claude `Read`／Copilot `view` 實際開 note 並寫 `source=read` | read | 時序與 identity 成立才進看過分子 |
+| `hippo usage mark-applied` | applied | 先有 attributable read 才進嚴格採用分子 |
+
+Cortex 中 Agent 真正用 `Read`/`view` 開啟 note 算 **read**；只是 prompt 已含摘要不算。Codex 缺少與 Claude/Copilot 對等且已 live-proven 的 read hook，因此看過率是可觀測下限，不可把零值解讀為確定沒看。
+
+## 報表形狀
+
+先交付 script 產生的主表，再附三項限制：
+
+- 「可讀性」是 schema/checksum 的機器 proxy，不是人類理解或內容正確性。
+- `searchable` 代表可檢索，不代表曾被讀取、引用或採用。
+- 零分母、缺 index 或 index integrity problem 顯示 `n/a`；ledger 缺檔／壞行列 diagnostics。診斷非零時數值只代表可解析子集，不要重建或修復。
+
+## Quick reference
+
+| 需求 | 參數／判定 |
+|---|---|
+| 可重現快照 | `--now <ISO-8601>` |
+| 排除 observer effect | `--exclude-session tool:id` |
+| Agent 看過 | same tool/session/slice 且 `read_ts > offer_ts` |
+| 嚴格採用 | same triple 且 `offer_ts < read_ts < applied_ts` |
+| 輸出 | `--format json` 或 `markdown` |
+
+## 常見錯誤
+
+| 錯誤 | 修正 |
+|---|---|
+| 用現存有效檔案反推 session 是否轉化 | session 轉化只看 final `promoted`；檔案有效率另算 |
+| 把 applied-before-offer 或 applied-only 當採用 | 主指標只計 ordered `offer → read → applied` |
+| 把 Cortex prompt injection 當 read | 無 Hippo read event 就是 neither |
+| 稽核時先 recall 再量測 | 不呼叫 recall，排除目前 session |

--- a/custom-skills/hippo-memory-kpi/evals/evals.json
+++ b/custom-skills/hippo-memory-kpi/evals/evals.json
@@ -1,0 +1,51 @@
+{
+  "skill_name": "hippo-memory-kpi",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "以 2026-08-18T12:00:00Z 為 now，唯讀整理以下合成 Hippo 快照的 7 天與 30 天 KPI 表。排除目前稽核 session codex:audit。import 最終資料：claude:s1 captured_at=2026-08-17 status=written；claude:s2 2026-08-16 written；claude:s3 2026-08-15 written；claude:s4 2026-08-10 empty-skip；claude:s5 2026-08-01 written；claude:old 2026-07-10 written；codex:audit 2026-08-18 written。processing 最終狀態：s1 promoted accepted_slices=2；s2 no-findings；s3 parked；s5 promoted accepted_slices=1；old promoted；audit promoted。產出 note：s1/A 存在且 schema/checksum 有效、searchable、artifact_kind=research；s1/B 存在但 checksum invalid、not searchable、research；s5/C 存在且 schema/checksum 有效、not searchable、artifact_kind=review。請清楚定義 session→atomic-note 轉化率、atomic note 可讀性與參考價值，並以表格呈現分子、分母、比率及限制。",
+      "expected_output": "A 7/30-day table that separates final processing conversion, machine-valid quality, raw searchability, and adjusted non-review searchability.",
+      "files": [],
+      "expectations": [
+        "7-day conversion reports 3 non-empty sessions, 1 promoted session, and 33.33% promoted/non-empty conversion after excluding codex:audit.",
+        "30-day conversion reports 5 intake sessions, 1 empty-skip, 4 non-empty sessions, 2 promoted sessions, and 50.00% promoted/non-empty conversion.",
+        "Session conversion uses the final processing state promoted as its numerator; current file validity is reported separately and cannot redefine whether the session was promoted.",
+        "No-findings, parked, pending, empty-skip, and accepted-note counts remain visible rather than being silently removed from the report.",
+        "Readability is explicitly labeled a machine-verifiable schema/checksum proxy, not human semantic readability.",
+        "7-day note quality reports 2 produced, 1 valid (50.00%), and 1 searchable (50.00%).",
+        "30-day note quality reports 3 produced, 2 valid (66.67%), and 1 searchable (33.33%), with adjusted searchable reference value 1/1 (100.00%) after separating invalid and review-pool exclusions."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "以 2026-08-18T12:00:00Z 為 now，從下列合成 ledger 計算 7 天與 30 天 Agent 看過率及採用率，排除 processing 最終 state=no-findings 的 claude:s2，並排除目前稽核 session codex:audit。offers：2026-08-17 claude:s1 A/B 10:00；2026-08-17 claude:s2 C 10:00；2026-08-18 codex:audit E 10:00；2026-08-05 codex:s3 D 10:00；2026-07-25 copilot-cli:s4 F 10:00。reads：s1/A 10:01；s1/B 09:59；s2/C 10:01；audit/E 10:01；s3/D 10:01；s4/F 10:01；另有 2026-08-17 claude:sx G 10:01 但從未 offer。applied：s1/A 10:02；s1/B 10:03；s3/D 09:30；s4/F 10:03；sx/G 10:04。所有事件 tool/session/slice 與上述相同。請用 unique atomic notes 為主漏斗，表格列出分子、分母、比率、direct read、寬鬆 applied 與嚴格採用的差異。",
+      "expected_output": "An ordered unique-note usage funnel for both windows, with no-findings/audit exclusions, direct reads, loose offer-applied, strict adoption, and Codex limits.",
+      "files": [],
+      "expectations": [
+        "7-day main funnel uses A and B as the 2 offered-note denominator, counts only A as strictly viewed, and reports 1/2 = 50.00% viewed.",
+        "7-day strict adoption counts only A and reports 1/2 = 50.00%.",
+        "30-day main funnel excludes no-findings C and audit E, uses A/B/D/F as the 4-note denominator, and reports 3/4 = 75.00% viewed.",
+        "30-day strict adoption counts only A and F and reports 2/4 = 50.00%.",
+        "The output explains that B's pre-offer read and G's never-offered read are direct reads, while B/D/G applied events do not prove strict adoption.",
+        "Raw direct reads are reported as 3 unique notes in 7 days and 5 unique notes in 30 days after the stated exclusions.",
+        "Loose offer-then-applied still requires an earlier matching offer, so D and G are invalid loose applications; it is supplemental only and does not replace the strict offer-then-read-then-applied metric.",
+        "Loose offer-then-applied is reported as 2/2 = 100.00% for 7 days and 3/4 = 75.00% for 30 days.",
+        "The output labels Codex read attribution as an observable lower bound rather than equivalent coverage across agents."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "請把下列 Cortex/Hippo 行為逐列分類為 neither、offer、read 或 applied，並說明是否能納入 Agent 看過率／採用率：A. Cortex manager 把 source_material 直接組進 job prompt，未呼叫 Hippo；B. Hippo shortlist 注入 context 並追加 offered.jsonl；C. Claude 用 Read 開啟 shortlist 中的 knowledge note，PostToolUse 追加 source=read；D. Copilot 用 view 開啟 note 並追加 source=read；E. Codex job prompt 已含 note 摘要但沒有 offered/read ledger；F. 同 session/slice 已 offer、已 read 後執行 hippo usage mark-applied。請特別回答 Cortex 中 Agent『看的』通常算哪一種，並交代 Codex attribution 的限制。",
+      "expected_output": "A compact classification table that separates Cortex prompt material from Hippo telemetry and keeps strict adoption and Codex observability explicit.",
+      "files": [],
+      "expectations": [
+        "A and E are classified as neither Hippo offer nor read because prompt source_material alone writes no Hippo telemetry.",
+        "B is classified as offer, C and D as read, and F as applied.",
+        "The answer states that Cortex Agent actually opening a note via Read/view belongs to read, not offer or applied.",
+        "The answer distinguishes opening content from influencing a decision and requires explicit ordered acknowledgement for adoption.",
+        "The main adoption metric is strict offer-then-read-then-applied; any applied-only session metric is labeled supplemental rather than the standard adoption rate.",
+        "Codex attribution is described as inconclusive or a lower bound, while Claude/Copilot Read/view hooks are the proven telemetry path."
+      ]
+    }
+  ]
+}

--- a/custom-skills/hippo-memory-kpi/scripts/report.py
+++ b/custom-skills/hippo-memory-kpi/scripts/report.py
@@ -1,0 +1,764 @@
+#!/usr/bin/env python3
+"""Read-only 7/30-day Hippo memory KPI report.
+
+The script deliberately reads ledger/index state directly.  It never invokes
+``hippo recall`` and never appends, rebuilds, or repairs any runtime artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from paulsha_hippo import __version__  # noqa: E402
+from paulsha_hippo.atomizer import slice_frontmatter  # noqa: E402
+from paulsha_hippo.build_info import build_identity  # noqa: E402
+from paulsha_hippo.moc import census, frontmatter_io  # noqa: E402
+
+
+SCHEMA_VERSION = "hippo-memory-kpi/v1"
+LEDGERS = (
+    "import.jsonl",
+    "processing.jsonl",
+    "publication.jsonl",
+    "offered.jsonl",
+    "memory_usage.jsonl",
+)
+SKIP_STATUSES = {"empty-skip", "self-skip", "trivial-skip"}
+PROVEN_READ_TOOLS = {"claude-code", "copilot-cli"}
+
+
+def _diagnostics() -> dict[str, int]:
+    return {
+        "missing_file": 0,
+        "io_error": 0,
+        "utf8_decode_error": 0,
+        "json_decode_error": 0,
+        "non_object": 0,
+        "invalid_timestamp": 0,
+    }
+
+
+def _read_jsonl(path: Path, diagnostics: dict[str, int]) -> Iterable[dict[str, Any]]:
+    """Stream a JSONL ledger fail-soft without modifying it."""
+    try:
+        handle = path.open("rb")
+    except FileNotFoundError:
+        diagnostics["missing_file"] += 1
+        return
+    except OSError:
+        diagnostics["io_error"] += 1
+        return
+    try:
+        while True:
+            try:
+                raw = handle.readline()
+            except OSError:
+                diagnostics["io_error"] += 1
+                return
+            if raw == b"":
+                return
+            try:
+                line = raw.decode("utf-8").strip()
+            except UnicodeDecodeError:
+                diagnostics["utf8_decode_error"] += 1
+                continue
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                diagnostics["json_decode_error"] += 1
+                continue
+            if not isinstance(event, dict):
+                diagnostics["non_object"] += 1
+                continue
+            yield event
+    finally:
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+def _parse_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _event_time(
+    event: dict[str, Any],
+    diagnostics: dict[str, int],
+    *fields: str,
+) -> datetime | None:
+    for field in fields:
+        if field in event:
+            value = _parse_time(event.get(field))
+            if value is None:
+                diagnostics["invalid_timestamp"] += 1
+            return value
+    diagnostics["invalid_timestamp"] += 1
+    return None
+
+
+def _in_window(value: datetime | None, start: datetime, end: datetime) -> bool:
+    return value is not None and start <= value <= end
+
+
+def _measure(count: int | None, denominator: int) -> dict[str, int | float | None]:
+    if count is None or denominator == 0:
+        rate: float | None = None
+    else:
+        rate = round(count * 100 / denominator, 2)
+    return {"count": count, "denominator": denominator, "rate_pct": rate}
+
+
+def _conversion_measure(
+    numerator: int, denominator: int
+) -> dict[str, int | float | None]:
+    return {
+        "numerator": numerator,
+        "denominator": denominator,
+        "rate_pct": round(numerator * 100 / denominator, 2) if denominator else None,
+    }
+
+
+def _session_key(event: dict[str, Any]) -> str:
+    explicit = event.get("logical_session_key") or event.get("session_key")
+    if explicit:
+        return str(explicit)
+    idempotency = str(event.get("idempotency_key") or "")
+    parts = idempotency.split(":")
+    return ":".join(parts[:2]) if len(parts) >= 2 else idempotency
+
+
+def _usage_session_key(event: dict[str, Any]) -> str:
+    tool = str(event.get("tool") or "").strip()
+    session_id = str(event.get("session_id") or "").strip()
+    return f"{tool}:{session_id}" if tool and session_id else ""
+
+
+def _fold_processing(
+    rows: list[dict[str, Any]],
+    now: datetime,
+    diagnostics: dict[str, int],
+) -> dict[str, dict[str, Any]]:
+    latest: dict[str, tuple[datetime, int, dict[str, Any]]] = {}
+    for index, event in enumerate(rows):
+        key = _session_key(event)
+        if not key:
+            continue
+        stamp = _event_time(event, diagnostics, "ts")
+        if stamp is None or stamp > now:
+            continue
+        candidate = (stamp, index, event)
+        if key not in latest or candidate[:2] > latest[key][:2]:
+            latest[key] = candidate
+    return {key: candidate[2] for key, candidate in latest.items()}
+
+
+def _session_conversion(
+    import_rows: list[dict[str, Any]],
+    processing: dict[str, dict[str, Any]],
+    *,
+    start: datetime,
+    now: datetime,
+    excluded: set[str],
+    diagnostics: dict[str, int],
+) -> dict[str, Any]:
+    latest: dict[str, tuple[datetime, int, dict[str, Any]]] = {}
+    for index, event in enumerate(import_rows):
+        key = _session_key(event)
+        if not key or key in excluded:
+            continue
+        stamp = _event_time(event, diagnostics, "captured_at", "recorded_at")
+        if not _in_window(stamp, start, now):
+            continue
+        candidate = (stamp, index, event)
+        if key not in latest or candidate[:2] > latest[key][:2]:
+            latest[key] = candidate
+
+    intake = len(latest)
+    skip_status_counts: dict[str, int] = defaultdict(int)
+    for _, _, event in latest.values():
+        status = str(event.get("status") or "")
+        if status in SKIP_STATUSES:
+            skip_status_counts[status] += 1
+    empty_skip = skip_status_counts.get("empty-skip", 0)
+    nonempty_keys = {
+        key
+        for key, (_, _, event) in latest.items()
+        if str(event.get("status") or "") not in SKIP_STATUSES
+    }
+    state_counts = defaultdict(int)
+    other_states = defaultdict(int)
+    accepted_notes = 0
+    for key in nonempty_keys:
+        event = processing.get(key, {})
+        state = str(event.get("state") or "pending")
+        if state in {"promoted", "no-findings", "parked", "pending"}:
+            state_counts[state] += 1
+        else:
+            other_states[state] += 1
+        if state == "promoted":
+            try:
+                accepted_notes += int(event.get("accepted_slices") or 0)
+            except (TypeError, ValueError):
+                pass
+
+    promoted = state_counts["promoted"]
+    parked = state_counts["parked"]
+    return {
+        "intake_sessions": intake,
+        "empty_skip": empty_skip,
+        "skipped_sessions": sum(skip_status_counts.values()),
+        "skip_status_counts": dict(sorted(skip_status_counts.items())),
+        "nonempty_sessions": len(nonempty_keys),
+        "promoted": promoted,
+        "no_findings": state_counts["no-findings"],
+        "parked": parked,
+        "pending": state_counts["pending"],
+        "other_processing_states": dict(sorted(other_states.items())),
+        "accepted_notes": accepted_notes,
+        "conversion": _conversion_measure(promoted, len(nonempty_keys)),
+        "substantive_conversion": _conversion_measure(promoted, promoted + parked),
+    }
+
+
+def _committed_publications(
+    rows: list[dict[str, Any]],
+    *,
+    now: datetime,
+    diagnostics: dict[str, int],
+) -> set[str]:
+    committed: set[str] = set()
+    for event in rows:
+        if event.get("event") != "publish_commit" or not event.get("publication_id"):
+            continue
+        stamp = _event_time(event, diagnostics, "now", "ts")
+        if stamp is not None and stamp <= now:
+            committed.add(str(event["publication_id"]))
+    return committed
+
+
+def _produced_notes(
+    rows: list[dict[str, Any]],
+    *,
+    committed: set[str],
+    start: datetime,
+    now: datetime,
+    excluded: set[str],
+    diagnostics: dict[str, int],
+) -> dict[str, str]:
+    produced: dict[str, str] = {}
+    for event in rows:
+        if event.get("event") != "publish_prepare":
+            continue
+        publication_id = str(event.get("publication_id") or "")
+        if not publication_id or publication_id not in committed:
+            continue
+        if _session_key(event) in excluded:
+            continue
+        stamp = _event_time(event, diagnostics, "now", "ts")
+        if not _in_window(stamp, start, now):
+            continue
+        items = event.get("items")
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            slice_id = str(item.get("slice_id") or item.get("sl_id") or "").strip()
+            if slice_id:
+                produced.setdefault(slice_id, str(item.get("target") or ""))
+    return produced
+
+
+def _knowledge_paths(root: Path) -> tuple[dict[str, list[Path]], list[str]]:
+    by_id: dict[str, list[Path]] = defaultdict(list)
+    problems: list[str] = []
+    for entry in census.filesystem_census(root):
+        if entry.slice_id:
+            by_id[entry.slice_id].append(Path(entry.path))
+    for slice_id, paths in by_id.items():
+        if len(paths) > 1:
+            problems.append(f"duplicate current files for {slice_id}: {len(paths)}")
+    return dict(by_id), problems
+
+
+def _searchable_ids(root: Path) -> tuple[set[str] | None, list[str]]:
+    try:
+        audit = census.audit_indexed_ids(root)
+    except Exception as exc:  # SearchIndexError and corrupt/read failures are report data.
+        return None, [str(exc)]
+    problems = list(audit.problems)
+    if problems:
+        return None, problems
+    return audit.searchable_ids, problems
+
+
+def _note_quality(
+    produced: dict[str, str],
+    *,
+    current_paths: dict[str, list[Path]],
+    searchable_ids: set[str] | None,
+    index_problems: list[str],
+) -> dict[str, Any]:
+    valid: set[str] = set()
+    valid_non_review: set[str] = set()
+    review: set[str] = set()
+    missing: set[str] = set()
+    invalid: set[str] = set()
+
+    for slice_id in produced:
+        candidates = current_paths.get(slice_id, [])
+        path = next((candidate for candidate in candidates if candidate.is_file()), None)
+        if path is None:
+            missing.add(slice_id)
+            continue
+        try:
+            frontmatter, body = frontmatter_io.read(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            invalid.add(slice_id)
+            continue
+        errors = slice_frontmatter.validate(frontmatter, body)
+        if frontmatter.get("slice_id") != slice_id:
+            errors.append("slice_id mismatch")
+        if errors:
+            invalid.add(slice_id)
+            continue
+        valid.add(slice_id)
+        if str(frontmatter.get("artifact_kind") or "").lower() == "review":
+            review.add(slice_id)
+        else:
+            valid_non_review.add(slice_id)
+
+    denominator = len(produced)
+    searchable_count = (
+        len(set(produced) & searchable_ids) if searchable_ids is not None else None
+    )
+    adjusted_count = (
+        len(valid_non_review & searchable_ids) if searchable_ids is not None else None
+    )
+    return {
+        "produced_unique_notes": denominator,
+        "current_files": denominator - len(missing),
+        "missing_current": len(missing),
+        "invalid_machine": len(invalid),
+        "machine_valid": _measure(len(valid), denominator),
+        "searchable": _measure(searchable_count, denominator),
+        "review_pool_excluded": len(review),
+        "adjusted_non_review_searchable": _measure(
+            adjusted_count, len(valid_non_review)
+        ),
+        "index_available": searchable_ids is not None,
+        "index_problems": index_problems,
+    }
+
+
+def _offered_ids(event: dict[str, Any]) -> list[str]:
+    value = event.get("offered")
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value:
+        slice_id = item.get("sl_id") if isinstance(item, dict) else item
+        if slice_id:
+            result.append(str(slice_id))
+    return result
+
+
+def _usage_metrics(
+    offered_rows: list[dict[str, Any]],
+    usage_rows: list[dict[str, Any]],
+    processing: dict[str, dict[str, Any]],
+    *,
+    start: datetime,
+    now: datetime,
+    excluded: set[str],
+    offered_diagnostics: dict[str, int],
+    usage_diagnostics: dict[str, int],
+) -> dict[str, Any]:
+    noise = {
+        key for key, event in processing.items() if event.get("state") == "no-findings"
+    }
+    offer_times: dict[tuple[str, str, str], datetime] = {}
+    offered_notes: set[str] = set()
+    offered_by_tool: dict[str, set[str]] = defaultdict(set)
+    for event in offered_rows:
+        stamp = _event_time(event, offered_diagnostics, "ts")
+        if not _in_window(stamp, start, now):
+            continue
+        session_key = _usage_session_key(event)
+        if not session_key or session_key in excluded or session_key in noise:
+            continue
+        tool, session_id = session_key.split(":", 1)
+        for slice_id in _offered_ids(event):
+            key = (tool, session_id, slice_id)
+            prior = offer_times.get(key)
+            if prior is None or stamp < prior:
+                offer_times[key] = stamp
+            offered_notes.add(slice_id)
+            offered_by_tool[tool].add(slice_id)
+
+    attributed_reads: dict[tuple[str, str, str], datetime] = {}
+    viewed_notes: set[str] = set()
+    viewed_by_tool: dict[str, set[str]] = defaultdict(set)
+    raw_read_events = 0
+    raw_read_notes: set[str] = set()
+    direct_events = 0
+    direct_notes: set[str] = set()
+    applied_events: list[tuple[tuple[str, str, str], datetime]] = []
+    for event in usage_rows:
+        stamp = _event_time(event, usage_diagnostics, "ts")
+        if not _in_window(stamp, start, now):
+            continue
+        session_key = _usage_session_key(event)
+        if not session_key or session_key in excluded or session_key in noise:
+            continue
+        tool, session_id = session_key.split(":", 1)
+        if event.get("kind") == "applied":
+            slice_id = str(event.get("slice_id") or event.get("sl_id") or "").strip()
+            if slice_id:
+                applied_events.append(((tool, session_id, slice_id), stamp))
+            continue
+        if event.get("source") != "read":
+            continue
+        slice_id = str(event.get("sl_id") or event.get("slice_id") or "").strip()
+        if not slice_id:
+            continue
+        raw_read_events += 1
+        raw_read_notes.add(slice_id)
+        key = (tool, session_id, slice_id)
+        offer_time = offer_times.get(key)
+        if offer_time is not None and offer_time < stamp:
+            prior = attributed_reads.get(key)
+            if prior is None or stamp < prior:
+                attributed_reads[key] = stamp
+            viewed_notes.add(slice_id)
+            viewed_by_tool[tool].add(slice_id)
+        else:
+            direct_events += 1
+            direct_notes.add(slice_id)
+
+    loose_notes: set[str] = set()
+    strict_notes: set[str] = set()
+    loose_by_tool: dict[str, set[str]] = defaultdict(set)
+    strict_by_tool: dict[str, set[str]] = defaultdict(set)
+    invalid_applied = 0
+    for key, applied_time in applied_events:
+        offer_time = offer_times.get(key)
+        if offer_time is None or not offer_time < applied_time:
+            invalid_applied += 1
+            continue
+        tool, _, slice_id = key
+        loose_notes.add(slice_id)
+        loose_by_tool[tool].add(slice_id)
+        read_time = attributed_reads.get(key)
+        if read_time is not None and read_time < applied_time:
+            strict_notes.add(slice_id)
+            strict_by_tool[tool].add(slice_id)
+
+    by_tool: dict[str, Any] = {}
+    for tool in sorted(offered_by_tool):
+        denominator = len(offered_by_tool[tool])
+        if tool in PROVEN_READ_TOOLS:
+            coverage = "proven-read-hook"
+        elif tool == "codex":
+            coverage = "lower-bound"
+        else:
+            coverage = "unknown"
+        by_tool[tool] = {
+            "offered_unique_notes": denominator,
+            "viewed": _measure(len(viewed_by_tool[tool]), denominator),
+            "strict_adopted": _measure(len(strict_by_tool[tool]), denominator),
+            "loose_offer_applied": _measure(len(loose_by_tool[tool]), denominator),
+            "attribution_coverage": coverage,
+        }
+
+    denominator = len(offered_notes)
+    return {
+        "offered_unique_notes": denominator,
+        "viewed": _measure(len(viewed_notes), denominator),
+        "strict_adopted": _measure(len(strict_notes), denominator),
+        "loose_offer_applied": _measure(len(loose_notes), denominator),
+        "raw_read_events": raw_read_events,
+        "raw_read_unique_notes": len(raw_read_notes),
+        "direct_read_events": direct_events,
+        "direct_read_unique_notes": len(direct_notes),
+        "invalid_applied_events": invalid_applied,
+        "by_tool": by_tool,
+    }
+
+
+def build_report(
+    root: Path,
+    *,
+    now: datetime,
+    days: list[int],
+    excluded_sessions: set[str],
+) -> dict[str, Any]:
+    ledger_root = root / "runtime" / "ledger"
+    diagnostics = {name: _diagnostics() for name in LEDGERS}
+    rows = {
+        name: list(_read_jsonl(ledger_root / name, diagnostics[name]))
+        for name in LEDGERS
+    }
+    processing = _fold_processing(
+        rows["processing.jsonl"], now, diagnostics["processing.jsonl"]
+    )
+    current_paths, path_problems = _knowledge_paths(root)
+    searchable_ids, index_problems = _searchable_ids(root)
+    all_index_problems = path_problems + index_problems
+    if path_problems:
+        searchable_ids = None
+    committed = _committed_publications(
+        rows["publication.jsonl"],
+        now=now,
+        diagnostics=diagnostics["publication.jsonl"],
+    )
+
+    windows: dict[str, Any] = {}
+    for window_days in days:
+        start = now - timedelta(days=window_days)
+        produced = _produced_notes(
+            rows["publication.jsonl"],
+            committed=committed,
+            start=start,
+            now=now,
+            excluded=excluded_sessions,
+            diagnostics=diagnostics["publication.jsonl"],
+        )
+        windows[f"{window_days}d"] = {
+            "days": window_days,
+            "since": start.isoformat(),
+            "until": now.isoformat(),
+            "session_conversion": _session_conversion(
+                rows["import.jsonl"],
+                processing,
+                start=start,
+                now=now,
+                excluded=excluded_sessions,
+                diagnostics=diagnostics["import.jsonl"],
+            ),
+            "note_quality": _note_quality(
+                produced,
+                current_paths=current_paths,
+                searchable_ids=searchable_ids,
+                index_problems=all_index_problems,
+            ),
+            "usage": _usage_metrics(
+                rows["offered.jsonl"],
+                rows["memory_usage.jsonl"],
+                processing,
+                start=start,
+                now=now,
+                excluded=excluded_sessions,
+                offered_diagnostics=diagnostics["offered.jsonl"],
+                usage_diagnostics=diagnostics["memory_usage.jsonl"],
+            ),
+        }
+
+    try:
+        identity = build_identity()
+    except Exception:
+        identity = {"version": __version__, "build_commit": "unknown"}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": now.isoformat(),
+        "memory_root": str(root),
+        "memory_root_resolved": str(root.resolve()),
+        "reporter_build_identity": identity,
+        "excluded_sessions": sorted(excluded_sessions),
+        "windows": windows,
+        "attribution_limits": {
+            "claude-code": "proven-read-hook",
+            "copilot-cli": "proven-read-hook",
+            "codex": "lower-bound",
+            "cortex_source_material": "neither-offer-nor-read",
+        },
+        "diagnostics": diagnostics,
+    }
+
+
+def _fraction(metric: dict[str, Any]) -> str:
+    count = metric.get("count", metric.get("numerator"))
+    denominator = metric.get("denominator", 0)
+    rate = metric.get("rate_pct")
+    if count is None or rate is None:
+        return f"n/a/{denominator} (n/a)"
+    return f"{count}/{denominator} ({rate:.2f}%)"
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    windows = report["windows"]
+    labels = [f"{payload['days']} 天" for payload in windows.values()]
+    lines = [
+        "# Hippo memory KPI",
+        "",
+        f"快照：`{report['generated_at']}`；memory root：`{report['memory_root_resolved']}`",
+        "",
+        "| 指標 | " + " | ".join(labels) + " | 定義 |",
+        "|---|" + "---:|" * len(labels) + "---|",
+    ]
+    rows = [
+        (
+            "Session → Atomic note",
+            [payload["session_conversion"]["conversion"] for payload in windows.values()],
+            "final processing promoted / non-empty intake sessions",
+        ),
+        (
+            "機器可讀 proxy",
+            [payload["note_quality"]["machine_valid"] for payload in windows.values()],
+            "current file + schema/checksum valid；不是人類語意可讀性",
+        ),
+        (
+            "參考價值 proxy",
+            [payload["note_quality"]["searchable"] for payload in windows.values()],
+            "searchable / produced unique notes",
+        ),
+        (
+            "調整後參考價值",
+            [payload["note_quality"]["adjusted_non_review_searchable"] for payload in windows.values()],
+            "searchable / valid non-review notes",
+        ),
+        (
+            "Agent 看過率",
+            [payload["usage"]["viewed"] for payload in windows.values()],
+            "same tool/session/slice offer → read",
+        ),
+        (
+            "Agent 嚴格採用率",
+            [payload["usage"]["strict_adopted"] for payload in windows.values()],
+            "same tool/session/slice offer → read → applied",
+        ),
+    ]
+    for name, metrics, definition in rows:
+        lines.append(
+            f"| {name} | " + " | ".join(_fraction(metric) for metric in metrics) + f" | {definition} |"
+        )
+
+    lines.extend(["", "## 狀態與排除", ""])
+    for key, payload in windows.items():
+        conversion = payload["session_conversion"]
+        usage = payload["usage"]
+        lines.append(
+            f"- {key}: intake={conversion['intake_sessions']}, empty-skip={conversion['empty_skip']}, "
+            f"skipped-total={conversion['skipped_sessions']}, "
+            f"nonempty={conversion['nonempty_sessions']}, promoted={conversion['promoted']}, "
+            f"no-findings={conversion['no_findings']}, parked={conversion['parked']}, "
+            f"pending={conversion['pending']}, other-states={conversion['other_processing_states']}, "
+            f"accepted-notes={conversion['accepted_notes']}; "
+            f"raw-read-events={usage['raw_read_events']}, "
+            f"unattributed-direct-read-events={usage['direct_read_events']}, "
+            f"invalid-applied-events={usage['invalid_applied_events']}"
+        )
+    exclusions = ", ".join(report["excluded_sessions"]) or "(none)"
+    lines.append(f"- 排除目前稽核 session：`{exclusions}`。")
+
+    diagnostic_lines: list[str] = []
+    for ledger_name, counters in report["diagnostics"].items():
+        nonzero = [f"{name}={count}" for name, count in counters.items() if count]
+        if nonzero:
+            diagnostic_lines.append(f"- `{ledger_name}`: {', '.join(nonzero)}")
+    index_problems = sorted(
+        {
+            problem
+            for payload in windows.values()
+            for problem in payload["note_quality"]["index_problems"]
+        }
+    )
+    diagnostic_lines.extend(f"- retrieval/index: {problem}" for problem in index_problems[:5])
+    if diagnostic_lines:
+        lines.extend(
+            [
+                "",
+                "## 資料診斷",
+                "",
+                *diagnostic_lines,
+                "- 診斷非零時，數值只代表成功解析的可觀測子集；不得當作完整母體。",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Attribution 限制",
+            "",
+            "- Cortex source_material 直接進 job prompt 屬 neither：不會因此產生 Hippo offer/read。",
+            "- Claude Read 與 Copilot view 有已證實的 read hook；Codex read telemetry 目前是可觀測下限。",
+            "- `applied` 只作補充時仍要有先行 offer；主採用率固定使用嚴格 offer → read → applied。",
+            "- 本報表唯讀，不呼叫 `hippo recall`，避免稽核本身新增 offer 污染分母。",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate read-only Hippo session/note/view/adoption KPIs."
+    )
+    parser.add_argument(
+        "--memory-root",
+        default=os.environ.get("PSC_MEMORY_ROOT", str(Path.home() / ".agents" / "memory")),
+    )
+    parser.add_argument("--days", type=int, action="append", dest="days")
+    parser.add_argument("--now", help="ISO-8601 upper bound; defaults to current UTC time")
+    parser.add_argument(
+        "--exclude-session",
+        action="append",
+        default=[],
+        help="logical tool:session-id to exclude; repeatable",
+    )
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    root = Path(args.memory_root).expanduser()
+    if not root.is_dir():
+        print(f"hippo-memory-kpi: error: memory root is not a directory: {root}", file=sys.stderr)
+        return 2
+    now = _parse_time(args.now) if args.now else datetime.now(timezone.utc)
+    if now is None:
+        print("hippo-memory-kpi: error: --now must be ISO-8601", file=sys.stderr)
+        return 2
+    days = args.days or [7, 30]
+    if any(value <= 0 for value in days):
+        print("hippo-memory-kpi: error: --days must be positive", file=sys.stderr)
+        return 2
+    days = list(dict.fromkeys(days))
+    report = build_report(
+        root,
+        now=now,
+        days=days,
+        excluded_sessions=set(args.exclude_session),
+    )
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+    else:
+        print(render_markdown(report), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hippo_memory_kpi_skill.py
+++ b/tests/test_hippo_memory_kpi_skill.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+from paulsha_hippo.lib.lifecycle import schema as lifecycle_schema
+from paulsha_hippo.moc import frontmatter_io, search
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPORT_SCRIPT = (
+    REPO_ROOT
+    / "custom-skills"
+    / "hippo-memory-kpi"
+    / "scripts"
+    / "report.py"
+)
+NOW = "2026-08-18T12:00:00Z"
+
+
+def _write_jsonl(root: Path, name: str, rows: list[dict], *, bad_line: bool = False) -> None:
+    ledger = root / "runtime" / "ledger"
+    ledger.mkdir(parents=True, exist_ok=True)
+    text = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows)
+    if bad_line:
+        text = "not-json\n" + text
+    (ledger / name).write_text(text, encoding="utf-8")
+
+
+def _write_note(
+    root: Path,
+    *,
+    slice_id: str,
+    session_id: str,
+    captured_at: str,
+    artifact_kind: str,
+    publication_id: str,
+    valid_checksum: bool = True,
+) -> Path:
+    body = (
+        f"This durable atomic note records deterministic KPI evidence for {slice_id}.\n"
+        "It contains enough substantive detail for retrieval and later engineering reference.\n"
+    )
+    checksum = lifecycle_schema.compute_checksum(body)
+    if not valid_checksum:
+        checksum = "0" * 64
+    phase = "review" if artifact_kind == "review" else "research"
+    frontmatter = {
+        "phase": phase,
+        "project": "paulsha-hippo",
+        "slice_id": slice_id,
+        "artifact_kind": artifact_kind,
+        "version": "1",
+        "created_at": captured_at,
+        "created_by": "claude-code",
+        "source_session": session_id,
+        "gate_required": False,
+        "checksum": checksum,
+        "memory_layer": "knowledge",
+        "source_agent": "claude-code",
+        "captured_at": captured_at,
+        "provenance": {"repo": "hamanpaul/paulsha-hippo", "commit": "abc", "path": "tests"},
+        "distiller": {},
+        "supersedes": [],
+        "distilled_from": f"claude-code:{session_id}",
+        "title": f"KPI evidence {slice_id}",
+        "atom_title": f"KPI evidence {slice_id}",
+        # Invalid-checksum fixture also carries an invalid MOC tags type so it is
+        # intentionally absent from the existing searchable index.  The KPI
+        # report must still classify checksum validity independently.
+        "tags": ["kpi", "memory"] if valid_checksum else [1],
+        "publication_id": publication_id,
+    }
+    path = root / "knowledge" / "paulsha-hippo" / f"{slice_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(frontmatter_io.dump(frontmatter, body), encoding="utf-8")
+    return path
+
+
+def _seed_memory_root(root: Path, *, malformed_usage: bool = False) -> None:
+    imports = [
+        {"logical_session_key": "claude-code:s1", "captured_at": "2026-08-17T00:00:00Z", "status": "written"},
+        {"logical_session_key": "claude-code:s2", "captured_at": "2026-08-16T00:00:00Z", "status": "written"},
+        {"logical_session_key": "claude-code:s3", "captured_at": "2026-08-15T00:00:00Z", "status": "written"},
+        {"logical_session_key": "claude-code:s4", "captured_at": "2026-08-10T00:00:00Z", "status": "empty-skip"},
+        {"logical_session_key": "claude-code:s5", "captured_at": "2026-08-01T00:00:00Z", "status": "written"},
+        {"logical_session_key": "claude-code:old", "captured_at": "2026-07-10T00:00:00Z", "status": "written"},
+        {"logical_session_key": "codex:audit", "captured_at": "2026-08-18T00:00:00Z", "status": "written"},
+    ]
+    processing = [
+        {"ts": "2026-08-17T12:00:00Z", "session_key": "claude-code:s1", "state": "promoted", "accepted_slices": 2},
+        {"ts": "2026-08-16T12:00:00Z", "session_key": "claude-code:s2", "state": "no-findings", "accepted_slices": 0},
+        {"ts": "2026-08-15T12:00:00Z", "session_key": "claude-code:s3", "state": "parked", "accepted_slices": 0},
+        {"ts": "2026-08-01T12:00:00Z", "session_key": "claude-code:s5", "state": "promoted", "accepted_slices": 1},
+        {"ts": "2026-07-10T12:00:00Z", "session_key": "claude-code:old", "state": "promoted", "accepted_slices": 1},
+        {"ts": "2026-08-18T01:00:00Z", "session_key": "codex:audit", "state": "promoted", "accepted_slices": 1},
+    ]
+    _write_jsonl(root, "import.jsonl", imports)
+    _write_jsonl(root, "processing.jsonl", processing)
+
+    note_a = _write_note(
+        root,
+        slice_id="sl-aaaaaaaaaaaaaaaa",
+        session_id="s1",
+        captured_at="2026-08-17T12:00:00Z",
+        artifact_kind="research",
+        publication_id="pub-s1",
+    )
+    note_b = _write_note(
+        root,
+        slice_id="sl-bbbbbbbbbbbbbbbb",
+        session_id="s1",
+        captured_at="2026-08-17T12:00:00Z",
+        artifact_kind="research",
+        publication_id="pub-s1",
+        valid_checksum=False,
+    )
+    note_c = _write_note(
+        root,
+        slice_id="sl-cccccccccccccccc",
+        session_id="s5",
+        captured_at="2026-08-01T12:00:00Z",
+        artifact_kind="review",
+        publication_id="pub-s5",
+    )
+    publications = [
+        {
+            "event": "publish_prepare",
+            "publication_id": "pub-s1",
+            "session_key": "claude-code:s1",
+            "now": "2026-08-17T12:00:00Z",
+            "items": [
+                {"slice_id": "sl-aaaaaaaaaaaaaaaa", "target": str(note_a)},
+                {"slice_id": "sl-bbbbbbbbbbbbbbbb", "target": str(note_b)},
+            ],
+        },
+        {"event": "publish_commit", "publication_id": "pub-s1", "now": "2026-08-17T12:01:00Z"},
+        {
+            "event": "publish_prepare",
+            "publication_id": "pub-s5",
+            "session_key": "claude-code:s5",
+            "now": "2026-08-01T12:00:00Z",
+            "items": [{"slice_id": "sl-cccccccccccccccc", "target": str(note_c)}],
+        },
+        {"event": "publish_commit", "publication_id": "pub-s5", "now": "2026-08-01T12:01:00Z"},
+    ]
+    _write_jsonl(root, "publication.jsonl", publications)
+
+    offered = [
+        {"ts": "2026-08-17T10:00:00Z", "tool": "claude-code", "session_id": "s1", "offered": ["sl-aaaaaaaaaaaaaaaa", "sl-bbbbbbbbbbbbbbbb"]},
+        {"ts": "2026-08-17T10:00:00Z", "tool": "claude-code", "session_id": "s2", "offered": ["sl-cccccccccccccccc"]},
+        {"ts": "2026-08-18T10:00:00Z", "tool": "codex", "session_id": "audit", "offered": ["sl-eeeeeeeeeeeeeeee"]},
+        {"ts": "2026-08-05T10:00:00Z", "tool": "codex", "session_id": "s3", "offered": ["sl-dddddddddddddddd"]},
+        {"ts": "2026-07-25T10:00:00Z", "tool": "copilot-cli", "session_id": "s4", "offered": ["sl-ffffffffffffffff"]},
+    ]
+    usage = [
+        {"ts": "2026-08-17T10:01:00Z", "tool": "claude-code", "session_id": "s1", "sl_id": "sl-aaaaaaaaaaaaaaaa", "source": "read"},
+        {"ts": "2026-08-17T09:59:00Z", "tool": "claude-code", "session_id": "s1", "sl_id": "sl-bbbbbbbbbbbbbbbb", "source": "read"},
+        {"ts": "2026-08-17T10:01:00Z", "tool": "claude-code", "session_id": "s2", "sl_id": "sl-cccccccccccccccc", "source": "read"},
+        {"ts": "2026-08-18T10:01:00Z", "tool": "codex", "session_id": "audit", "sl_id": "sl-eeeeeeeeeeeeeeee", "source": "read"},
+        {"ts": "2026-08-05T10:01:00Z", "tool": "codex", "session_id": "s3", "sl_id": "sl-dddddddddddddddd", "source": "read"},
+        {"ts": "2026-07-25T10:01:00Z", "tool": "copilot-cli", "session_id": "s4", "sl_id": "sl-ffffffffffffffff", "source": "read"},
+        {"ts": "2026-08-17T10:01:00Z", "tool": "claude-code", "session_id": "sx", "sl_id": "sl-gggggggggggggggg", "source": "read"},
+        {"ts": "2026-08-17T10:02:00Z", "tool": "claude-code", "session_id": "s1", "slice_id": "sl-aaaaaaaaaaaaaaaa", "kind": "applied"},
+        {"ts": "2026-08-17T10:03:00Z", "tool": "claude-code", "session_id": "s1", "slice_id": "sl-bbbbbbbbbbbbbbbb", "kind": "applied"},
+        {"ts": "2026-08-05T09:30:00Z", "tool": "codex", "session_id": "s3", "slice_id": "sl-dddddddddddddddd", "kind": "applied"},
+        {"ts": "2026-07-25T10:03:00Z", "tool": "copilot-cli", "session_id": "s4", "slice_id": "sl-ffffffffffffffff", "kind": "applied"},
+        {"ts": "2026-08-17T10:04:00Z", "tool": "claude-code", "session_id": "sx", "slice_id": "sl-gggggggggggggggg", "kind": "applied"},
+    ]
+    _write_jsonl(root, "offered.jsonl", offered)
+    _write_jsonl(root, "memory_usage.jsonl", usage, bad_line=malformed_usage)
+
+    coverage = search.build_index(root, link_weights={})
+    assert coverage["eligible"] == 1
+    assert coverage["indexed"] == 1
+
+
+def _run_report(root: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(REPORT_SCRIPT),
+            "--memory-root",
+            str(root),
+            "--now",
+            NOW,
+            "--days",
+            "7",
+            "--days",
+            "30",
+            "--exclude-session",
+            "codex:audit",
+            *extra,
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _snapshot(root: Path) -> dict[str, str]:
+    return {
+        str(path.relative_to(root)): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_report_json_enforces_conversion_quality_and_ordered_usage_contract(tmp_path):
+    _seed_memory_root(tmp_path)
+
+    completed = _run_report(tmp_path, "--format", "json")
+
+    assert completed.returncode == 0, completed.stderr
+    report = json.loads(completed.stdout)
+    assert report["schema_version"] == "hippo-memory-kpi/v1"
+    assert report["excluded_sessions"] == ["codex:audit"]
+
+    seven = report["windows"]["7d"]
+    assert seven["session_conversion"] == {
+        "intake_sessions": 3,
+        "empty_skip": 0,
+        "skipped_sessions": 0,
+        "skip_status_counts": {},
+        "nonempty_sessions": 3,
+        "promoted": 1,
+        "no_findings": 1,
+        "parked": 1,
+        "pending": 0,
+        "other_processing_states": {},
+        "accepted_notes": 2,
+        "conversion": {"numerator": 1, "denominator": 3, "rate_pct": 33.33},
+        "substantive_conversion": {"numerator": 1, "denominator": 2, "rate_pct": 50.0},
+    }
+    assert seven["note_quality"]["produced_unique_notes"] == 2
+    assert seven["note_quality"]["machine_valid"] == {"count": 1, "denominator": 2, "rate_pct": 50.0}
+    assert seven["note_quality"]["searchable"] == {"count": 1, "denominator": 2, "rate_pct": 50.0}
+    assert seven["note_quality"]["adjusted_non_review_searchable"] == {"count": 1, "denominator": 1, "rate_pct": 100.0}
+    assert seven["usage"]["offered_unique_notes"] == 2
+    assert seven["usage"]["raw_read_events"] == 3
+    assert seven["usage"]["raw_read_unique_notes"] == 3
+    assert seven["usage"]["viewed"] == {"count": 1, "denominator": 2, "rate_pct": 50.0}
+    assert seven["usage"]["strict_adopted"] == {"count": 1, "denominator": 2, "rate_pct": 50.0}
+
+    thirty = report["windows"]["30d"]
+    assert thirty["session_conversion"]["intake_sessions"] == 5
+    assert thirty["session_conversion"]["empty_skip"] == 1
+    assert thirty["session_conversion"]["nonempty_sessions"] == 4
+    assert thirty["session_conversion"]["promoted"] == 2
+    assert thirty["session_conversion"]["accepted_notes"] == 3
+    assert thirty["session_conversion"]["conversion"] == {"numerator": 2, "denominator": 4, "rate_pct": 50.0}
+    assert thirty["note_quality"]["produced_unique_notes"] == 3
+    assert thirty["note_quality"]["machine_valid"] == {"count": 2, "denominator": 3, "rate_pct": 66.67}
+    assert thirty["note_quality"]["searchable"] == {"count": 1, "denominator": 3, "rate_pct": 33.33}
+    assert thirty["note_quality"]["review_pool_excluded"] == 1
+    assert thirty["note_quality"]["adjusted_non_review_searchable"] == {"count": 1, "denominator": 1, "rate_pct": 100.0}
+    assert thirty["usage"]["offered_unique_notes"] == 4
+    assert thirty["usage"]["viewed"] == {"count": 3, "denominator": 4, "rate_pct": 75.0}
+    assert thirty["usage"]["strict_adopted"] == {"count": 2, "denominator": 4, "rate_pct": 50.0}
+    assert thirty["usage"]["loose_offer_applied"] == {"count": 3, "denominator": 4, "rate_pct": 75.0}
+    assert thirty["usage"]["raw_read_events"] == 5
+    assert thirty["usage"]["raw_read_unique_notes"] == 5
+    assert thirty["usage"]["direct_read_events"] == 2
+    assert report["attribution_limits"]["codex"] == "lower-bound"
+    assert "reporter_build_identity" in report
+    assert "runtime_identity" not in report
+
+
+def test_report_is_read_only_and_surfaces_bounded_parse_diagnostics(tmp_path):
+    _seed_memory_root(tmp_path, malformed_usage=True)
+    before = _snapshot(tmp_path)
+
+    completed = _run_report(tmp_path, "--format", "json")
+
+    assert completed.returncode == 0, completed.stderr
+    assert _snapshot(tmp_path) == before
+    report = json.loads(completed.stdout)
+    assert report["diagnostics"]["memory_usage.jsonl"]["json_decode_error"] == 1
+    assert report["windows"]["30d"]["usage"]["viewed"]["rate_pct"] == 75.0
+
+
+def test_report_markdown_keeps_proxies_and_cortex_caveats_explicit(tmp_path):
+    _seed_memory_root(tmp_path)
+
+    completed = _run_report(tmp_path, "--format", "markdown")
+
+    assert completed.returncode == 0, completed.stderr
+    assert "| 指標 | 7 天 | 30 天 |" in completed.stdout
+    assert "機器可讀 proxy" in completed.stdout
+    assert "不是人類語意可讀性" in completed.stdout
+    assert "offer → read → applied" in completed.stdout
+    assert "Cortex source_material" in completed.stdout
+    assert "Codex" in completed.stdout and "可觀測下限" in completed.stdout
+    assert "codex:audit" in completed.stdout
+
+
+def test_report_treats_index_integrity_problems_as_unavailable(tmp_path):
+    _seed_memory_root(tmp_path)
+    conn = sqlite3.connect(search.index_path(tmp_path))
+    try:
+        conn.execute(
+            "DELETE FROM slices_fts WHERE slice_id = ?",
+            ("sl-aaaaaaaaaaaaaaaa",),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    completed = _run_report(tmp_path, "--format", "json")
+
+    assert completed.returncode == 0, completed.stderr
+    quality = json.loads(completed.stdout)["windows"]["7d"]["note_quality"]
+    assert quality["index_available"] is False
+    assert quality["searchable"] == {"count": None, "denominator": 2, "rate_pct": None}
+    assert quality["adjusted_non_review_searchable"] == {
+        "count": None,
+        "denominator": 1,
+        "rate_pct": None,
+    }
+    assert quality["index_problems"]
+
+
+def test_report_ignores_publications_committed_after_snapshot(tmp_path):
+    _seed_memory_root(tmp_path)
+    publication = tmp_path / "runtime" / "ledger" / "publication.jsonl"
+    with publication.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "event": "publish_prepare",
+                    "publication_id": "pub-future",
+                    "session_key": "claude-code:s1",
+                    "now": "2026-08-17T13:00:00Z",
+                    "items": [
+                        {
+                            "slice_id": "sl-futurefuturefuture",
+                            "target": str(tmp_path / "knowledge" / "future.md"),
+                        }
+                    ],
+                }
+            )
+            + "\n"
+        )
+        handle.write(
+            json.dumps(
+                {
+                    "event": "publish_commit",
+                    "publication_id": "pub-future",
+                    "now": "2026-08-19T00:00:00Z",
+                }
+            )
+            + "\n"
+        )
+
+    completed = _run_report(tmp_path, "--format", "json")
+
+    assert completed.returncode == 0, completed.stderr
+    report = json.loads(completed.stdout)
+    assert report["windows"]["7d"]["note_quality"]["produced_unique_notes"] == 2
+
+
+def test_report_marks_missing_sources_and_zero_denominators_as_unavailable(tmp_path):
+    tmp_path.mkdir(exist_ok=True)
+
+    completed = _run_report(tmp_path, "--format", "json")
+
+    assert completed.returncode == 0, completed.stderr
+    report = json.loads(completed.stdout)
+    assert all(
+        report["diagnostics"][name]["missing_file"] == 1
+        for name in (
+            "import.jsonl",
+            "processing.jsonl",
+            "publication.jsonl",
+            "offered.jsonl",
+            "memory_usage.jsonl",
+        )
+    )
+    seven = report["windows"]["7d"]
+    assert seven["session_conversion"]["conversion"] == {
+        "numerator": 0,
+        "denominator": 0,
+        "rate_pct": None,
+    }
+    assert seven["note_quality"]["machine_valid"] == {
+        "count": 0,
+        "denominator": 0,
+        "rate_pct": None,
+    }
+    assert seven["note_quality"]["searchable"] == {
+        "count": None,
+        "denominator": 0,
+        "rate_pct": None,
+    }
+    assert seven["usage"]["viewed"] == {
+        "count": 0,
+        "denominator": 0,
+        "rate_pct": None,
+    }
+
+    markdown = _run_report(tmp_path, "--format", "markdown")
+    assert markdown.returncode == 0, markdown.stderr
+    assert "## 資料診斷" in markdown.stdout
+    assert "missing_file=1" in markdown.stdout


### PR DESCRIPTION
## 摘要

新增 repo-local `hippo-memory-kpi` skill，以唯讀 ledger、knowledge files 與 retrieval index 產生可重現的 7 天／30 天 KPI 表。

它將 session 產出、atomic note 品質與 Agent 消費拆成不同漏斗，避免把 Cortex prompt material、offer、read 與 applied 混為同一種證據。

Closes #134

## 變更內容

- 新增 deterministic JSON／Markdown report script。
- session→atomic note 使用 final `processing.state=promoted / non-empty intake sessions`。
- 分開呈現 schema/checksum machine-valid、raw searchable 與 adjusted non-review searchable。
- Agent 看過與採用固定要求同 tool/session/slice 的 `offer < read < applied` 時序。
- 排除 final `no-findings` 與目前稽核 session，並保留 pre-offer／never-offered direct reads。
- 明列 Cortex `source_material` 為 neither，以及 Codex read attribution 為可觀測下限。
- 新增合成 ledger、index integrity、future commit、缺失來源與唯讀雜湊 regression tests。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過
- [x] `python3 -m policy_check --repo .`（含 PR context）通過
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片，或 PR 已標示合法豁免與理由
- [x] `VERSION` 與 release 意圖一致
- [x] 文件與 CLI help 已同步，或已說明不適用

驗證證據：

- `python -m pytest`：1782 passed、4 skipped。
- `openspec validate --all --strict`：20 passed、0 failed。
- `skill-creator quick_validate.py`：Skill is valid。
- live smoke 對 5 個 ledger 與 retrieval DB 做前後雜湊比對：6/6 unchanged。
- `VERSION=0.1.2`，本 PR 不觸發 release。
- 新增 repo-local skill，不修改既有 CLI entrypoint；CLI help 同步不適用。

## 風險與回復

- 報表只讀，不執行 `hippo recall`，也不重建或修復 ledger/index。
- 「可讀性」只代表 schema/checksum machine proxy；searchable 不代表實際讀取或採用。
- Codex read telemetry 仍是可觀測下限，不應和 Claude/Copilot 視為等覆蓋。
- 未包含安裝、部署、版號或資料遷移；需要回復時可 revert 本 PR。