### PR TITLE
docs: 登錄通用 task memory payload 計劃

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -12,3 +12,17 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/plans/2026-08-04-issue-99-cg-max-session-chunks.md'
     excludes: []
+  issue-146-task-memory-payload:
+    title: 'issue-146-task-memory-payload'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-hippo#146'
+      - kind: path
+        ref: 'docs/superpowers/specs/2026-09-07-issue-146-task-memory-payload-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/2026-09-07-issue-146-task-memory-payload-design.md'
+      - kind: path
+        ref: 'docs/superpowers/plans/2026-09-07-issue-146-task-memory-payload.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/issue-146-task-memory-payload/todo.md'
+    excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ## [Unreleased]
 
 ### Added
+
+- #146 正式規劃：通用 task memory payload、capability-aware delivery、tool-neutral evidence 與 Cortex host adapter 依賴（僅規劃，不代表 runtime 已完成）。
+
 - 新增 repo-local `custom-skills/hippo-memory-kpi/`：唯讀產生 7/30 天 session→atomic note、note machine-valid/searchable、Agent offer→read→applied KPI，固定排除 observer/no-findings 污染並區分 Cortex source material、offer、read、applied 與 Codex 可觀測下限。
 - Issue #136 knowledge 層衛生（provenance）：SessionEnd hook 補截 git commit/branch/dirty 快照，importer/atomizer 貫通六鍵 provenance（新增 `commit_source`/`branch`/`dirty`），新增一次性 migration `hippo knowledge backfill-provenance` 近似回填既有 slice 的 commit 與 cites，janitor 新增可選 `check_provenance_commit` 將 dangling commit 視為 `source_invalid`。
 - Issue #136 knowledge 層衛生（show --agent）：新增 `hippo show --agent <slice_id>` 精簡 note 視圖（省約 70% token）並記 read 歸因；shortlist hint 依新設定 `shortlist.read_hint` 改建議 `hippo show --agent` 換取全文。

--- a/changelog.d/issue-146-task-memory-payload-planning.md
+++ b/changelog.d/issue-146-task-memory-payload-planning.md
@@ -1,0 +1,3 @@
+### Added
+
+- #146：持久化通用 task memory payload、capability-aware delivery、tool-neutral evidence 與 Cortex host adapter 依賴的正式規劃；本變更不宣稱 runtime 已完成。

