### PR TITLE
fix(atomize): surface silently-skipped already-processed re-dispatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 - 修 issue #141：四個 atomizer 測試繞過僅在 pytest 下才生效的 `_isolate_runtime_config` fixture（用 `python3 -m unittest` 等方式直接執行時會完全跳過 `conftest.py`），直接讀寫使用者真實 `~/.config/paulsha-hippo/config.yaml`（2026-08-25 生產事故：蓋成單一 fake-agent profile，31 筆 session parked，蒸餾靜默停擺一週）。新增共用 helper `tests/atomizer_config_testutil.py::isolated_atomizer_config()`，四個測試改用它在測試主體內自行隔離 `HIPPO_CONFIG_ROOT`；另新增 `tests/conftest.py` regression guard 比對真實 config 的 bytes 是否被任何測試動過。
+- 修 issue #142：`_split_pass()` 對已有處理狀態的 session_key（`split`／`parked`，或 `promoted`／`no-findings` 且 inbox 內容 hash 未變）完全靜默跳過，重新派送已處理過的文件時 `slices: 0, skipped: 0, warnings: []`，外觀跟「inbox 空的」一樣，實際上文件被略過、原封不動留在 inbox。兩個 skip 分支補上具名 `warnings` 項目與獨立的 summary counter `skipped_already_processed`；跳過語意本身未變。
 - lifecycle 詞彙表改為記憶平面與治理平面的聯集，修復與 `paulsha-cortex` 的跨平面對齊 FAIL：`lib/lifecycle/schema.PHASES` 新增 cortex 的首階段 `claim`，成為 `("claim", "research", "define", "plan", "build", "verify", "review", "ship")`。`claim`（cortex 的 work item 認領）與 `research`（本平面記憶 slice 的調查階段）語意不同、不可互相改名，故採聯集——既有 235 個 `phase: research` slice 零遷移即維持合法。`PHASES` 在本平面只做成員資格檢查與 gates 產生、不決定順序，擴充不改變既有行為，`current_phase` 預設仍為 `research`。三套套件之間維持零 import 依賴，相等性續由 paulshaclaw 的消費端對齊測試守。**本項於 0.1.2 凍結後才落地，不含於 `v0.1.2`，隨 0.1.3 發布。**
 
 ## [0.1.2] - 2026-08-08

--- a/changelog.d/142-observable-already-processed-skip.md
+++ b/changelog.d/142-observable-already-processed-skip.md
@@ -1,0 +1,6 @@
+---
+type: fix
+---
+- 修 issue #142：`paulsha_hippo/atomizer/pipeline.py::_split_pass()` 對「session_key 已有處理狀態」（`split`／`parked`，或 `promoted`／`no-findings` 且 inbox 內容 hash 未變）的兩個 skip 分支完全靜默——`continue` 前不寫 `warnings`、不累加任何 counter。生產實證：一份已由該 session 自己的 hook import 處理過的 inbox 文件被重新丟進 `hippo atomize`，回傳 `slices: 0, skipped: 0, warnings: []`，外觀上跟「inbox 空的」一模一樣，實際上文件被默默略過、原封不動留在 inbox。
+- 兩個分支現在都補上具名 `warnings` 項目（含檔案路徑、`session_key`、既有狀態）與獨立的 summary counter `skipped_already_processed`（與既有涵蓋所有跳過原因的 `summary.skipped` 分開）。`_split_pass()` 回傳值新增第三個元素（`count, dry_run_fragments, skipped_already_processed`），呼叫端 `run()` 已同步更新；跳過語意本身未變（idempotency 仍是對的，只是從靜默變成可觀測）。
+- 新增兩個回歸測試（`tests/test_atomizer_pipeline.py`）：`test_redispatch_with_existing_split_state_is_observable_not_silent`（`split` 分支）與 `test_redispatch_with_unchanged_promoted_content_is_observable_not_silent`（`promoted`＋hash 未變分支），各自預先寫入處理狀態後重跑 `pipeline.run()`，斷言 `summary.skipped_already_processed == 1`、`warnings` 內出現點名該路徑／session_key／狀態的訊息，且原始 inbox 文件維持存在、未被移動。

--- a/paulsha_hippo/atomizer/pipeline.py
+++ b/paulsha_hippo/atomizer/pipeline.py
@@ -794,8 +794,9 @@ def _promote_fragments(
 
 
 def _split_pass(memory_root: Path, config: AtomizerConfig, config_hash: str, now: str,
-                dry_run: bool, warnings: list[str]) -> tuple[int, dict[str, list[Fragment]]]:
+                dry_run: bool, warnings: list[str]) -> tuple[int, dict[str, list[Fragment]], int]:
     count = 0
