### PR TITLE
docs(openspec): 恢復 task payload correlation

### DIFF
--- a/changelog.d/issue-146-openspec-correlation.md
+++ b/changelog.d/issue-146-openspec-correlation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- 恢復 `issue-146-task-memory-payload` 的 active OpenSpec intake metadata，讓 governed work correlation 能解析唯一的 PR/OpenSpec/Todo tuple。

--- a/openspec/changes/issue-146-task-memory-payload/design.md
+++ b/openspec/changes/issue-146-task-memory-payload/design.md
@@ -1,0 +1,36 @@
+---
+status: accepted
+work_item: issue-146-task-memory-payload
+---
+
+# Issue #146 task memory payload 設計
+
+## Background
+
+既有 memory retrieval 與 read attribution 已能做 shortlist offer 與 read ledger，但缺少一個可被 host adapter 重用的正式 payload 契約：候選上限、授權過濾、shareable redaction，以及 inline/snapshot/note_fetch 的 read 語意原本散落或不存在。這張卡先以最小 diff 補純函式模組，不改現行 host routing。
+
+## Decisions
+
+### D1：以獨立純函式模組承接 payload contract
+
+`paulsha_hippo.task_memory_payload` 只負責建構/驗證 envelope 與彙整 delivery outcome，不直接做 IO、provider 呼叫或授權繞過，讓 Cortex #857 可作 thin adapter 映射。
+
+### D2：候選固定上限 3、只保留已授權項目
+
+builder 先依 `rank` 與 `ref` 做 deterministic ordering，再裁成最多三筆；未授權候選直接排除，provider unavailable 但已授權的候選可保留 availability failure facts。
+
+### D3：shareable-safe redaction 先於持久化/展示
+
+候選 `summary`/`excerpt` 先去掉 home path 再走既有 `redact_secret_text()`，避免 public fixture、report 或 changelog 不小心持久化敏感片段。
+
+### D4：returned 才能進 read，returned+applied 才能進 applied
+
+delivery summarizer 將 mode 與事件拆開判定：`inline`/`snapshot` 僅代表內容已隨 payload 或 artifact ready，不得推導 read；`note_fetch` 只有出現 `returned` 才算 read，且必須再看到 `applied` 才算 applied。`failed` 僅保留分類，不得升格成功。
+
+## Testing
+
+- `tests/test_task_memory_payload_contract.py`
+- `python3 -m pytest tests/test_task_memory_payload_contract.py -q`
+- `python3 -m pytest tests/ -q`
+- `python3 -m policy_check --repo .`
+- `openspec validate --all --strict`

--- a/openspec/changes/issue-146-task-memory-payload/proposal.md
+++ b/openspec/changes/issue-146-task-memory-payload/proposal.md
@@ -1,0 +1,20 @@
+---
+status: accepted
+work_item: issue-146-task-memory-payload
+---
+
+## Why
+
+cross-session task memory 需要一個工具中立、可版本化的 payload 契約，能同時表達任務意圖、候選可用性、授權結果與實際內容交付結果；inline context 不能再被誤判成 read，且 shareable artifact 不得外洩 secret 或 denied note 內容。
+
+## What Changes
+
+- 新增 `paulsha_hippo.task_memory_payload`，集中處理 task memory payload envelope 的建構與驗證。
+- payload 僅保留最多三筆已授權候選，並以 deterministic ordering 排序；候選摘要/摘錄走 shareable-safe redaction。
+- 新增 delivery outcome summarizer，將 `inline`、`snapshot`、`note_fetch`、`ineligible`、`failure` 與 read KPI 分離；只有 `returned` 才算 read，且需 `applied` 才算 applied。
+
+## Capabilities
+
+### Added Capabilities
+
+- `stage2-memory-task-payload`：版本化 payload envelope、capability-aware delivery outcome，以及 tool-neutral evidence/read KPI semantics。