--- a/docs/superpowers/plans/2026-09-07-issue-146-task-memory-payload.md
+++ b/docs/superpowers/plans/2026-09-07-issue-146-task-memory-payload.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+work_item: issue-146-task-memory-payload
+---
+
+# issue-146-task-memory-payload Implementation Plan
+
+> 本 PR 只持久化可審查的正式契約與工作分解，不宣稱 Hippo 或 Cortex runtime 已完成。
+
+## Scope and dependencies
+
+- Core repo：`hamanpaul/paulsha-hippo`，issue [#146](https://github.com/hamanpaul/paulsha-hippo/issues/146)。
+- Host adapter：`hamanpaul/paulsha-cortex`，issue [#857](https://github.com/hamanpaul/paulsha-cortex/issues/857)。
+- Cortex adapter 依賴本計劃的 payload schema/capability/evidence contract；兩 repo 不共用 special case，也不固定下游模型或 executor。
+- 首道 gate：每個 delivery/capability path 至少 5 筆 canary，eligible authorized retrieval >=95%；通過後才做 utility trial。
+
+## Global constraints
+
+- PR、commit、changelog 與文件使用 zh-tw；公開 spec/fixture/report 使用合成 task/session attribution ID 與去識別路徑，不含 secrets 或私密筆記正文。runtime evidence 可保留必要且 bounded 的 attribution ID。
+- inline 不算 read；strict KPI 的分母、read/read-through 與 retention 語意不變。
+- 不擴大全域權限、不關閉 sandbox、不改 raw ledger/registry、不用 recall 繞過授權。
+- 不以 Hippo/Cortex project name special case，亦不要求 Luna 或任何固定模型 identity；下游沿現行 routing。
+- 先做測試契約，再做最小核心實作；每步保存工具中立 attempt/return/failure/applied evidence。
+
+## Task 1：固定 payload 與 candidate contract（RED）
+
+- [ ] 為 envelope、schema version、intent、最多三筆 candidates、授權/可用性結果寫 validation tests。
+- [ ] 為 deterministic ordering、空候選、provider unavailable、未授權候選與 redaction 寫失敗測試。
+- [ ] 明確保留舊 consumer 對未知 optional 欄位的相容行為。
+
+## Task 2：交付 mode 與 evidence contract（RED）
+
+- [ ] 測試 `inline`、`snapshot`、`note_fetch`、`ineligible`、`failure` 的互斥語意；snapshot/materialized ready/offer 不等於 content-returned。
+- [ ] 測試 inline/context-delivered 不增加 read；只有 tool/provider 成功返回內容才可記 content-returned；note fetch 能表達 attempt → returned/failed → applied；缺事件不推導成功。
+- [ ] 將工具中立事件與既有 strict KPI 對帳，不能改分母或把 inline 計入 read。
+
+## Task 3：Hippo core implementation（GREEN）
+
+- [ ] 以最小 diff 實作 payload builder、capability-aware delivery 與 bounded intent retrieval。
+- [ ] provider/permission failure 保留分類證據並 fail closed；不新增 global allow-all 或 fallback 授權。
+- [ ] 補單元/契約測試，確認公開 fixtures/reports 使用合成 ID、去識別路徑且不含 secrets；runtime payload 僅保留必要 bounded attribution metadata。
+
+## Task 4：Cortex host adapter handoff
+
+- [ ] 由 Cortex #857 依本契約建立 thin adapter；只映射 host capability 與現有 routing，不複製 Hippo core。
+- [ ] 以正式 `cortex work intake` 建立持久 work item/run；若 system provider、registration 或 hard gate 拒絕，保留 CLI 證據並停止，不手改 durable state。
+- [ ] 驗證 Hippo 未安裝或 payload provider 不可用時，既有 dispatch 仍依原有 fail-closed 行為回報。
+
+## Task 5：canary 與 utility trial
+
+- [ ] 每個 delivery/capability path 收集至少 5 筆 canary，記錄 attempt、return、failure、applied 與 authorization outcome。
+- [ ] 以 eligible authorized retrieval 為分母，達到 >=95% 才進 utility trial；缺少 per-job authorization evidence 的資料列不能算成功。
+- [ ] utility trial 另報實際效用，不變更 strict KPI，也不把未授權或 inline 視為 read。
+
+## Task 6：verification gates
+
+- [ ] `python3 -m pytest tests/ -q`。
+- [ ] `python3 -m policy_check --repo .` 無 failure。
+- [ ] `openspec validate --all --strict` 通過。
+- [ ] PR review 確認跨 repo dependency、security boundary、KPI 語意與 redaction 均有證據；runtime completion 另行驗證。

--- a/docs/superpowers/specs/2026-09-07-issue-146-task-memory-payload-design.md
+++ b/docs/superpowers/specs/2026-09-07-issue-146-task-memory-payload-design.md
@@ -1,0 +1,76 @@
+---
+status: accepted
+work_item: issue-146-task-memory-payload
+---
+
+# 通用 task memory payload 與 capability-aware 內容交付設計
+
+- 日期：2026-09-07
+- Issue：[#146](https://github.com/hamanpaul/paulsha-hippo/issues/146)
+- 狀態：已核可為正式規劃基線，待分階段實作與驗證
+
+## 設計邊界
+
+Hippo 負責通用 payload、候選檢索、交付 mode 與 evidence contract；host 負責把自身 capability/permission result 映射到
+契約。Cortex [#857](https://github.com/hamanpaul/paulsha-cortex/issues/857) 是首個 adapter，不是核心的特殊分支。兩個
+repo 的 work item 分開，Cortex adapter 依賴 Hippo schema 與 provider capability result。
+
+## Decisions
+
+### D1：以 task envelope 作為唯一交付邊界
+
+選擇版本化 envelope，而非讓每個 host 直接讀 Hippo 內部檔案或 ledger。envelope 能攜帶候選、能力結果與 evidence，並可在
+未來增加欄位而保持舊 consumer 可讀；不把 raw note、secret 或個人路徑暴露到 shareable artifact。runtime evidence 如需
+task/session attribution，僅保留 bounded ID；公開 spec/fixture/report 使用合成 ID 與去識別路徑。
+
+### D2：intent 檢索先產生 bounded candidates
+
+候選階段只接受 task intent 與既有可見性邊界，最多回傳三筆穩定排序候選。無候選、無權限與索引/provider 不可用是不同
+狀態，不能以空陣列掩蓋原因，也不能以 host/project 名稱改變排序或授權。
+
+### D3：能力協商決定 mode
+
+mode 選擇由 payload provider 回報的 capability facts 與 host 允許範圍共同決定：inline/context-delivered 代表內容已交付但
+不是 Read；snapshot/materialized 只代表唯讀 manifest 已 ready/offer，只有實際 tool/provider 成功返回內容才是
+`content-returned`。需要 note fetch 時必須產生 read attempt 並回報 return/failure；能力不足或 provider 缺失則輸出
+ineligible/failure，檔案已寫好不能取代內容返回證據。
+禁止「嘗試 Read 失敗後假裝 inline 成功」的無證據降級。
+
+### D4：evidence 是工具中立事件
+
+Hippo 定義事件類型與必要識別欄位，host 可附自己的 non-secret metadata。事件順序必須能對帳 attempt → returned/failed →
+applied；缺少任一環節不自動推導成功。這使不同 tool、host 與 executor 可共用 strict KPI 對帳，而不綁定某一模型名稱。
+
+### D5：KPI 層與交付層分離
+
+保留現行 offered/read/read-through 與 retention 語意。payload 交付、inline、snapshot 只做交付觀測；只有既有 Read 定義
+要求的事件才進 read 分子。新 evidence 不改既有 strict KPI 分母，另以 path-level report 支援首道 95% gate。
+
+### D6：權限與失敗 fail closed
+
+此設計不新增全域權限、不關閉 sandbox、不繞過 daemon/provider gate、不直接寫 raw durable state。Hippo 未安裝或 provider
+不可用時保留既有 dispatch 結果與 failure evidence；adapter 不得自己發明 fallback 授權。
+
+## Data flow
+
+```text
+task intent
+   -> Hippo candidate retrieval (<=3, authorized only)
+   -> capability negotiation
+   -> inline | snapshot | note_fetch | ineligible | failure
+   -> tool-neutral attempt/return/failure/applied evidence
+   -> strict KPI unchanged + path-level canary report
+```
+
+## Compatibility and rollout
+
+先落地 schema/validation 與 provider capability contract，再由 Cortex adapter 做每 path 至少 5 筆的 canary。只有 eligible
+authorized retrieval >=95% 且 evidence 完整時，才進 utility trial；utility 失敗不回頭放寬授權或變更 KPI。舊 consumer 對
+未知 optional 欄位保持可讀，未知 mode 必須視為 ineligible/failure 而非成功。
+
+## Review gates
+
+1. schema、candidate bound、mode 與 evidence 的 RED/GREEN 測試。
+2. Hippo 全套 pytest、`python3 -m policy_check --repo .`、`openspec validate --all --strict`。
+3. Cortex adapter 透過正式 `cortex work intake` 取得可持久化 work item/run；若 provider、project registration 或 hard gate
+   阻擋，保存 CLI 的 fail-closed evidence，不以手動 state 或 infra 修改繞過。

--- a/docs/superpowers/specs/2026-09-07-issue-146-task-memory-payload-spec.md
+++ b/docs/superpowers/specs/2026-09-07-issue-146-task-memory-payload-spec.md
@@ -1,0 +1,85 @@
+---
+status: accepted
+work_item: issue-146-task-memory-payload
+---
+
+# 通用 task memory payload 與 capability-aware 內容交付規格（issue #146）
+
+- Issue：[#146](https://github.com/hamanpaul/paulsha-hippo/issues/146)
+- 依賴的首個 host adapter：Cortex [#857](https://github.com/hamanpaul/paulsha-cortex/issues/857)
+- 本文件只定義 Hippo 通用核心契約；不把任何 host、project、executor 或模型名稱寫入契約。
+
+## Problem and outcome
+
+目前跨 session 的 task memory 需要同時回答「這項任務需要什麼」與「目前執行環境能安全取得什麼」。現有聚合觀察涵蓋
+278 個 Cortex/Copilot offer session，其中 222 個有 log、126 個曾嘗試取閱 offered note；Hippo 另有 299 次 memory
+view 全部 permission denied。這些數字是跨 session 聚合證據，不足以證明每個 job 所在的 permission layer，也不應被簡化成
+單一旗標即可修復的問題；另有缺少 log 的 session 不作成功或失敗推論。
+
+預期結果是將 task memory 內容、能力協商、取得嘗試與結果分離成可驗證的通用 payload：符合能力且有授權時可靠交付；能力
+不足、provider 不可用或取得失敗時明確回報，不把 inline 注入冒充 Read；既有嚴格 KPI 的分母與語意維持不變。
+
+## Requirements
+
+### R1. 通用 task envelope
+
+Hippo SHALL 提供版本化、可 redaction 的 task memory payload，至少包含：
+
+- `task_id` 與 bounded `intent`（任務意圖，不複製整段 prompt）；
+- `candidates`（最多 3 個、可為空；每項有穩定 reference、摘要、授權/可用性結果）；
+- `delivery`（協商後的交付 mode 與 capability facts）；
+- `evidence`（取得嘗試、返回、失敗與 downstream applied 結果）；
+- `schema_version` 與 producer/adapter identity；公開 spec/fixture/report 不包含 secret、私密筆記正文或個人絕對路徑。runtime evidence 可保留必要且 bounded 的 task/session attribution ID，但公開 fixture 一律使用合成 ID、去識別路徑。
+
+### R2. 依 task intent 檢索且有界
+
+候選檢索 SHALL 以 task intent 與既有索引/權限邊界為輸入，固定最多 3 筆並保留 deterministic ordering。不得以 host
+project 名稱作 special case，也不得把未授權內容混入候選或透過 fallback 取得。
+
+### R3. Capability-aware delivery
+
+交付 mode SHALL 明確區分：`inline`、`snapshot`、`note_fetch`、`ineligible`、`failure`。inline/context-delivered 只是
+payload 交付，**不計為 read**；snapshot/materialized 只代表唯讀 manifest/content artifact 已 ready/offer，檔案存在本身
+不是 content returned。只有實際 tool/provider 成功返回內容才能產生 `content-returned`；需要另行取閱時，adapter 必須
+先聲明對應 capability，並將不可用、拒絕、逾時等結果回報為可分類的 failure/ineligible，不得默默降級成成功。
+
+### R4. Tool-neutral evidence
+
+核心 SHALL 定義與工具無關的事件與欄位，至少能表達 `read_attempt`、`returned`、`failed`、`applied` 與失敗分類；
+host adapter 可將自己的工具事件映射進來，但不可要求某個工具、模型或 executor identity 才算有效。
+
+### R5. KPI compatibility
+
+既有 strict KPI 與 retention/usage 語意 SHALL 維持。inline、snapshot 與 note fetch 各自可觀測，但只有實際符合既有
+read 定義的行為才進 read/read-through 分子；不可藉由改分母或把 inline 當 read 達標。
+
+### R6. 安全與失敗邊界
+
+本項不得擴大全域 allow-all、關閉 sandbox、繞過 permission gate、直接改 ledger/registry 或以 recall 取代授權檢查。
+Hippo 未安裝或 payload provider 不可用時，既有 dispatch 行為與拒絕/失敗證據須保留；任何新 mode 都必須 fail closed。
+
+### R7. 首個 host adapter 驗證
+
+Cortex 是首個 host adapter 與驗證場景，但僅依賴本通用契約，不引入 Cortex/專案名稱特判。Cortex 端工作見
+[#857](https://github.com/hamanpaul/paulsha-cortex/issues/857)，其依賴本 issue 的契約與 provider capability 回報。
+
+### R8. 分階段驗收
+
+第一道 gate 是 eligible、已授權內容的有效取得率至少 95%；canary 應按 delivery/capability path 分組且每組至少 5
+筆，逐筆保存 attempt/return/failure/applied evidence。第一道 gate 通過後才進真正 utility trial；utility 不能回頭改寫
+strict KPI 或把未授權成功算入分母。
+
+## Non-goals
+
+- 不為任何 host/project 建立 special case 或共享預設模型要求。
+- 不把 inline injection、候選顯示或 snapshot 產生誤報為 Read。
+- 不在本 issue 內實作 Cortex lifecycle、project registration、provider infrastructure 或 GitHub dispatch。
+- 不弱化既有權限、sandbox、ledger/registry ownership 或 fail-closed gate。
+
+## Acceptance
+
+- payload schema、mode、capability 與 tool-neutral evidence 有 round-trip/validation 測試；公開 fixture/report 使用合成 attribution ID、去識別路徑，且不含秘密或私密筆記正文。
+- 依 task intent 的候選上限、排序、授權過濾與 provider unavailable/failure 分類有測試。
+- inline 不會新增 read；真正 read、失敗與 applied 的 KPI 對帳與現行 strict KPI 相容。
+- Cortex adapter 能使用本契約完成分 path canary，並以 >=95% eligible authorized retrieval 作第一道 gate。
+- Hippo 的 pytest、policy_check、OpenSpec strict 與文件治理檢查全綠；本 PR 僅為正式規劃/契約，不宣稱 runtime 已完成。

--- a/docs/superpowers/workstreams/issue-146-task-memory-payload/todo.md
+++ b/docs/superpowers/workstreams/issue-146-task-memory-payload/todo.md
@@ -1,0 +1,30 @@
+---
+status: accepted
+work_item: issue-146-task-memory-payload
+---
+
+# issue-146-task-memory-payload / todo
+
+正式規劃來源：
+
+- spec — `docs/superpowers/specs/2026-09-07-issue-146-task-memory-payload-spec.md`
+- design — `docs/superpowers/specs/2026-09-07-issue-146-task-memory-payload-design.md`
+- plan — `docs/superpowers/plans/2026-09-07-issue-146-task-memory-payload.md`
+- issue — [hamanpaul/paulsha-hippo#146](https://github.com/hamanpaul/paulsha-hippo/issues/146)
+- host adapter dependency — [hamanpaul/paulsha-cortex#857](https://github.com/hamanpaul/paulsha-cortex/issues/857)
+
+## Tasks
+
+- [ ] payload envelope/schema 與 bounded intent candidate contract（RED/GREEN）
+- [ ] capability-aware delivery modes 與 tool-neutral evidence（RED/GREEN）
+- [ ] strict KPI compatibility、inline-not-read 與 fail-closed 測試
+- [ ] Hippo core 最小實作與 shareable redaction
+- [ ] Cortex thin adapter 依 #857 沿現行 routing 接入
+- [ ] 每 path 至少 5 筆 canary，eligible authorized retrieval >=95%
+- [ ] 通過第一道 gate 後才執行 utility trial
+- [ ] pytest、policy_check、OpenSpec strict 與跨 repo review gate
+
+## Blockers / dependencies
+
+- [ ] Cortex #857 adapter 尚未完成；本 repo 先持久化可審查契約，不把 runtime 或 dispatch 宣稱完成。
+- [ ] system provider/registration/hard gate 是否允許正式 intake，須以現行 Cortex CLI 證據為準，不透過手動 state 或 infra 修改繞過。


### PR DESCRIPTION
## 摘要

持久化通用 task memory payload、capability-aware delivery、tool-neutral evidence 的 Hippo 核心正式規劃，並登錄與 Cortex host adapter 的跨 repo dependency。此 PR 僅建立可審查的 spec/design/plan/Todo 與 work registration，不包含 runtime implementation 或權限放寬。

公開文件與 fixture 使用合成 attribution ID、去識別路徑；runtime evidence 若需要歸因可保留必要且 bounded 的 task/session ID。snapshot/materialized 只代表 ready/offer，只有 tool/provider 真正返回內容才是 `content-returned`；inline/context-delivered 不計為 read。

## 驗證

- [x] `python3 -m pytest tests/ -q`（1954 passed, 4 skipped, 193 subtests passed）
- [x] `python3 -m policy_check --repo .`（25 pass, 0 fail；僅既有 R-22 dangling-reference warning）
- [x] `openspec validate --all --strict`（14 passed, 0 failed）
- [x] `changelog.d/` 已新增規劃碎片
- [x] `VERSION` 與 release 意圖一致（docs-only planning）
- [x] 文件與 CLI help 已同步，或已說明不適用（本 PR 不改 CLI）

## 風險與回復

- Cortex adapter 為另一 repo 的獨立 work item，依賴本 PR 的契約；不在本 PR 宣稱 host dispatch、runtime 或 utility trial 已完成。
- 第一個驗收 gate 為各 delivery/capability path 至少 5 筆 canary 且 eligible authorized retrieval >=95%；strict KPI 分母不變。
- 若 review 不接受規劃，可關閉本 PR；不需要 runtime migration 或 rollback。

## 相關工作

- Hippo issue：https://github.com/hamanpaul/paulsha-hippo/issues/146
- Cortex adapter issue：https://github.com/hamanpaul/paulsha-cortex/issues/857