+    skipped_already_processed = 0
     dry_run_fragments: dict[str, list[Fragment]] = {}
     for raw_path in _raw_session_docs(memory_root):
         path_session_key = f"{raw_path.parent.parent.name}:{raw_path.stem}"
@@ -865,6 +866,18 @@ def _split_pass(memory_root: Path, config: AtomizerConfig, config_hash: str, now
         current_event = processing.fold_events(memory_root).get(session_key)
         current_state = str(current_event.get("state", "")) if current_event else ""
         if current_state in {"split", "parked"}:
+            # Idempotency is correct here (re-dispatching a document whose
+            # session_key is still split/parked must not re-split it), but a
+            # silent `continue` left operators unable to tell "nothing to
+            # process" apart from "something was skipped" (issue #142: a
+            # well-formed re-dispatch returned slices/skipped/warnings all
+            # zero and the file sat in inbox untouched, looking identical to
+            # an empty inbox). Surface it instead of changing the skip.
+            warnings.append(
+                f"{raw_path}: skipped (session_key={session_key} already {current_state}); "
+                "re-dispatch with a fresh source_session to force reprocessing"
+            )
+            skipped_already_processed += 1
             continue
         if current_state in {"promoted", "no-findings"}:
             prior_hash = current_event.get("source_inbox_hash") if current_event else None
@@ -872,6 +885,12 @@ def _split_pass(memory_root: Path, config: AtomizerConfig, config_hash: str, now
             # explicit recovery/requeue operation; never guess that an old inbox copy
             # is a new capture.  New-format events re-open only on a proven byte change.
             if not isinstance(prior_hash, str) or prior_hash == source_inbox_hash:
+                warnings.append(
+                    f"{raw_path}: skipped (session_key={session_key} already {current_state}, "
+                    "inbox content unchanged); re-dispatch with a fresh source_session to force "
+                    "reprocessing"
+                )
+                skipped_already_processed += 1
                 continue
         captured_at = str(data.get("captured_at", now))
         provenance = data.get("provenance") if isinstance(data.get("provenance"), dict) else {}
@@ -916,7 +935,7 @@ def _split_pass(memory_root: Path, config: AtomizerConfig, config_hash: str, now
             )
         _move(raw_path, archive)
         count += 1
-    return count, dry_run_fragments
+    return count, dry_run_fragments, skipped_already_processed
 
 
 def _render_fragment(project, agent, session, source_artifact, captured_at, provenance, index, body, session_title="") -> str:
@@ -1230,7 +1249,9 @@ def run(memory_root: Path, *, config: AtomizerConfig, config_hash: str, now: str
         from .publication import recover_incomplete
 
         publication_recovery = recover_incomplete(memory_root)
-    split, dry_run_fragments = _split_pass(memory_root, config, config_hash, now, dry_run, warnings)
+    split, dry_run_fragments, skipped_already_processed = _split_pass(
+        memory_root, config, config_hash, now, dry_run, warnings
+    )
     slices, noise_dropped, produced_slice_ids = _promote_pass(
         memory_root, config, config_hash, now, dry_run, promoter, warnings,
         dry_run_fragments, doc_corpus, run_id,
@@ -1238,6 +1259,7 @@ def run(memory_root: Path, *, config: AtomizerConfig, config_hash: str, now: str
     return {
         "run_id": run_id,
         "summary": {"run_id": run_id, "split_sessions": split, "slices": slices, "skipped": len(warnings),
+                    "skipped_already_processed": skipped_already_processed,
                     "noise_dropped": noise_dropped,
                     "config_hash": config_hash, "backend_identity": "external-cli" if not isinstance(promoter, IdentityPromoter) else "identity",
                     "dry_run": dry_run},

--- a/tests/test_atomizer_pipeline.py
+++ b/tests/test_atomizer_pipeline.py
@@ -264,6 +264,57 @@ class PipelineTests(unittest.TestCase):
             self.assertEqual(result2["summary"]["slices"], 0)
             self.assertEqual(len(list((root / "knowledge").rglob("*.md"))), before)
 
+    def test_redispatch_with_existing_split_state_is_observable_not_silent(self):
+        """#142: re-dispatching a doc whose session_key already has processing
+        state (e.g. the session's own hook import ran first) must not be
+        silently swallowed -- the skip is correct, but it has to show up in
+        warnings and a dedicated counter instead of leaving
+        slices/skipped/warnings all zero, indistinguishable from an empty
+        inbox."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            raw = _seed_raw(root)
+            cfg, h = atomizer_config.load_config(override_path=None)
+            processing.append_state(root, session_key="claude:s1", state="split",
+                                    now="2026-05-31T02:00:00Z", config_hash=h,
+                                    fragments=260)
+
+            result = pipeline.run(root, config=cfg, config_hash=h,
+                                  now="2026-05-31T03:00:00Z")
+
+            self.assertEqual(result["summary"]["slices"], 0)
+            self.assertEqual(result["summary"]["skipped_already_processed"], 1)
+            self.assertTrue(any(
+                str(raw) in warning and "claude:s1" in warning and "split" in warning
+                for warning in result["warnings"]
+            ), result["warnings"])
+            self.assertTrue(raw.exists())
+            self.assertEqual(processing.state_of(root, "claude:s1"), "split")
+
+    def test_redispatch_with_unchanged_promoted_content_is_observable_not_silent(self):
+        """Same observability requirement (#142) for the other silent-skip
+        branch: an already-promoted session_key whose inbox content hash is
+        unchanged."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            raw = _seed_raw(root)
+            raw_hash = hashlib.sha256(raw.read_bytes()).hexdigest()
+            cfg, h = atomizer_config.load_config(override_path=None)
+            processing.append_state(root, session_key="claude:s1", state="promoted",
+                                    now="2026-05-31T02:00:00Z", config_hash=h,
+                                    source_inbox_hash=raw_hash, slices=2)
+
+            result = pipeline.run(root, config=cfg, config_hash=h,
+                                  now="2026-05-31T03:00:00Z")
+
+            self.assertEqual(result["summary"]["slices"], 0)
+            self.assertEqual(result["summary"]["skipped_already_processed"], 1)
+            self.assertTrue(any(
+                str(raw) in warning and "claude:s1" in warning and "promoted" in warning
+                for warning in result["warnings"]
+            ), result["warnings"])
+            self.assertTrue(raw.exists())
+
     def test_flow_through_empties_working_layers(self):
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -843,7 +894,7 @@ class PipelineTests(unittest.TestCase):
             _seed_raw(root)
             cfg, h = atomizer_config.load_config(override_path=None)
             warnings: list[str] = []
-            dry_run_split, _ = pipeline._split_pass(root, cfg, h, "2026-05-31T03:00:00Z", False, warnings)
+            dry_run_split, _, _ = pipeline._split_pass(root, cfg, h, "2026-05-31T03:00:00Z", False, warnings)
             self.assertEqual(dry_run_split, 1)
             cached_client = agent_exec.CachingAgentClient(
                 FakeAgentClient(


### PR DESCRIPTION
## Summary

- 修 #142：`paulsha_hippo/atomizer/pipeline.py::_split_pass()` 對已有處理狀態的 session_key（`split`／`parked`，或 `promoted`／`no-findings` 且 inbox 內容 hash 未變）完全靜默跳過——`continue` 前不寫 `warnings`、不累加任何 counter。生產實證：一份已由該 session 自己的 hook import 處理過的 inbox 文件被重新丟進 `hippo atomize`，回傳 `slices: 0, skipped: 0, warnings: []`，外觀上跟「inbox 空的」一模一樣，實際上文件被默默略過、原封不動留在 inbox。
- 兩個 skip 分支補上具名 `warnings` 項目（檔案路徑／`session_key`／既有狀態）與獨立的 summary counter `skipped_already_processed`（與既有涵蓋所有跳過原因的 `summary.skipped` 分開）。`_split_pass()` 回傳值新增第三個元素，`run()` 已同步更新。**跳過語意本身未變**——idempotency 是對的，只是從靜默變成可觀測。

## 驗證

- 新增兩個回歸測試（`tests/test_atomizer_pipeline.py`）：
  - `test_redispatch_with_existing_split_state_is_observable_not_silent`（`split` 分支）
  - `test_redispatch_with_unchanged_promoted_content_is_observable_not_silent`（`promoted`＋hash 未變分支）
  各自預先寫入處理狀態後重跑 `pipeline.run()`，斷言 `summary.skipped_already_processed == 1`、`warnings` 內出現點名該路徑／session_key／狀態的訊息，且原始 inbox 文件維持存在、未被移動。
- `python3 -m pytest -q tests/` 全綠（1952 passed, 4 skipped, 193 subtests passed），既有斷言 `warnings == []` 的測試（`test_recovery.py`、`test_inbox_quarantine.py`）逐一確認未落在本次新增的兩個 skip 分支上，未受影響。
- `openspec validate --all --strict` 全綠。

Closes #142