--- a/openspec/changes/issue-146-task-memory-payload/specs/stage2-memory-task-payload/spec.md
+++ b/openspec/changes/issue-146-task-memory-payload/specs/stage2-memory-task-payload/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Versioned task memory payload envelope
+
+Hippo SHALL provide a versioned task memory payload helper that builds and validates an envelope containing `schema_version`, `task_id`, bounded `intent`, `candidates`, `delivery`, `evidence`, and producer/adapter identity. Candidate ordering SHALL be deterministic, the payload SHALL contain at most three candidates, and denied candidates MUST NOT be exposed in the final envelope. Shareable summary/excerpt text SHALL be redacted before it leaves the helper.
+
+#### Scenario: builder keeps the top three authorized candidates
+
+- **WHEN** the caller passes four candidates with mixed authorization states and unordered ranks
+- **THEN** the payload SHALL keep only the first three authorized candidates after deterministic sorting, and denied candidates SHALL be excluded
+
+#### Scenario: validation preserves unknown optional fields
+
+- **WHEN** a caller validates a payload that contains additional optional delivery metadata
+- **THEN** validation SHALL keep those optional fields intact while still enforcing the required contract
+
+### Requirement: Delivery outcome summary keeps read KPI strict
+
+Hippo SHALL provide a delivery outcome summarizer for `inline`, `snapshot`, `note_fetch`, `ineligible`, and `failure`. `inline` and `snapshot` SHALL NOT count as read. `note_fetch` SHALL count as read only when the evidence contains `returned`, and SHALL count as applied only when `returned` and `applied` are both present. Failed events MAY expose a failure reason but MUST NOT be inferred as success.
+
+#### Scenario: inline and snapshot stay out of read
+
+- **WHEN** the summarizer receives `inline` or `snapshot` mode events without a `returned` event
+- **THEN** the summary SHALL report `content_returned=false`, `counts_as_read=false`, and `counts_as_applied=false`
+
+#### Scenario: note fetch requires returned before applied counts
+
+- **WHEN** the summarizer receives `note_fetch` mode with `read_attempt`, `returned`, and `applied`
+- **THEN** the summary SHALL report `content_returned=true`, `counts_as_read=true`, and `counts_as_applied=true`
+
+#### Scenario: applied without returned does not count as read
+
+- **WHEN** the summarizer receives `note_fetch` mode with only `applied`
+- **THEN** the summary SHALL still report `content_returned=false`, `counts_as_read=false`, and `counts_as_applied=false`

--- a/openspec/changes/issue-146-task-memory-payload/tasks.md
+++ b/openspec/changes/issue-146-task-memory-payload/tasks.md
@@ -1,0 +1,29 @@
+---
+status: accepted
+work_item: issue-146-task-memory-payload
+---
+
+# issue-146-task-memory-payload tasks
+
+## Task 1: payload contract 與 shareable-safe envelope
+
+- [x] RED：新增契約測試，固定 schema_version、bounded intent、最多三筆 candidates、deterministic ordering、空候選、provider unavailable、未授權候選與 redaction。
+- [x] RED repair：將 truncation fixture 擴成四筆 authorized 候選，明確驗證 deterministic first-three truncation，不再是三選三 no-op。
+- [x] GREEN：新增 `paulsha_hippo.task_memory_payload` 的 builder/validator，固定最多三筆、授權過濾、deterministic ordering 與 unknown optional fields 相容。
+
+## Task 2: delivery mode 與 evidence/read semantics
+
+- [x] RED：新增契約測試，固定 inline、snapshot、note_fetch、failure 的 evidence 邊界。
+- [x] GREEN：新增 `summarize_delivery_outcome()`，固定只有 `returned` 才算 read、`returned`+`applied` 才算 applied，inline/snapshot 不得升格為 read。
+
+## Task 3: 後續整合與驗證
+
+- [ ] Cortex thin adapter 依 hamanpaul/paulsha-cortex#857 接入既有 routing。
+- [ ] 每個 delivery/capability path 至少 5 筆 canary，eligible authorized retrieval >=95%。
+- [ ] 通過第一道 gate 後才執行 utility trial。
+- [x] Governed preflight repair：runtime-health 測試固定改用 `/` 這個穩定且非暫存的既有 cwd fixture，避免 disposable HOME／temp checkout 被誤判為 `cwd-temp-worktree`。
+- [x] Governed preflight repair：`stage2_integration_check.sh` 的 MOC fixture 改放進 EXIT 會清掉的 `TMP_DIR`，並讓 `tests/test_skillopt_valset.py` 清掉空的 `.test-work/skillopt-valset` 父目錄，避免 pytest 後留下 worktree residue。
+- [x] `python3 -m pytest tests/ -q`。
+- [x] `python3 -m policy_check --repo .`。
+- [x] `openspec validate --all --strict`。
+- [ ] 跨 repo review gate。


### PR DESCRIPTION
## 摘要
恢復 `main` 上 `issue-146-task-memory-payload` 的 active OpenSpec intake 檔案，讓 governed work correlation 能解析唯一的 PR/OpenSpec/Todo tuple，解除既有 exact candidate 的 delivery correlation 阻塞。

## 驗證
- [x] `openspec validate --all --strict`（15/15）
- [x] `python3 -m policy_check --repo .`（25 pass、0 fail；R-22 為既有 advisory warning）
- [x] `git diff --check`

本 PR 僅回填 repository correlation metadata，另附一個對應 changelog fragment；不修改 runtime implementation，也不改動既有 implementation PR。