### PR TITLE
fix(cli): escape % in show subcommand help (crashes hippo --help)

### DIFF
--- a/changelog.d/139-fix-show-help-percent.md
+++ b/changelog.d/139-fix-show-help-percent.md
@@ -1,0 +1,4 @@
+---
+type: fix
+---
+- 修正 `hippo --help` crash：`cli.py` 的 `show` 子命令 help 字串裡 `~70% token` 有一個未跳脫的 `%`，argparse 對 help 字串做 `%`-formatting 時炸掉（`ValueError: unsupported format character 't'`），改為 `~70%% token`；PR #137（issue #136）帶進來的，補上遞迴 render 全部子命令 help 的 regression test（issue #139）。

--- a/paulsha_hippo/cli.py
+++ b/paulsha_hippo/cli.py
@@ -546,7 +546,7 @@ def _build_parser() -> argparse.ArgumentParser:
     recall_p.set_defaults(func=_recall)
 
     show_p = memory_subparsers.add_parser(
-        "show", help="印出一筆 knowledge note；--agent 只印精簡 header＋body（省 ~70% token）")
+        "show", help="印出一筆 knowledge note；--agent 只印精簡 header＋body（省 ~70%% token）")
     show_p.add_argument("ref", help="slice_id 或檔案路徑")
     show_p.add_argument("--memory-root", required=True)
     show_p.add_argument("--agent", action="store_true")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import argparse
+
 import pytest
 
 from paulsha_hippo import cli
@@ -95,3 +97,27 @@ def test_mark_episodic_exit_codes(tmp_path, capsys):
     ]) == 1
     err = capsys.readouterr().err
     assert "warning:" in err
+
+
+def _iter_parsers(parser: argparse.ArgumentParser):
+    """Yield `parser` and every subparser reachable via `add_subparsers()`,
+    recursively (e.g. `followups` nests its own list/verify/close/extract
+    subparsers under the top-level `knowledge`/`memory` ones)."""
+    yield parser
+    subparsers_group = getattr(parser, "_subparsers", None)
+    if subparsers_group is None:
+        return
+    for action in subparsers_group._group_actions:
+        for sub in getattr(action, "choices", {}).values():
+            yield from _iter_parsers(sub)
+
+
+def test_help_renders_for_every_subcommand_without_exception():
+    # issue #139: an un-escaped `%` in a `help=` string (e.g. "~70% token")
+    # made argparse's `%`-formatting of help text raise ValueError at
+    # `--help` time. Render top-level help and every subparser's help
+    # recursively so any future unescaped `%` fails here instead of at
+    # `hippo --help` in the field.
+    parser = cli._build_parser()
+    for sub_parser in _iter_parsers(parser):
+        sub_parser.format_help()


### PR DESCRIPTION
## 摘要

`paulsha_hippo/cli.py:549` 的 `show` 子命令 help 字串裡有一個未跳脫的 `%`（`~70% token`），argparse 對 `help=` 字串做 `%`-formatting 展開時炸掉，導致 `hippo --help`（以及任何會 render 到 top-level help 的路徑）直接 crash（`ValueError: unsupported format character 't'`）。PR #137 帶進來的，目前沒有任何測試 render 過 top-level help，因此沒被抓到，正擋住 #136 的 live migration rollout。

修法：`~70% token` 跳脫為 `~70%% token`（純字串修正，不動行為），並新增一個 regression test：build parser 後遞迴 render top-level 與所有 subparser（含巢狀的 `followups` 子命令）的 help，斷言不拋例外。

## 驗證

- [x] 已新增或更新必要測試，且完整測試通過（`tests/test_cli.py`：新增 `test_help_renders_for_every_subcommand_without_exception`，已確認在修法前 FAIL、修法後連同既有 8 個 test 一起 PASS）
- [x] `python3 -m policy_check --repo .`（含 PR context）通過 —— 經 preflight wrapper 執行
- [x] OpenSpec validation 與 repo 額外 gates 通過
- [x] `changelog.d/` 已有對應碎片：`changelog.d/139-fix-show-help-percent.md`
- [x] `VERSION` 與 release 意圖一致（本次未變更 `VERSION`，屬 hotfix，不觸發版號變動）
- [x] 文件與 CLI help 已同步，或已說明不適用（本變更即是修正 CLI help 本身的 crash，無其他文件需同步）

## 風險與回復

純字串跳脫修正 + 新增測試，不涉資料遷移或 live deployment。風險極低；回復方式為直接 revert 本 PR 的 commit。

Closes #139
